### PR TITLE
Picasso caching example card images

### DIFF
--- a/MapboxAndroidDemo/src/gpservices/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
+++ b/MapboxAndroidDemo/src/gpservices/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
@@ -4,6 +4,8 @@ import android.app.Application;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.squareup.picasso.OkHttpDownloader;
+import com.squareup.picasso.Picasso;
 
 public class MapboxApplication extends Application {
 
@@ -15,5 +17,11 @@ public class MapboxApplication extends Application {
       .setApplicationId(getString(R.string.firebase_app_id))
       .build()
     );
+
+    Picasso.Builder builder = new Picasso.Builder(this);
+    builder.downloader(new OkHttpDownloader(this, Integer.MAX_VALUE));
+    Picasso built = builder.build();
+    built.setLoggingEnabled(true);
+    Picasso.setSingletonInstance(built);
   }
 }

--- a/MapboxAndroidDemo/src/gpservices/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
+++ b/MapboxAndroidDemo/src/gpservices/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
@@ -12,12 +12,19 @@ public class MapboxApplication extends Application {
   @Override
   public void onCreate() {
     super.onCreate();
+    initializeFirebaseApp();
+    setUpPicasso();
+  }
+
+  private void initializeFirebaseApp() {
     FirebaseApp.initializeApp(this, new FirebaseOptions.Builder()
       .setApiKey(getString(R.string.firebase_api_key))
       .setApplicationId(getString(R.string.firebase_app_id))
       .build()
     );
+  }
 
+  private void setUpPicasso() {
     Picasso.Builder builder = new Picasso.Builder(this);
     builder.downloader(new OkHttpDownloader(this, Integer.MAX_VALUE));
     Picasso built = builder.build();


### PR DESCRIPTION
I'm a bit skeptical because it seemed so easy, but the few lines in this pull request seem to have fixed #71 

Here's how I've tested it:  I loaded some card images while connected to wifi. Then killed the app and went into airplane mode. Opened the app and images that were opened while on wifi are still visible while in airplane mode. The Picasso logs also say `from DISK` when the images load while in airplane mode 👇  

![screen shot 2017-08-08 at 1 15 02 pm](https://user-images.githubusercontent.com/4394910/29092622-d2ad107e-7c3b-11e7-9599-f8bea8e5bb80.png)
