### PR TITLE
Fix wear app not synced automatically

### DIFF
--- a/MapboxAndroidDemo/src/gpservices/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/gpservices/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
 
     <uses-feature android:name="android.hardware.location.gps"/>
 


### PR DESCRIPTION
- `app` part needs to have all the permissions the `wear` component has (`WAKE_LOCK` was missing)
- Fixes #330 

👀 @tobrun @langsmith 