### PR TITLE
Bumped to 5.0.2 in both gradle files

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   gpservicesCompile 'com.google.firebase:firebase-crash:10.0.1'
 
   // Mapbox dependencies
-  compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.1@aar') {
+  compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar') {
     transitive = true
   }
 

--- a/MapboxAndroidWearDemo/build.gradle
+++ b/MapboxAndroidWearDemo/build.gradle
@@ -28,7 +28,7 @@ dependencies {
   compile 'com.google.android.gms:play-services-wearable:10.2.0'
   compile 'com.google.android.gms:play-services-location:10.2.0'
   // Mapbox dependencies
-  compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.1@aar') {
+  compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.0.2@aar') {
     transitive = true
   }
 }


### PR DESCRIPTION
@cammace 

Adjusted gradle files.

Based on the 5.0.2 highlights, it doesn't seem like there are other changes to be made [like there were for the 4.0 to 5.0 transition](https://github.com/mapbox/mapbox-gl-native/wiki/Android-4.x-to-5.0-update). Let me know if so.