### PR TITLE
Changed download & list text/drawable colors

### DIFF
--- a/MapboxAndroidDemo/src/main/res/drawable/ic_get_app_24dp.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable/ic_get_app_24dp.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="@color/mapboxRed"
+        android:fillColor="@color/mapboxWhite"
         android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z"/>
 </vector>

--- a/MapboxAndroidDemo/src/main/res/drawable/ic_list_24dp.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable/ic_list_24dp.xml
@@ -1,9 +1,9 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
         android:width="24dp"
         android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
+        android:viewportHeight="24.0"
+        android:viewportWidth="24.0">
     <path
-        android:fillColor="@color/mapboxRed"
+        android:fillColor="@color/mapboxWhite"
         android:pathData="M3,13h2v-2H3v2zm0,4h2v-2H3v2zm0,-8h2V7H3v2zm4,4h14v-2H7v2zm0,4h14v-2H7v2zM7,7v2h14V7H7z"/>
 </vector>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_offline_manager.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_offline_manager.xml
@@ -34,7 +34,7 @@
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:layout_alignParentBottom="true"
-        android:background="@color/colorPrimary"
+        android:background="@color/colorAccent"
         android:elevation="8dp"
         android:orientation="horizontal"
         android:paddingTop="8dp">
@@ -50,7 +50,7 @@
             android:drawableTop="@drawable/ic_get_app_24dp"
             android:text="Download"
             android:textAllCaps="false"
-            android:textColor="@color/colorAccent"
+            android:textColor="@color/mapboxWhite"
             android:textSize="12sp"/>
 
         <Button
@@ -63,7 +63,7 @@
             android:drawableTop="@drawable/ic_list_24dp"
             android:text="List"
             android:textAllCaps="false"
-            android:textColor="@color/colorAccent"
+            android:textColor="@color/mapboxWhite"
             android:textSize="12sp"/>
 
     </LinearLayout>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_offline_manager.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_offline_manager.xml
@@ -48,7 +48,7 @@
             android:background="@android:color/transparent"
             android:clickable="true"
             android:drawableTop="@drawable/ic_get_app_24dp"
-            android:text="Download"
+            android:text="@string/offline_manager_download_button_text"
             android:textAllCaps="false"
             android:textColor="@color/mapboxWhite"
             android:textSize="12sp"/>
@@ -61,7 +61,7 @@
             android:layout_weight="1"
             android:background="@android:color/transparent"
             android:drawableTop="@drawable/ic_list_24dp"
-            android:text="List"
+            android:text="@string/offline_manager_list_button_text"
             android:textAllCaps="false"
             android:textColor="@color/mapboxWhite"
             android:textSize="12sp"/>

--- a/MapboxAndroidDemo/src/main/res/values/strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/strings.xml
@@ -233,5 +233,10 @@
     <string name="turf_inside_marker_status_inside">Inside</string>
     <string name="turf_inside_marker_status_outside">Outside</string>
 
+    <!--Offline manager button text-->
+    <string name="offline_manager_download_button_text">Download</string>
+    <string name="offline_manager_list_button_text">List</string>
+
+
 
 </resources>


### PR DESCRIPTION
I felt that the current red on blue was hard on the eyes:

<img width="400" alt="screen shot 2017-04-06 at 4 55 58 pm" src="https://cloud.githubusercontent.com/assets/4394910/24780145/f4557878-1ae9-11e7-9fa8-92d5eaab6d85.jpg">

I changed the bottom part of the activity to be more legible. See screenshots below. This PR would make the bottom part be white on red. Easy to go switch to the white on blue.

<img width="325" alt="screen shot 2017-04-06 at 4 52 56 pm" src="https://cloud.githubusercontent.com/assets/4394910/24780194/398d058c-1aea-11e7-8278-a840b4803c7d.png">
<img width="327" alt="screen shot 2017-04-06 at 4 52 40 pm" src="https://cloud.githubusercontent.com/assets/4394910/24780193/398b91ac-1aea-11e7-838e-d1d7f70cf79f.png">


