### PR TITLE
Update dependencies to v5.0.1

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -66,7 +66,7 @@ dependencies {
   gpservicesCompile 'com.google.firebase:firebase-crash:10.0.1'
 
   // Mapbox dependencies
-  compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.0@aar') {
+  compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.1@aar') {
     transitive = true
   }
 

--- a/MapboxAndroidWearDemo/build.gradle
+++ b/MapboxAndroidWearDemo/build.gradle
@@ -28,7 +28,7 @@ dependencies {
   compile 'com.google.android.gms:play-services-wearable:10.2.0'
 
   // Mapbox dependencies
-  compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.0@aar') {
+  compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.1@aar') {
     transitive = true
   }
 }

--- a/whatsnew/whatsnew-en-US
+++ b/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-Update Mapbox GL Android SDK to 5.0.0
+This a minor release that fixes a shader precision issue that created a rendering problem on some devices.


### PR DESCRIPTION
Release 5.0.1 was published yesterday: https://github.com/mapbox/mapbox-gl-native/issues/8501.