### PR TITLE
Las Angeles typo refactoring

### DIFF
--- a/MapboxAndroidDemo/src/gpservices/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/gpservices/AndroidManifest.xml
@@ -336,7 +336,7 @@
 
         <activity
             android:name=".labs.LosAngelesTourismActivity"
-            android:label="@string/activity_lab_las_angeles_tourism_title">
+            android:label="@string/activity_lab_los_angeles_tourism_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity"/>

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -350,7 +350,7 @@
         </activity>
         <activity
             android:name=".labs.LosAngelesTourismActivity"
-            android:label="@string/activity_lab_las_angeles_tourism_title">
+            android:label="@string/activity_lab_los_angeles_tourism_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity"/>

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -546,10 +546,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           R.string.activity_lab_mapillary_url
         ));
         exampleItemModel.add(new ExampleItemModel(
-          R.string.activity_lab_las_angeles_tourism_title,
-          R.string.activity_lab_las_angeles_tourism_description,
+          R.string.activity_lab_los_angeles_tourism_title,
+          R.string.activity_lab_los_angeles_tourism_description,
           new Intent(MainActivity.this, LosAngelesTourismActivity.class),
-          R.string.activity_lab_las_angeles_tourism_url
+          R.string.activity_lab_los_angeles_tourism_url
         ));
         exampleItemModel.add(new ExampleItemModel(
           R.string.activity_lab_indoor_map_title,

--- a/MapboxAndroidDemo/src/main/res/values-ca/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-ca/descriptions_strings.xml
@@ -59,6 +59,6 @@
     <string name="activity_lab_marker_following_route_description">Emprant una ruta GeoJSON encaixada amb el mapa el marcador es desplaça al llarg de la ruta a velocitat constant.</string>
     <string name="activity_lab_space_station_location_description">Veu la posició de l\'Estació Espacial Internacional en temps real.</string>
     <string name="activity_lab_off_route_description">Detecta quan el vehicle és fora de la ruta i el redirigeix.</string>
-    <string name="activity_lab_las_angeles_tourism_description">Utilitza l\'API d\'estil per ressaltar parcs, hotels i atraccions. També s\'afegeix una animació de batec als colors.</string>
+    <string name="activity_lab_los_angeles_tourism_description">Utilitza l\'API d\'estil per ressaltar parcs, hotels i atraccions. També s\'afegeix una animació de batec als colors.</string>
     <string name="activity_lab_indoor_map_description">Mostra un mapa d\'interiors d\'un edifici amb opcions per canviar entre els pisos.</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values-ca/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-ca/titles_strings.xml
@@ -58,7 +58,7 @@
     <string name="activity_lab_marker_following_route_title">Marcador seguint la ruta</string>
     <string name="activity_lab_space_station_location_title">Posició actual de l\'estació espacial</string>
     <string name="activity_lab_off_route_title">Detecció de fora ruta</string>
-    <string name="activity_lab_las_angeles_tourism_title">Los Angeles per a turistes</string>
+    <string name="activity_lab_los_angeles_tourism_title">Los Angeles per a turistes</string>
     <string name="activity_lab_indoor_map_title">Mapa d\'interior</string>
 
 

--- a/MapboxAndroidDemo/src/main/res/values-vi/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-vi/titles_strings.xml
@@ -55,7 +55,7 @@
     <string name="activity_lab_marker_following_route_title">Ghim theo dõi tuyến đường</string>
     <string name="activity_lab_picture_in_picture_title">Hình trong hình</string>
     <string name="activity_lab_off_route_title">Nhận ra vụ lạc đường</string>
-    <string name="activity_lab_las_angeles_tourism_title">Los Angeles dành cho khách du lịch</string>
+    <string name="activity_lab_los_angeles_tourism_title">Los Angeles dành cho khách du lịch</string>
     <string name="activity_lab_indoor_map_title">Bản đồ trong nhà</string>
 
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -65,7 +65,7 @@
     <string name="activity_lab_space_station_location_description">See the International Space Station location in real time.</string>
     <string name="activity_lab_picture_in_picture_description">Use the Android O release of picture-in-picture to maintain a map in a separate window</string>
     <string name="activity_lab_off_route_description">Detect when the car is off route and reroute them.</string>
-    <string name="activity_lab_las_angeles_tourism_description">Use the style API to highlight parks, hotels, and attractions. A pulsing animation is also added to the colors.</string>
+    <string name="activity_lab_los_angeles_tourism_description">Use the style API to highlight parks, hotels, and attractions. A pulsing animation is also added to the colors.</string>
     <string name="activity_lab_indoor_map_description">Display an indoor map of a building with toggles to switch between floor levels.</string>
     <string name="activity_lab_rv_on_map_description">Manipulate the map based on recyclerview interactions.</string>
     <string name="activity_lab_mapillary_description">Add Mapillary vector tiles to a map</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -64,7 +64,7 @@
     <string name="activity_lab_space_station_location_title">Space station current location</string>
     <string name="activity_lab_picture_in_picture_title">Picture in picture</string>
     <string name="activity_lab_off_route_title">Off route detection</string>
-    <string name="activity_lab_las_angeles_tourism_title">Los Angeles for tourists</string>
+    <string name="activity_lab_los_angeles_tourism_title">Los Angeles for tourists</string>
     <string name="activity_lab_indoor_map_title">Indoor Map</string>
     <string name="activity_labs_mapillary_title">Mapillary integration</string>
 

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -66,7 +66,7 @@
     <string name="activity_lab_space_station_location_url" translatable="false">http://i.imgur.com/PxuB1T8.png</string>
     <string name="activity_lab_picture_in_picture_url" translatable="false">http://i.imgur.com/kascJEy.png</string>
     <string name="activity_lab_off_route_url" translatable="false">http://i.imgur.com/lx1LdkA.png</string>
-    <string name="activity_lab_las_angeles_tourism_url" translatable="false">http://i.imgur.com/FUIFkIm.png</string>
+    <string name="activity_lab_los_angeles_tourism_url" translatable="false">http://i.imgur.com/FUIFkIm.png</string>
     <string name="activity_lab_indoor_map_url" translatable="false">http://i.imgur.com/ItqdTiG.png</string>
     <string name="activity_lab_rv_on_map_url" translatable="false">http://i.imgur.com/8mQQuMo.jpg</string>
     <string name="activity_lab_mapillary_url" translatable="false">http://i.imgur.com/w4SSif1.png</string>


### PR DESCRIPTION
Las Angeles was misspelled. Changed to `los`