### PR TITLE
Fixing manifest merger issue

### DIFF
--- a/MapboxAndroidWearDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidWearDemo/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        tools:node="replace"
         android:theme="@android:style/Theme.DeviceDefault">
 
         <meta-data


### PR DESCRIPTION
Was getting the following manifest merger error
```java
Error:Execution failed for task ':MapboxAndroidWearDemo:processDebugManifest'.
> Manifest merger failed : Attribute meta-data#android.support.VERSION@value value=(26.0.0) from [com.android.support:percent:26.0.0] AndroidManifest.xml:25:13-35
  	is also present at [com.android.support:design:25.4.0] AndroidManifest.xml:28:13-35 value=(25.4.0).
  	Suggestion: add 'tools:replace="android:value"' to <meta-data> element at AndroidManifest.xml:23:9-25:38 to override.
```
Spent lots of time searching for a solution and finally decided to add the `tools:node="replace"` line based on [official manifest merging documentation](https://developer.android.com/studio/build/manifest-merge.html)
