### PR TITLE
Refactored to change from heatmap to hotspots

### DIFF
--- a/MapboxAndroidDemo/src/gpservices/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/gpservices/AndroidManifest.xml
@@ -287,8 +287,8 @@
         </activity>
 
         <activity
-            android:name=".examples.dds.CreateHeatmapPointsActivity"
-            android:label="@string/activity_dds_create_heatmap_points_title">
+            android:name=".examples.dds.CreateHotspotsActivity"
+            android:label="@string/activity_dds_create_hotspots_points_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity"/>

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -319,8 +319,8 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity"/>
         </activity>
         <activity
-            android:name=".examples.dds.CreateHeatmapPointsActivity"
-            android:label="@string/activity_dds_create_heatmap_points_title">
+            android:name=".examples.dds.CreateHotspotsActivity"
+            android:label="@string/activity_dds_create_hotspots_points_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity"/>

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -75,7 +75,7 @@ import com.mapbox.mapboxandroiddemo.examples.query.SelectBuildingActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.AddWmsSourceActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.AdjustLayerOpacityActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.ColorSwitcherActivity;
-import com.mapbox.mapboxandroiddemo.examples.dds.CreateHeatmapPointsActivity;
+import com.mapbox.mapboxandroiddemo.examples.dds.CreateHotspotsActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.DefaultStyleActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.GeoJsonClusteringActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.GeojsonLayerInStackActivity;
@@ -640,10 +640,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           R.string.activity_dds_style_line_identity_property_url, false
         ));
         exampleItemModel.add(new ExampleItemModel(
-          R.string.activity_dds_create_heatmap_points_title,
-          R.string.activity_dds_create_heatmap_points_description,
-          new Intent(MainActivity.this, CreateHeatmapPointsActivity.class),
-          R.string.activity_dds_create_heatmap_points_url
+          R.string.activity_dds_create_hotspots_points_title,
+          R.string.activity_dds_create_hotspots_points_description,
+          new Intent(MainActivity.this, CreateHotspotsActivity.class),
+          R.string.activity_dds_create_hotspots_points_url
         ));
         exampleItemModel.add(new ExampleItemModel(
           R.string.activity_dds_json_vector_mix_title,

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CreateHotspotsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CreateHotspotsActivity.java
@@ -26,9 +26,9 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
 
 /**
- * Use Mapbox GL clustering to visualize point data as a heatmap.
+ * Use Mapbox GL clustering to visualize point data as hotspots.
  */
-public class CreateHeatmapPointsActivity extends AppCompatActivity {
+public class CreateHotspotsActivity extends AppCompatActivity {
 
   private MapView mapView;
 
@@ -41,7 +41,7 @@ public class CreateHeatmapPointsActivity extends AppCompatActivity {
     Mapbox.getInstance(this, getString(R.string.access_token));
 
     // This contains the MapView in XML and needs to be called after the access token is configured.
-    setContentView(R.layout.activity_style_create_heatmap_points);
+    setContentView(R.layout.activity_style_create_hotspots_points);
 
     mapView = (MapView) findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
@@ -107,11 +107,11 @@ public class CreateHeatmapPointsActivity extends AppCompatActivity {
           new GeoJsonOptions()
             .withCluster(true)
             .withClusterMaxZoom(15) // Max zoom to cluster points on
-            .withClusterRadius(20) // Use small cluster radius for the heatmap look
+            .withClusterRadius(20) // Use small cluster radius for the hotspots look
         )
       );
     } catch (MalformedURLException malformedUrlException) {
-      Log.e("heatmapActivity", "Check the URL " + malformedUrlException.getMessage());
+      Log.e("CreateHotspotsActivity", "Check the URL " + malformedUrlException.getMessage());
     }
 
     // Use the earthquakes source to create four layers:

--- a/MapboxAndroidDemo/src/main/res/layout/activity_style_create_hotspots_points.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_style_create_hotspots_points.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".examples.dds.CreateHeatmapPointsActivity">
+    tools:context=".examples.dds.CreateHotspotsActivity">
 
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"

--- a/MapboxAndroidDemo/src/main/res/values-ca/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-ca/descriptions_strings.xml
@@ -15,7 +15,7 @@
     <string name="activity_styles_vector_source_description">Afegiu una font vectorial en un mapa i mostreu-la com una capa.</string>
     <string name="activity_styles_add_wms_source_description">Afegiu una capa WMS externa al mapa</string>
     <string name="activity_styles_zoom_dependent_fill_color_description">Feu que una propietat depengui del nivell de zoom del mapa, en aquest cas el color de reomplert de la capa aigua.</string>
-    <string name="activity_dds_create_heatmap_points_description">Feu servir l\'SDK Android de Mapbox per visualitzar dades puntuals com mapes de calor.</string>
+    <string name="activity_dds_create_hotspots_points_description">Feu servir l\'SDK Android de Mapbox per visualitzar dades puntuals com mapes de calor.</string>
     <string name="activity_styles_create_data_cluster_description">Feu servir GeoJSON per visualitzar dades puntuals com agregacions.</string>
     <string name="activity_styles_line_layer_description">Crear línia amb GeoJSON,  canvia\'n l\'estil emprant les propietats, i afegir la capa al mapa.</string>
     <string name="activity_styles_symbol_layer_description">Mostra marcadors al mapa afegint una capa de de símbols. Consulta el mapa i anima la mida de les icones quan s\'hi faci clic.</string>

--- a/MapboxAndroidDemo/src/main/res/values-ca/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-ca/titles_strings.xml
@@ -15,7 +15,7 @@
     <string name="activity_styles_vector_source_title">Afegeix una font de tessel·les vector</string>
     <string name="activity_styles_add_wms_source_title">Afegeix una font WMS</string>
     <string name="activity_styles_zoom_dependent_fill_color_title">El color en funció del nivell de zoom</string>
-    <string name="activity_dds_create_heatmap_points_title">Crea un mapa de calor a partir de punts</string>
+    <string name="activity_dds_create_hotspots_points_title">Crea un mapa de calor a partir de punts</string>
     <string name="activity_styles_data_clusters_title">Crea i dona estils a agrupacions de dades</string>
     <string name="activity_styles_line_layer_title">Crea una capa de línies</string>
     <string name="activity_styles_symbol_layer_title">Capa de símbols marcadors</string>

--- a/MapboxAndroidDemo/src/main/res/values-vi/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-vi/titles_strings.xml
@@ -17,7 +17,7 @@
     <string name="activity_styles_vector_source_title">Thêm nguồn mảnh vectơ</string>
     <string name="activity_styles_add_wms_source_title">Thêm nguồn WMS</string>
     <string name="activity_styles_zoom_dependent_fill_color_title">Màu sắc tùy mức thu phóng</string>
-    <string name="activity_dds_create_heatmap_points_title">Tạo bản đồ nhiệt từ các điểm</string>
+    <string name="activity_dds_create_hotspots_points_title">Tạo bản đồ nhiệt từ các điểm</string>
     <string name="activity_styles_data_clusters_title">Tạo và định kiểu các cụm dữ liệu</string>
     <string name="activity_styles_line_layer_title">Tạo lớp đường kẻ</string>
     <string name="activity_styles_symbol_layer_title">Lớp dấu ghim</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -18,7 +18,7 @@
     <string name="activity_styles_vector_source_description">Add a vector source to a map and display it as a layer.</string>
     <string name="activity_styles_add_wms_source_description">Adding an external Web Map Service layer to the map</string>
     <string name="activity_styles_zoom_dependent_fill_color_description">Make a property depend on the map zoom level, in this case, the water layers fill color.</string>
-    <string name="activity_dds_create_heatmap_points_description">Use the Mapbox Android SDK to visualize point data as a heatmap.</string>
+    <string name="activity_dds_create_hotspots_points_description">Use the Mapbox Android SDK to visualize point data as hotspots.</string>
     <string name="activity_styles_create_data_cluster_description">Use GeoJSON to visualize point data in clusters.</string>
     <string name="activity_styles_line_layer_description">Create a GeoJSON line source, style it using properties, and add the layer to the map.</string>
     <string name="activity_styles_symbol_layer_description">Display markers on the map by adding a symbol layer. Query the map and animate the icon size if clicked on.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -17,7 +17,7 @@
     <string name="activity_styles_vector_source_title">Add a vector tile source</string>
     <string name="activity_styles_add_wms_source_title">Add a WMS source</string>
     <string name="activity_styles_zoom_dependent_fill_color_title">Color dependent on zoom level</string>
-    <string name="activity_dds_create_heatmap_points_title">Create a heatmap from points</string>
+    <string name="activity_dds_create_hotspots_points_title">Create hotspots from points</string>
     <string name="activity_styles_data_clusters_title">Create and style data clusters</string>
     <string name="activity_styles_line_layer_title">Create a line layer</string>
     <string name="activity_styles_symbol_layer_title">Marker symbol layer</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -19,7 +19,7 @@
     <string name="activity_styles_adjust_layer_opacity_url" translatable="false">http://i.imgur.com/0Av8kWD.png</string>
     <string name="activity_styles_vector_source_url" translatable="false">http://i.imgur.com/N0altyP.png</string>
     <string name="activity_styles_add_wms_source_url" translatable="false">http://i.imgur.com/k14WdRG.png</string>
-    <string name="activity_dds_create_heatmap_points_url" translatable="false">http://i.imgur.com/pAejKLH.png</string>
+    <string name="activity_dds_create_hotspots_points_url" translatable="false">http://i.imgur.com/pAejKLH.png</string>
     <string name="activity_styles_create_cluster_data_points_url" translatable="false">http://i.imgur.com/fGeZhcD.png</string>
     <string name="activity_styles_line_layer_url" translatable="false">http://i.imgur.com/Iqxoing.png</string>
     <string name="activity_styles_symbol_layer_url" translatable="false">http://i.imgur.com/TQ4iA0L.png</string>


### PR DESCRIPTION
This pr renames the heatmap demo to call it a “hotspot map” instead of a “heatmap”, both for correctness and in preparation for actual heatmap support in the Mapbox Maps SDK: mapbox/mapbox-gl-native#10146.


Related to https://github.com/mapbox/android-docs/pull/241