### PR TITLE
Data driven circles example

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -386,5 +386,13 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity"/>
         </activity>
+
+        <activity
+            android:name=".examples.styles.DataDrivenCircleActivity"
+            android:label="@string/activity_style_data_driven_circle_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
     </application>
 </manifest>

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -52,6 +52,7 @@ import com.mapbox.mapboxandroiddemo.examples.styles.AdjustLayerOpacityActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.ColorSwitcherActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.CreateHeatmapPointsActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.CustomRasterStyleActivity;
+import com.mapbox.mapboxandroiddemo.examples.styles.DataDrivenCircleActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.DefaultStyleActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.GeojsonLayerInStackActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.LanguageSwitchActivity;
@@ -198,6 +199,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           R.string.activity_style_add_wms_source_description,
           new Intent(MainActivity.this, AddWmsSourceActivity.class),
           R.string.activity_style_add_wms_source_url,
+          true
+        ));
+        exampleItemModel.add(new ExampleItemModel(
+          R.string.activity_style_data_driven_circle_title,
+          R.string.activity_style_data_driven_circle_description,
+          new Intent(MainActivity.this, DataDrivenCircleActivity.class),
+          R.string.activity_style_data_driven_circle_url,
           true
         ));
         exampleItemModel.add(new ExampleItemModel(

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/DataDrivenCircleActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/DataDrivenCircleActivity.java
@@ -1,0 +1,87 @@
+package com.mapbox.mapboxandroiddemo.examples.styles;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.style.layers.CircleLayer;
+import com.mapbox.mapboxsdk.style.sources.VectorSource;
+
+import static com.mapbox.mapboxsdk.style.layers.Function.stop;
+import static com.mapbox.mapboxsdk.style.layers.Function.zoom;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
+
+public class DataDrivenCircleActivity extends AppCompatActivity {
+
+  MapView mapView;
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_style_data_driven_circle);
+
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(MapboxMap mapboxMap) {
+
+        VectorSource vectorSource = new VectorSource("population", "mapbox://examples.8fgz4egr");
+        mapboxMap.addSource(vectorSource);
+
+        CircleLayer circleLayer = new CircleLayer("population", "population");
+        circleLayer.setSourceLayer("sf2010");
+        circleLayer.setProperties(
+
+          // make circles larger as the user zooms from z12 to z22
+          circleRadius(zoom(0.75f,
+            stop(12, circleRadius(2f)),
+            stop(22, circleRadius(8f))
+          ))
+
+          // color circles by ethnicity, using data-driven styles
+//          circleColor(
+//            stop()
+//          )
+
+        );
+
+        mapboxMap.addLayer(circleLayer);
+      }
+    });
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_style_data_driven_circle.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_style_data_driven_circle.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:center_latitude="37.753574"
+        mapbox:center_longitude="-122.447303"
+        mapbox:style_url="@string/style_light"
+        mapbox:zoom="12"/>
+
+</LinearLayout>

--- a/MapboxAndroidDemo/src/main/res/values/strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="activity_styles_geojson_layer_in_stack_title">Add a new layer below labels</string>
     <string name="activity_styles_vector_source_title">Add a vector tile source</string>
     <string name="activity_style_add_wms_source_title">Add a WMS source</string>
+    <string name="activity_style_data_driven_circle_title">Data-driven circle coloring by ethnicity</string>
     <string name="activity_style_zoom_dependent_fill_color_title">Color dependent on zoom level</string>
     <string name="activity_style_create_heatmap_points_title">Create a heatmap from points</string>
     <string name="activity_annotation_marker_title">Draw a marker</string>
@@ -101,6 +102,7 @@
     <string name="activity_styles_geojson_layer_in_stack_description">Using the second argument of addLayer, you can be more precise</string>
     <string name="activity_styles_vector_source_description">Add a vector source to a map and display it as a layer.</string>
     <string name="activity_style_add_wms_source_description">Adding an external Web Map Service layer to the map</string>
+    <string name="activity_style_data_driven_circle_description">Using a categorical circle-color property for a visualization</string>
     <string name="activity_style_zoom_dependent_fill_color_description">Make a property depend on the map zoom level, in this case, the water layers fill color.</string>
     <string name="activity_style_create_heatmap_points_description">Use the Mapbox Android SDK to visualize point data as a heatmap.</string>
     <string name="activity_annotation_marker_description">Create a default marker with an InfoWindow.</string>
@@ -151,6 +153,7 @@
     <string name="activity_styles_adjust_layer_opacity_url">http://i.imgur.com/0Av8kWD.png</string>
     <string name="activity_styles_vector_source_url">http://i.imgur.com/N0altyP.png</string>
     <string name="activity_style_add_wms_source_url">http://i.imgur.com/k14WdRG.png</string>
+    <string name="activity_style_data_driven_circle_url"> </string>
     <string name="activity_style_create_heatmap_points_url">http://i.imgur.com/pAejKLH.png</string>
     <string name="activity_annotation_marker_url">https://www.mapbox.com/android-sdk/images/marker.png</string>
     <string name="activity_annotation_custom_marker_url">https://www.mapbox.com/android-sdk/images/custom-marker-icon.png</string>


### PR DESCRIPTION
Data driven circles example similar to the Gl-JS example [found here](https://www.mapbox.com/mapbox-gl-js/example/data-driven-circle-colors/). Not sure how to do the coloring, right now I can only create stops depending on the zoom and in the example they do it by ethnicity.

![ezgif com-video-to-gif 1](https://cloud.githubusercontent.com/assets/5652865/18601977/246abb4a-7c34-11e6-9196-404b1d672706.gif)

cc: @zugaldia @ivovandongen 