### PR TITLE
Show/hide PIP based on version number

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -3,6 +3,7 @@ package com.mapbox.mapboxandroiddemo;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -575,12 +576,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           new Intent(MainActivity.this, SpaceStationLocationActivity.class),
           R.string.activity_lab_space_station_location_url
         ));
-        exampleItemModel.add(new ExampleItemModel(
-          R.string.activity_lab_picture_in_picture_title,
-          R.string.activity_lab_picture_in_picture_description,
-          new Intent(MainActivity.this, PictureInPictureActivity.class),
-          R.string.activity_lab_picture_in_picture_url, true
-        ));
+        if (Build.VERSION.SDK_INT > 24) {
+          exampleItemModel.add(new ExampleItemModel(
+            R.string.activity_lab_picture_in_picture_title,
+            R.string.activity_lab_picture_in_picture_description,
+            new Intent(MainActivity.this, PictureInPictureActivity.class),
+            R.string.activity_lab_picture_in_picture_url, true
+          ));
+        }
         exampleItemModel.add(new ExampleItemModel(
           R.string.activity_lab_rv_on_map_title,
           R.string.activity_lab_rv_on_map_description,

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -576,7 +576,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           new Intent(MainActivity.this, SpaceStationLocationActivity.class),
           R.string.activity_lab_space_station_location_url
         ));
-        if (Build.VERSION.SDK_INT > 24) {
+        if (Build.VERSION.SDK_INT > 26) {
           exampleItemModel.add(new ExampleItemModel(
             R.string.activity_lab_picture_in_picture_title,
             R.string.activity_lab_picture_in_picture_description,

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -576,7 +576,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           new Intent(MainActivity.this, SpaceStationLocationActivity.class),
           R.string.activity_lab_space_station_location_url
         ));
-        if (Build.VERSION.SDK_INT > 26) {
+        if (Build.VERSION.SDK_INT >= 26) {
           exampleItemModel.add(new ExampleItemModel(
             R.string.activity_lab_picture_in_picture_title,
             R.string.activity_lab_picture_in_picture_description,


### PR DESCRIPTION
Fixes #472 by adding a version check which determines whether to show/hide the Picture in Picture example card. I've set the minimum # to 26 (Oreo) because only devices running Oreo can do PIP. If this thinking is incorrect, please let me know.

cc @tobrun 