### PR TITLE
Ls new color values for new logo/brand launch

### DIFF
--- a/MapboxAndroidDemo/src/main/res/values/colors.xml
+++ b/MapboxAndroidDemo/src/main/res/values/colors.xml
@@ -9,10 +9,10 @@
     <color name="materialDarkGrey">#DFDFDF</color>
 
     <color name="mapboxWhite">#ffffff</color>
-    <color name="mapboxCyan">#3BB2D0</color>
-    <color name="mapboxGreen">#56B881</color>
-    <color name="mapboxBlue">#3887BE</color>
-    <color name="mapboxBlueDark">#1F6EA5</color>
+    <color name="mapboxCyan">#009cc6</color>
+    <color name="mapboxGreen">#00b35b</color>
+    <color name="mapboxBlue">#406787</color>
+    <color name="mapboxBlueDark">#112c43</color>
     <color name="mapboxPurple">#8A8ACB</color>
     <color name="mapboxPurpleDark">#7171b2</color>
     <color name="mapboxPurpleLight">#A4A4E5</color>

--- a/MapboxAndroidDemo/src/main/res/values/colors.xml
+++ b/MapboxAndroidDemo/src/main/res/values/colors.xml
@@ -2,28 +2,66 @@
 <resources>
     <!-- Mapbox colors -->
     <color name="colorPrimary">@color/mapboxBlue</color>
-    <color name="colorPrimaryDark">@color/mapboxBlueDark</color>
-    <color name="colorAccent">@color/mapboxRed</color>
+    <color name="colorPrimaryDark">@color/mapboxGrayDark</color>
+    <color name="colorAccent">@color/mapboxPink</color>
 
     <color name="materialGrey">#F5F5F5</color>
     <color name="materialDarkGrey">#DFDFDF</color>
 
     <color name="mapboxWhite">#ffffff</color>
     <color name="mapboxCyan">#009cc6</color>
-    <color name="mapboxGreen">#00b35b</color>
-    <color name="mapboxBlue">#406787</color>
-    <color name="mapboxBlueDark">#112c43</color>
-    <color name="mapboxPurple">#8A8ACB</color>
-    <color name="mapboxPurpleDark">#7171b2</color>
-    <color name="mapboxPurpleLight">#A4A4E5</color>
+
+
+    <color name="mapboxGreenDark">#269561</color>
+    <color name="mapboxGreen">#33c377</color>
+    <color name="mapboxGreenLight">#afdec5</color>
+    <color name="mapboxGreenFaint">#e8f5ee</color>
+
+
+    <color name="mapboxBlue">#4264fb</color>
+    <color name="mapboxBlueDark">#314ccd</color>
+    <color name="mapboxBlueLight">#aab7ef</color>
+    <color name="mapboxBlueFaint">#edf0fd</color>
+
+    <color name="mapboxGrayDark">#273d56</color>
+    <color name="mapboxGray">#607d9c</color>
+    <color name="mapboxGrayLight">#c6d2e1</color>
+    <color name="mapboxGrayFaint">#f4f7fb</color>
+
+    <color name="mapboxPinkDark">#b43b71</color>
+    <color name="mapboxPink">#ee4e8b</color>
+    <color name="mapboxPinkLight">#f8c8da</color>
+    <color name="mapboxPinkFaint">#fbe5ee</color>
+
+    <color name="mapboxPurple">#7753eb</color>
+    <color name="mapboxPurpleDark">#5a3fc0</color>
+    <color name="mapboxPurpleLight">#c5b9eb</color>
+    <color name="mapboxPurpleFaint">#f2effa</color>
 
     <color name="mapboxDenim">#50667F</color>
-    <color name="mapboxTeal">#41AFA5</color>
-    <color name="mapboxOrange">#F9886C</color>
-    <color name="mapboxRed">#E55E5E</color>
-    <color name="mapboxPink">#ED6498</color>
-    <color name="mapboxYellow">#f1f075</color>
+
+    <color name="mapboxTealDark">#136174</color>
+    <color name="mapboxTeal">#11b4da</color>
+    <color name="mapboxTealLight">#a4deeb</color>
+    <color name="mapboxTealFaint">#d7f1f6</color>
+
+    <color name="mapboxOrangeDark">#ba7334</color>
+    <color name="mapboxOrange">#f79640</color>
+    <color name="mapboxOrangeLight">#fbcea6</color>
+    <color name="mapboxOrangeFaint">#feefe2</color>
+
+    <color name="mapboxRedDark">#ba3b3f</color>
+    <color name="mapboxRed">#f74e4e</color>
+    <color name="mapboxRedLight">#f6b7b7</color>
+    <color name="mapboxRedFaint">#fbe5e5</color>
+
+    <color name="mapboxYellowDark">#a4a62d</color>
+    <color name="mapboxYellow">#d9d838</color>
+    <color name="mapboxYellowLight">#FFF5A0</color>
+    <color name="mapboxYellowFaint">#FCFCDF</color>
+
     <color name="mapboxMustard">#FBB03B</color>
+
     <color name="mapboxNavy">#28353D</color>
     <color name="mapboxNavyDark">#222B30</color>
 


### PR DESCRIPTION
Adjusted color file to account for new branding. I added all of the various colors from [the new styleguide](https://www.mapbox.com/styleguide/colors/) because I figured it'd be good to have all of them at our disposal in-app for the future.

@cammace , I would say that the main thing for you to look at below is the 3 colors that I've chosen... `colorPrimary`, `colorPrimaryDark`, and `colorAccent`. 

<img width="575" alt="screen shot 2017-04-24 at 6 14 29 pm" src="https://cloud.githubusercontent.com/assets/4394910/25364821/eb71acfc-2919-11e7-88f8-63f14fc14d34.png">

<img width="477" alt="screen shot 2017-04-24 at 6 14 34 pm" src="https://cloud.githubusercontent.com/assets/4394910/25364820/eb6deb44-2919-11e7-89c0-e062461f19f5.png">
