### PR TITLE
Bumped MAS dependency to 2.2.9

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
     version = [
             // mapbox
             mapboxMapSdk       : '5.2.0-beta.4',
-            mapboxAndroidUI    :  '2.2.8',
+            mapboxAndroidUI    :  '2.2.9',
 
             mapboxPluginBuilding      : '0.1.0',
             mapboxPluginGeoJson       : '0.1.0',


### PR DESCRIPTION
Part of [the 2.2.9 MAS release](https://github.com/mapbox/mapbox-java/issues/637)