### PR TITLE
Fix nasty FloatingActionBar/SVG issue on Android 6.0.1, API 23

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   compile "com.android.support:appcompat-v7:${supportLibVersion}"
   compile "com.android.support:cardview-v7:${supportLibVersion}"
   compile "com.android.support:recyclerview-v7:${supportLibVersion}"
+  compile "com.android.support:design:${supportLibVersion}"
   compile 'com.github.javiersantos:MaterialStyledDialogs:1.5.5'
   compile 'com.getbase:floatingactionbutton:1.10.1'
   compile 'com.squareup.picasso:picasso:2.5.2'

--- a/MapboxAndroidDemo/src/main/res/layout/activity_location_basic.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_location_basic.xml
@@ -21,7 +21,8 @@
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
         android:layout_margin="16dp"
-        android:src="@drawable/ic_my_location_24dp"
+        app:srcCompat="@drawable/ic_my_location_24dp"
+        tools:ignore="VectorDrawableCompat"
         app:backgroundTint="@color/colorAccent"/>
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
###  The Activity `BasicUserLocation` fails when testing from a local build with Android Studio 2.1.3

* Building a local version for testing was failing on Nexus 5, Android 6.0.1, API 23 device.
* The activity `BasicUserLocation` works in the current version from Play Store 
* In demo app, the user interface for the activity `BasicUserLocation` is "Show User Location"
* A fairly nasty/tough/brutal bug because the error message was sparse and cryptic
* Not an issue with the play store, so filing this PR instead of an issue.  You can decide if this is an issue for the demo app, but I needed this to do some debugging of the `LocationListener`.

-----

Steps to reproduce

* `git checkout 0768f2f2679765e5e51a31bba44fc0be91e0d8ef`
* Build on Android Studio 2.1.3
* Install APK > Menu > User Location > "Show User Location"  (which runs the activity `BasicUserLocation`)
* StackOverflow discussion refers to older devices, and I've had issues with older (API 19) devices in previous projects, but now it is showing up on a Nexus 5 with most up to date SDK (23).
* http://stackoverflow.com/a/37665023
* **tough** error description, from `adb log`
```
Caused by: android.view.InflateException: Binary XML file line #18: Binary XML file line #18: Error inflating class android.support.design.widget.FloatingActionButton
                                                                                
```
-----

This fix does the following

* by referencing SVG's with `app:srcCompat` instead of `android:src`
* adding to build.gradle `com.android.support.design`