### PR TITLE
Adjusted string url

### DIFF
--- a/MapboxAndroidDemo/src/main/res/values/strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/strings.xml
@@ -196,7 +196,7 @@
     <string name="activity_annotation_basic_marker_view_url" translatable="false">http://i.imgur.com/vbWTLIE.png</string>
     <string name="activity_annotation_custom_info_window_url" translatable="false">http://i.imgur.com/mCWbosy.png</string>
     <string name="activity_annotation_animated_marker_url" translatable="false">http://i.imgur.com/XegvIKr.png</string>
-    <string name="activity_camera_animate_url" translatable="false">http://i.imgur.com/4ny2U84.gifv</string>
+    <string name="activity_camera_animate_url" translatable="false">http://i.imgur.com/PN3vyNJ.jpg</string>
     <string name="activity_camera_bounding_box_url" translatable="false">http://i.imgur.com/A0JL21Q.png</string>
     <string name="activity_camera_restrict_url" translatable="false">http://i.imgur.com/A227BEs.jpg</string>
     <string name="activity_offline_simple_url" translatable="false">http://i.imgur.com/dV4DgDT.png</string>


### PR DESCRIPTION
Picasso doesn't support gifs, so the Animate Camera example card was blank because a gif url was in the string file. Replaced with a static image.