### PR TITLE
Added main activity landscape layout

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
 
         <activity
             android:name=".MainActivity"
-            android:configChanges="orientation|screenSize|uiMode"
             android:label="@string/app_name"
             android:launchMode="singleTop"
             android:theme="@style/AppTheme.NoActionBar">

--- a/MapboxAndroidDemo/src/main/res/layout-land/content_main.xml
+++ b/MapboxAndroidDemo/src/main/res/layout-land/content_main.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/materialDarkGrey"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:context=".MainActivity"
+    tools:showIn="@layout/app_bar_main">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/details_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingEnd="110dp"
+        android:paddingLeft="110dp"
+        android:paddingStart="110dp"
+        android:paddingRight="110dp"
+        android:layout_weight="0.4"
+        android:clipToPadding="false"
+        android:paddingBottom="6dp"
+        android:paddingTop="6dp" />
+
+</LinearLayout>


### PR DESCRIPTION
To conform even further with material design, while in landscape the padding for cards increases so it will look like this:

![screenshot_20160627-141246](https://cloud.githubusercontent.com/assets/5652865/16390554/58637b38-3c71-11e6-8962-6028be48ab1a.png)

Going ahead and merging this one.