### PR TITLE
bumped android UI dependency to 2.2.1

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'
 
     // Mapbox Android UI
-    compile 'com.mapbox.mapboxsdk:mapbox-android-ui:2.2.0'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-ui:2.2.1'
 
     // Other dependencies
     compile 'com.github.javiersantos:MaterialStyledDialogs:2.1'


### PR DESCRIPTION
Part of [the MAS 2.2.1 release](https://github.com/mapbox/mapbox-java/issues/542)