### PR TITLE
bumped map sdk dependencies to 5.2.0-beta.1

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.8'
 
     // Mapbox dependencies
-    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.4@aar') {
+    compile('com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.0-beta.1@aar') {
         transitive = true
     }
 

--- a/MapboxAndroidWearDemo/build.gradle
+++ b/MapboxAndroidWearDemo/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile 'com.google.android.gms:play-services-wearable:11.0.4'
     compile 'com.google.android.gms:play-services-location:11.0.4'
     // Mapbox dependencies
-    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.1.4@aar') {
+    compile ('com.mapbox.mapboxsdk:mapbox-android-sdk:5.2.0-beta.1@aar') {
         transitive = true
     }
 


### PR DESCRIPTION
Part of [the 5.2.0-beta.1 release](https://github.com/mapbox/mapbox-gl-native/issues/10140#event-1281604883)

This pr bumps the dependency lines for the regular and wearable apps