### PR TITLE
Switch to getString(R.string.access_token) in DirectionsActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/mas/DirectionsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/mas/DirectionsActivity.java
@@ -90,7 +90,7 @@ public class DirectionsActivity extends AppCompatActivity {
       .setDestination(destination)
       .setOverview(DirectionsCriteria.OVERVIEW_FULL)
       .setProfile(DirectionsCriteria.PROFILE_CYCLING)
-      .setAccessToken(Mapbox.getAccessToken())
+      .setAccessToken(getString(R.string.access_token))
       .build();
 
     client.enqueueCall(new Callback<DirectionsResponse>() {


### PR DESCRIPTION
DirectionsActivity had the outdated way of retrieving the token