### PR TITLE
Added config file for pulling in Transifex translations

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -7,3 +7,4 @@ file_filter = mapbox-android-demo/MapboxAndroidDemo/src/main/res/values-<lang>/s
 source_file = mapbox-android-demo/MapboxAndroidDemo/src/main/res/values/strings.xml
 source_lang = en
 type = ANDROID
+

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,9 @@
+[main]
+host = https://www.transifex.com
+minimum_perc = 80
+
+[mapbox-android-demo.stringsxml]
+file_filter = mapbox-android-demo/MapboxAndroidDemo/src/main/res/values-<lang>/strings.xml
+source_file = mapbox-android-demo/MapboxAndroidDemo/src/main/res/values/strings.xml
+source_lang = en
+type = ANDROID

--- a/mapbox-android-demo/MapboxAndroidDemo/src/main/res/values-ca/strings.xml
+++ b/mapbox-android-demo/MapboxAndroidDemo/src/main/res/values-ca/strings.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="app_name">Vista prèvia Mapbox Dev</string>
+    <string name="examples">Exemples Android</string>
+
+    <!-- UI Strings -->
+    <string name="navigation_drawer_open">Obrir panell de navegació</string>
+    <string name="navigation_drawer_close">Tancar panell de navegació</string>
+
+    <string name="info_dialog_title">Començar</string>
+    <string name="info_dialog_description">T\'agrada aquesta biblioteca? Aprén com incloure-la a la teva app!</string>
+    <string name="info_dialog_positive_button_text">Inicia l\'aprenentatge</string>
+    <string name="info_dialog_negative_button_text">Ara no</string>
+
+    <string name="description_labs">Mentre que les altres categories en aquesta aplicació mostren exemples fent una cosa específica, la categoria de laboratori combina exemples per demostrar el poder de l\'SDK.</string>
+    <string name="description_mas">El Servei Android de Mapbox empaqueta moltes de les API Mapbox en un únic SDK, com ara adreces, geocodificació i molts altres serveis oferts.</string>
+    <string name="description_query">Aquests exemples mostren com consultar les dades dels mapes per obtenir informació com les característiques d\'una geometria o les propietats.</string>
+
+    <!-- toolbar items -->
+    <string name="info">Informació</string>
+
+    <!-- nav drawer categories -->
+    <string name="getting_started_category">Començar</string>
+    <string name="styles_category">Estils</string>
+    <string name="dds_category">Estil guiat per dades</string>
+    <string name="annotations_category">Annotacions</string>
+    <string name="camera_category">Càmera</string>
+    <string name="offline_category">Offline</string>
+    <string name="query_map_category">Interrogar mapa</string>
+    <string name="android_services_category">Serveis Android</string>
+    <string name="location_category">Localització de l\'usuari</string>
+    <string name="lab_category">Laboratori</string>
+
+    <!-- Spinner for color picker example-->
+    <string-array name="layer_spinner_array">
+        <item>Aigua</item>
+        <item>Edifici</item>
+    </string-array>
+
+    <!-- example titles -->
+    <string name="activity_basic_simple_mapview_title">Vista simple de mapa</string>
+    <string name="activity_basic_support_map_frag_title">Fragment de mapa base</string>
+    <string name="activity_basic_mapbox_options_title">Genera vista de mapa dinàmicament</string>
+    <string name="activity_style_mapbox_studio_title">Esti Mapbox Studio</string>
+    <string name="activity_style_raster_title">Estil ràster personalitzat</string>
+    <string name="activity_style_default_title">Estils per defecte</string>
+    <string name="activity_styles_show_hide_layer_title">Mostra i amaga capes</string>
+    <string name="activity_styles_langauge_switch_title">Canvia l\'idioma del mapa</string>
+    <string name="activity_styles_color_switcher_title">Canvia el color de la capa</string>
+    <string name="activity_styles_adjust_layer_opacity_title">Ajusta la transparència de la capa</string>
+    <string name="activity_styles_geojson_layer_in_stack_title">Afegeix una capa per sota de les etiquetes</string>
+    <string name="activity_styles_vector_source_title">Afegeix una font de tessel·les vector</string>
+    <string name="activity_style_add_wms_source_title">Afegeix una font WMS</string>
+    <string name="activity_style_zoom_dependent_fill_color_title">El color en funció del nivell de zoom</string>
+    <string name="activity_style_create_heatmap_points_title">Crea un mapa de calor a partir de punts</string>
+    <string name="activity_style_data_clusters_title">Crea i dona estils a agrupacions de dades</string>
+    <string name="activity_style_line_layer_title">Crea una capa de línies</string>
+    <string name="activity_style_symbol_layer_title">Capa de símbols marcadors</string>
+    <string name="activity_dds_style_circle_categorically_title">Aplicar estil per categories als cercles</string>
+    <string name="activity_dds_choropleth_zoom_change_title">Actualitza un mapa coroplètic per nivell de zoom</string>
+    <string name="activity_dds_style_line_identity_property_title">Aplicar estil a les línies utilitzant una funció de propietat d\'identitat</string>
+    <string name="activity_annotation_marker_title">Dibuixa un marcador</string>
+    <string name="activity_annotation_custom_marker_title">Dibuixa un marcador amb icona personalitzada</string>
+    <string name="activity_annotation_geojson_line_title">Dibuixa una línia GeoJSON</string>
+    <string name="activity_annotation_polygon_title">Dibuixa un polígon</string>
+    <string name="activity_annotation_marker_view_title">Dibuixa una vista de marcador</string>
+    <string name="activity_annotation_custom_info_window_title">Finestra d\'informació personalitzada</string>
+    <string name="activity_annotation_animated_marker_title">Afegeix animació a la posició del marcador</string>
+    <string name="activity_camera_animate_title">Afegeix animació a la càmera del mapa</string>
+    <string name="activity_camera_bounding_box_title">Encaixa la càmera en el requadre delimitador</string>
+    <string name="activity_camera_restrict_title">Restringeix desplaçar el mapa</string>
+    <string name="activity_offline_simple_title">Un mapa senzill offline</string>
+    <string name="activity_offline_manager_title">Gestor offline</string>
+    <string name="activity_query_feature_title">Interroga una propietat del mapa</string>
+    <string name="activity_query_select_building_title">Escull un edifici</string>
+    <string name="activity_query_feature_count_title">Compta el nombre d\'elements</string>
+    <string name="activity_location_basic_title">Mostra la posició de l\'usuari</string>
+    <string name="activity_location_tracking_title">Segueix la posició de l\'usuari</string>
+    <string name="activity_location_animated_icon_title">Afegeix animació a l\'icona d\'usuari</string>
+    <string name="activity_location_customize_user_title">Personalitza la icona de la posició de l\'usuari</string>
+    <string name="activity_mas_directions_title">Mostra indicacions al mapa</string>
+    <string name="activity_mas_geocoding_title">Giny per autocompletar la geocodificació</string>
+    <string name="activity_mas_static_image_title">Descarrega un mapa estàtic</string>
+    <string name="activity_mas_simplify_polyline_title">Simplifica una polilínia</string>
+    <string name="activity_mas_map_matching_title">Igualar mapes</string>
+    <string name="activity_lab_location_picker_title">Selector de posició</string>
+    <string name="activity_lab_marker_following_route_title">Marcador seguint la ruta</string>
+    <string name="activity_lab_space_station_location_title">Posició actual de l\'estació espacial</string>
+    <string name="activity_lab_off_route_title">Detecció de fora ruta</string>
+    <string name="activity_lab_las_angeles_tourism_title">Los Angeles per a turistes</string>
+    <string name="activity_lab_indoor_map_title">Mapa d\'interior</string>
+
+    <!-- example descriptions-->
+    <string name="activity_basic_simple_mapview_description">Mostra un mapa a la teva app emprant l\'SDK per Android de Mapbox</string>
+    <string name="activity_basic_support_map_frag_description">Afegeix un fragment de mapa a la teca app emprant la llibreria de suport d\'Android</string>
+    <string name="activity_basic_mapbox_options_description">Afegir una vista de mapa en un disseny creat de forma dinàmica.</string>
+    <string name="activity_style_mapbox_studio_description">Utilitza un estil personalitzat hostatjat a Mapbox.</string>
+    <string name="activity_style_raster_description">Utitlitza les tessel·les ràster obsoletes a la teva aplicació.</string>
+    <string name="activity_style_default_description">Utilitza una varietat d\'estils dissenyts professionalment amb Mapbox Android SDK.</string>
+    <string name="activity_styles_show_hide_layer_description">Crear un gestor de capes personalitzat per mostrar diferents conjunts de dades.</string>
+    <string name="activity_styles_langauge_switch_description">Canvia l\'idioma dels mapes de forma dinàmica</string>
+    <string name="activity_styles_color_switcher_description">Utilitza el conjunt de capes per canviar el color de reomplert d\'una capa</string>
+    <string name="activity_styles_adjust_layer_opacity_description">Arrossegueu la barra per ajustar l\'opacitat d\'una capa ràster a sobre d\'un mapa.</string>
+    <string name="activity_styles_geojson_layer_in_stack_description">Podeu ser més precís emprant el segon argument d\'addLayer</string>
+    <string name="activity_styles_vector_source_description">Afegiu una font vectorial en un mapa i mostreu-la com una capa.</string>
+    <string name="activity_style_add_wms_source_description">Afegiu una capa WMS externa al mapa</string>
+    <string name="activity_style_zoom_dependent_fill_color_description">Feu que una propietat depengui del nivell de zoom del mapa, en aquest cas el color de reomplert de la capa aigua.</string>
+    <string name="activity_style_create_heatmap_points_description">Feu servir l\'SDK Android de Mapbox per visualitzar dades puntuals com mapes de calor.</string>
+    <string name="activity_style_create_data_cluster_description">Feu servir GeoJSON per visualitzar dades puntuals com agregacions.</string>
+    <string name="activity_style_line_layer_description">Crear línia amb GeoJSON,  canvia\'n l\'estil emprant les propietats, i afegir la capa al mapa.</string>
+    <string name="activity_style_symbol_layer_description">Mostra marcadors al mapa afegint una capa de de símbols. Consulta el mapa i anima la mida de les icones quan s\'hi faci clic.</string>
+    <string name="activity_dds_style_circle_categorically_description">Usant una funció de propietat categòrica per al cercle-color per a la seva visualització.</string>
+    <string name="activity_dds_choropleth_zoom_change_description">Emprant dades del cens de 2014 mostreu la població de l\'estat o el comptat depenent del nivell de zoom.</string>
+    <string name="activity_dds_style_line_identity_property_description">Usant una funció de propietat d\'identitat de línia-color per a la seva visualització.</string>
+    <string name="activity_annotation_marker_description">Crea un marcador per defecte amb una finestra d\'informació .</string>
+    <string name="activity_annotation_custom_marker_description">Crea un marcador amb una icona personalitzada emprant l\'SDK Android de Mapbox.</string>
+    <string name="activity_annotation_geojson_line_description">Dibuixa una polilínia mitjançant l\'anàlisi d\'un arxiu GeoJSON amb l\'SDK Android de Mapbox.</string>
+    <string name="activity_annotation_polygon_description">Dibuixa un polígon vector en un mapa amb l\'SDK Android de Mapbox.</string>
+    <string name="activity_annotation_marker_view_description">Adjunta una vista a una posició donada en el mapa.</string>
+    <string name="activity_annotation_custom_info_window_description">Utilitza un adaptador de la finestra d\'informació per personalitzar la finestra d\'informació.</string>
+    <string name="activity_annotation_animated_marker_description">Anima el marcador a una nova posició al mapa.</string>
+    <string name="activity_camera_animate_description">Anima la posició de la càmera, l\'iinclinació, el rodament i el zoom del mapa.</string>
+    <string name="activity_camera_bounding_box_description">Col·loca la càmera de manera que tots els marcadors donats estan a la vista.</string>
+    <string name="activity_camera_restrict_description">Evita que un mapa es pugui moure a un altre panell</string>
+    <string name="activity_offline_simple_description">Descarrega i consulta un mapa offline amb l\'SDK Android de Mapbox.</string>
+    <string name="activity_offline_manager_description">Descarregar, veure, navegar a, i eliminar una regió offline.</string>
+    <string name="activity_query_feature_description">Feu clic al mapa per afegir un marcador al lloc i mostrar la informació de les propietats del mapa per a aquesta característica.</string>
+    <string name="activity_query_select_building_description">Utilitza la funció de consulta per a seleccionar un edifici, obtenir la seva geometria i dibuixar un polígon que el ressalti.</string>
+    <string name="activity_query_feature_count_description">Obtenir el recompte de característiques dins d\'un requadre delimitador i ressaltar tots els edificis.</string>
+    <string name="activity_location_basic_description">Alterna la posició actual de l\'usuari en el mapa.</string>
+    <string name="activity_location_tracking_description">Bloqueja la càmera centrada sobre la ubicació de l\'usuari.</string>
+    <string name="activity_location_animated_icon_description">Utilitza una vista de marcador per marcar la ubicació dels usuaris i afegeix-hi una animació de batec.</string>
+    <string name="activity_location_customize_user_description">Ajustar el color de la icona d\'ubicació de l\'usuari i l\'encoixinat per tal que aparegui més avall a la pantalla.</string>
+    <string name="activity_mas_directions_description">Empra Mapbox Android Services per demanar indicacions.</string>
+    <string name="activity_mas_geocoding_description">Empra el geocodificador de Mapbox Android Services per convertir llocs textuals en coordenads geogràfiques.</string>
+    <string name="activity_mas_static_image_description">Empra Mapbox Android Services per generar una url i descarregar un mapa estàtic.</string>
+    <string name="activity_mas_simplify_polyline_description">Emprant l\'eina de polilínies simplifica una polilínia, cosa que redueix la quantitat de coordenades que componen la polilínia depenent de la tolerància.</string>
+    <string name="activity_mas_map_matching_description">Feu coincidir els punts GPS amb el mapa de manera que encaixin amb les carreteres/vies.</string>
+    <string name="activity_lab_location_picker_description">Posa un punt en una ubicació específica i després realitza la geocodificació inversa.</string>
+    <string name="activity_lab_marker_following_route_description">Emprant una ruta GeoJSON encaixada amb el mapa el marcador es desplaça al llarg de la ruta a velocitat constant.</string>
+    <string name="activity_lab_space_station_location_description">Veu la posició de l\'Estació Espacial Internacional en temps real.</string>
+    <string name="activity_lab_off_route_description">Detecta quan el vehicle és fora de la ruta i el redirigeix.</string>
+    <string name="activity_lab_las_angeles_tourism_description">Utilitza l\'API d\'estil per ressaltar parcs, hotels i atraccions. També s\'afegeix una animació de batec als colors.</string>
+    <string name="activity_lab_indoor_map_description">Mostra un mapa d\'interiors d\'un edifici amb opcions per canviar entre els pisos.</string>
+
+    <!--Default style names-->
+    <string name="menu_map_style_streets">Carrers</string>
+    <string name="menu_map_style_dark">Fosc</string>
+    <string name="menu_map_style_light">Clar</string>
+    <string name="menu_map_style_outdoors">A l\'aire lliure</string>
+    <string name="menu_map_style_satellite">Satèl·lit</string>
+    <string name="menu_map_style_satellite_streets">Carrers satèl·lit</string>
+
+    <!--Move map instruction for toast-->
+    <string name="move_map_instruction">Desplaça el mapa per afegir place\nmarker a la posició desitjada</string>
+
+    <!--Zoom in and out map instruction for toast-->
+    <string name="zoom_map_in_and_out_instruction">Apropa\'t i allunya\'t per veure com canvien les xifres a les agrupacions</string>
+
+    <!--Geocode widget hint text-->
+    <string name="hint_text_in_geocode_widget">Escull ubicació </string>
+
+    <!--Tap on feature box instruction-->
+    <string name="tap_on_feature_box_instruction">Toqueu al requadre delimitador</string>
+
+    <!--Fragment below textview in support fragment activity-->
+    <string name="fragment_in_card_below">Contenidor de fragment de mapa a la targeta de sota</string>
+
+    <!--Offline manager button text-->
+    <string name="offline_manager_download_button_text">Descarrega</string>
+    <string name="offline_manager_list_button_text">Llista</string>
+
+    <!--Basic user location permission toasts-->
+    <string name="user_location_permission_explanation">Aquesta app necessita permisos per mostrar la seva funcionalitat.</string>
+    <string name="user_location_permission_not_granted">No heu proporcionat permisos de localització.</string>
+
+    <!--Basic offline map-->
+    <string name="basic_offline_deleted_toast">Mapa offlilne de Yosemite esborrat</string>
+
+    <!--Tap on map instruction for toast-->
+    <string name="tap_on_map_instruction">Toqueu en qualsevol lloc al mapa</string>
+    <string name="tap_on_map_turf_inside_instruction">Toqueu a l\'interior del polígon blau</string>
+
+</resources>


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-android-demo/issues/226

Basically copied and adjusted [the additions that Tobrun made in GL-native](https://github.com/mapbox/mapbox-gl-native/pull/8556/files#diff-cb86fa52440c3b29e9ad70ce1a82fe14) to fit the demo app's paths. I didn't adjust anything in `strings.xml` file because the appropriate string resources already have `translatable="false"` next to them

cc @1ec5 @jcsg @zugaldia 