### PR TITLE
added map clear toast and functionality

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/mas/OptimizationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/mas/OptimizationActivity.java
@@ -61,8 +61,10 @@ public class OptimizationActivity extends AppCompatActivity {
     // This contains the MapView in XML and needs to be called after the access token is configured.
     setContentView(R.layout.activity_mas_optimization);
 
-    // Initialize list of Position objects and add the origin Position to the list
-    initializeListOfStops();
+    stops = new ArrayList<>();
+
+    // Add the origin Position to the list
+    addFirstStopToStopsList();
 
     // Setup the MapView
     mapView = (MapView) findViewById(R.id.mapView);
@@ -91,6 +93,15 @@ public class OptimizationActivity extends AppCompatActivity {
           }
         });
         Toast.makeText(OptimizationActivity.this, R.string.click_instructions, Toast.LENGTH_SHORT).show();
+
+        map.setOnMapLongClickListener(new MapboxMap.OnMapLongClickListener() {
+          @Override
+          public void onMapLongClick(@NonNull LatLng point) {
+            map.clear();
+            stops.clear();
+            addFirstStopToStopsList();
+          }
+        });
       }
     });
   }
@@ -113,9 +124,7 @@ public class OptimizationActivity extends AppCompatActivity {
     stops.add(Position.fromCoordinates(point.getLongitude(), point.getLatitude()));
   }
 
-  private void initializeListOfStops() {
-    // Set up stop list
-    stops = new ArrayList<>();
+  private void addFirstStopToStopsList() {
     // Set first stop
     origin = Position.fromCoordinates(30.335098600000038, 59.9342802);
     stops.add(origin);

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -192,7 +192,7 @@
     <!-- Optimization API activity -->
     <string name="origin">Origin</string>
     <string name="destination">Destination</string>
-    <string name="only_twelve_stops_allowed">Only 12 stops allowed on route</string>
+    <string name="only_twelve_stops_allowed">Only 12 stops allowed on route. Press on the map and hold to clear markers.</string>
     <string name="click_instructions">Tap on the map to select a maximum of 12 locations</string>
     <string name="successful_but_no_routes">No routes found for that location</string>
     <string name="no_success">No routes found, make sure you set the right user and access token</string>


### PR DESCRIPTION
Rather than forcing the user to exit the example once 12 locations have been selected, this PR instructs the user to long press the map to clear markers. That way, more can be added if they want to see another fully optimized route.
![ezgif com-resize 1](https://user-images.githubusercontent.com/4394910/31899683-28636fba-b7d1-11e7-92c2-fe6d5c2667d6.gif)
