### PR TITLE
making a null check for the throwable object to print the error message

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SpaceStationLocationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SpaceStationLocationActivity.java
@@ -159,9 +159,9 @@ public class SpaceStationLocationActivity extends AppCompatActivity {
           public void onFailure(Call<IssModel> call, Throwable throwable) {
             // If retrofit fails or the API was unreachable, an error will be called.
             //to check if throwable is null, then give a custom message.
-            if (throwable.getMessage() == null){
+            if (throwable.getMessage() == null) {
               Log.e(TAG, "Http connection failed");
-            }else{
+            } else {
               Log.e(TAG, throwable.getMessage());
             }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SpaceStationLocationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SpaceStationLocationActivity.java
@@ -158,7 +158,13 @@ public class SpaceStationLocationActivity extends AppCompatActivity {
           @Override
           public void onFailure(Call<IssModel> call, Throwable throwable) {
             // If retrofit fails or the API was unreachable, an error will be called.
-            Log.e(TAG, throwable.getMessage());
+            //to check if throwable is null, then give a custom message.
+            if (throwable.getMessage() == null){
+              Log.e(TAG, "Http connection failed");
+            }else{
+              Log.e(TAG, throwable.getMessage());
+            }
+
           }
         });
         // Schedule the next execution time for this runnable.


### PR DESCRIPTION
In SpaceStationLocationActivity, made a null check for the throwable object. If it is null, log a custom message else throwable.getMessage().

https://github.com/mapbox/mapbox-android-demo/issues/260 