### PR TITLE
Fix Firebase Test Lab command in CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,7 +52,7 @@ workflows:
 
             echo "Run tests on firebase:"
             gcloud auth activate-service-account --key-file secret.json --project mapbox-android-demo
-            gcloud beta test android run --type robo --app MapboxAndroidDemo/build/outputs/apk/MapboxAndroidDemo-gpservices-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
+            gcloud firebase test android run --type robo --app MapboxAndroidDemo/build/outputs/apk/MapboxAndroidDemo-gpservices-debug.apk --device-ids shamu --os-version-ids 22 --locales en --orientations portrait --timeout 10m
     - deploy-to-bitrise-io:
         inputs:
         - notify_user_groups: none


### PR DESCRIPTION
- Builds on CI are failing because `gcloud beta test android run` is not valid anymore.
  - We should use `gcloud firebase test android run` instead.

cc/ @tobrun @langsmith 