### PR TITLE
Mapillary zoom level config

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/MapillaryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/MapillaryActivity.java
@@ -6,13 +6,11 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import android.view.View;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
-
-import android.view.View;
-
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -149,6 +147,8 @@ public class MapillaryActivity extends AppCompatActivity {
 
     static Source createSource() {
       TileSet mapillaryTileset = new TileSet("2.1.0", Mapillary.URL_TILESET);
+      mapillaryTileset.setMinZoom(0);
+      mapillaryTileset.setMaxZoom(14);
       return new VectorSource(Mapillary.ID_SOURCE, mapillaryTileset);
     }
 


### PR DESCRIPTION
This PR updates the Mapillary example with the correct zoom configuration. 
With this in place the vector tiles aren't removed when zooming in.

![ezgif com-video-to-gif 35](https://user-images.githubusercontent.com/2151639/30278203-21d4bcea-970a-11e7-862e-c966e06c0c05.gif)
