### PR TITLE
Bumped MAS version to 2.2.5

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     compile 'com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:0.3.0'
 
     // Mapbox Android UI
-    compile 'com.mapbox.mapboxsdk:mapbox-android-ui:2.2.4'
+    compile 'com.mapbox.mapboxsdk:mapbox-android-ui:2.2.5'
 
     // Other dependencies
     compile 'com.google.firebase:firebase-crash:11.0.4'


### PR DESCRIPTION
Part of [the 2.2.5 release](https://github.com/mapbox/mapbox-java/issues/577)