### PR TITLE
Fix a crash with Android support FAB

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -29,6 +29,7 @@ repositories {
 }
 
 dependencies {
+  compile "com.android.support:design:${supportLibVersion}"
   compile "com.android.support:gridlayout-v7:${supportLibVersion}"
   compile "com.android.support:appcompat-v7:${supportLibVersion}"
   compile "com.android.support:cardview-v7:${supportLibVersion}"


### PR DESCRIPTION
It fixes a crash in all activities using Android support FAB.
We have to add the dependency com.android.support:design:24.2.0