### PR TITLE
Fixed animate user location example

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/AnimatedLocationIconActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/AnimatedLocationIconActivity.java
@@ -70,6 +70,7 @@ public class AnimatedLocationIconActivity extends AppCompatActivity implements P
 
     // Get the location engine object for later use.
     locationEngine = LocationSource.getLocationEngine(this);
+    locationEngine.activate();
 
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);


### PR DESCRIPTION
Despite @cammace 's [previous PR](https://github.com/mapbox/mapbox-android-demo/pull/299), the animate user icon example wasn't working on `master`. This PR updates `master` to the code on that PR.