### PR TITLE
add APK splits option to build.gradle

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -44,7 +44,7 @@ android {
     splits {
         abi {
             enable true
-            universalApk true
+            universalApk false
         }
     }
 }

--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -40,6 +40,13 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    splits {
+        abi {
+            enable true
+            universalApk true
+        }
+    }
 }
 
 dependencies {

--- a/MapboxAndroidDemo/proguard-rules.pro
+++ b/MapboxAndroidDemo/proguard-rules.pro
@@ -21,5 +21,9 @@
 # Picasso
 -dontwarn com.squareup.okhttp.**
 
+-dontwarn android.support.**
+-dontwarn java.lang.**
+-dontwarn org.codehaus.**
 -keep class com.google.**
 -dontwarn com.google.**
+-dontwarn java.nio.**

--- a/MapboxAndroidWearDemo/proguard-rules.pro
+++ b/MapboxAndroidWearDemo/proguard-rules.pro
@@ -1,17 +1,29 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /Users/antonio/Library/Android/sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# Retrofit 2
+# Platform calls Class.forName on types which do not exist on Android to determine platform.
+-dontnote retrofit2.Platform
+# Platform used when running on RoboVM on iOS. Will not be used at runtime.
+-dontnote retrofit2.Platform$IOS$MainThreadExecutor
+# Platform used when running on Java 8 VMs. Will not be used at runtime.
+-dontwarn retrofit2.Platform$Java8
+# Retain generic type information for use by reflection by converters and adapters.
+-keepattributes Signature
+# Retain declared checked exceptions for use by a Proxy instance.
+-keepattributes Exceptions
 
-# Add any project specific keep options here:
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+# Gson specific classes
+-dontwarn sun.misc.**
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-dontwarn okio.**
+-dontwarn okhttp3.**
+
+# Picasso
+-dontwarn com.squareup.okhttp.**
+
+-dontwarn android.support.**
+-dontwarn java.lang.**
+-dontwarn org.codehaus.**
+-keep class com.google.**
+-dontwarn com.google.**
+-dontwarn java.nio.**

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -63,7 +63,7 @@ workflows:
         - apk_path: "$BITRISE_SIGNED_APK_PATH"
         - service_account_json_key_path: "$BITRISEIO_SERVICE_ACCOUNT_JSON_URL"
         - package_name: com.mapbox.mapboxandroiddemo
-        - track: beta
+        - track: alpha
         - whatsnews_dir: whatsnew
         - service_account_email: ''
         - key_file_path: ''

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -45,7 +45,7 @@ workflows:
 
             echo "Run tests on firebase:"
             gcloud auth activate-service-account --key-file secret.json --project mapbox-android-demo
-            gcloud beta test android run --type robo --app MapboxAndroidDemo/build/outputs/apk/MapboxAndroidDemo-gpservices-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
+            gcloud beta test android run --type robo --app MapboxAndroidDemo/build/outputs/apk/MapboxAndroidDemo-gpservices-armeabi-v7a-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
     - deploy-to-bitrise-io:
         inputs:
         - notify_user_groups: none
@@ -54,9 +54,13 @@ workflows:
     - gradle-runner:
         inputs:
         - gradle_task: "$GRADLE_TASK"
-    - sign-apk: {}
+    - sign-apk:
+        inputs:
+        - apk_path: "$BITRISE_APK_PATH_LIST"
+        - apk_file_exclude_filter: "*-unsigned.apk"
     - google-play-deploy:
         inputs:
+        - apk_path: "$BITRISE_SIGNED_APK_PATH"
         - service_account_json_key_path: "$BITRISEIO_SERVICE_ACCOUNT_JSON_URL"
         - package_name: com.mapbox.mapboxandroiddemo
         - track: beta

--- a/script-git-version.gradle
+++ b/script-git-version.gradle
@@ -24,6 +24,6 @@ import org.ajoberstar.grgit.Grgit
 ext {
     git = Grgit.open(currentDir: projectDir)
     gitVersionName = git.describe()
-    gitVersionCode = git.tag.list().size() + 51 // 51 = base version code
+    gitVersionCode = git.tag.list().size() + 52 // + base version code
     gitVersionCodeTime = git.head().time
 }

--- a/whatsnew/whatsnew-en-US
+++ b/whatsnew/whatsnew-en-US
@@ -1,1 +1,1 @@
-This a minor release that fixes a shader precision issue that created a rendering problem on some devices.
+Update to 5.1.0-beta.4


### PR DESCRIPTION
Closes #288, this PR introduces APK splits option in build.gradle. 
This results in building separate APKs for all supported ABI configurations:

<img width="468" alt="screen shot 2017-06-09 at 16 41 32" src="https://user-images.githubusercontent.com/2151639/26980520-bc751dc0-4d32-11e7-8234-51f132396cb0.png">

The size of universal APK =  18.6 mb
The size of a specific ABI APK = 6.4 mb

TODO:
 - [x] validate if bitrise is able to handle the upload of APK splits to google play automatically
 - [x] validate if the signature of the release APK has changed (requires changes in bitrise.yml)
