### PR TITLE
Remove usage of deprecated MarkerViewOptions() class

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/AnimatedMarkerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/AnimatedMarkerActivity.java
@@ -11,7 +11,7 @@ import android.widget.Toast;
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Marker;
-import com.mapbox.mapboxsdk.annotations.MarkerViewOptions;
+import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -41,8 +41,9 @@ public class AnimatedMarkerActivity extends AppCompatActivity {
       @Override
       public void onMapReady(MapboxMap mapboxMap) {
 
-        final Marker marker = mapboxMap.addMarker(new MarkerViewOptions()
+        final Marker marker = mapboxMap.addMarker(new MarkerOptions()
           .position(new LatLng(64.900932, -18.167040)));
+
 
         Toast.makeText(
           AnimatedMarkerActivity.this,

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/BoundingBoxCameraActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/BoundingBoxCameraActivity.java
@@ -7,7 +7,7 @@ import android.widget.Toast;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
-import com.mapbox.mapboxsdk.annotations.MarkerViewOptions;
+import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.LatLngBounds;
@@ -44,10 +44,10 @@ public class BoundingBoxCameraActivity extends AppCompatActivity {
         final LatLng locationTwo = new LatLng(25.837058, -106.646234);
 
         // Add markers to map
-        mapboxMap.addMarker(new MarkerViewOptions()
+        mapboxMap.addMarker(new MarkerOptions()
           .position(locationOne));
 
-        mapboxMap.addMarker(new MarkerViewOptions()
+        mapboxMap.addMarker(new MarkerOptions()
           .position(locationTwo));
 
         // Toast instructing user to tap on the map to start animation and set bounds

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/QueryFeatureActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/QueryFeatureActivity.java
@@ -9,7 +9,7 @@ import com.google.gson.JsonElement;
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Marker;
-import com.mapbox.mapboxsdk.annotations.MarkerViewOptions;
+import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -67,7 +67,7 @@ public class QueryFeatureActivity extends AppCompatActivity {
                   stringBuilder.append(System.getProperty("line.separator"));
                 }
 
-                featureMarker = mapboxMap.addMarker(new MarkerViewOptions()
+                featureMarker = mapboxMap.addMarker(new MarkerOptions()
                   .position(point)
                   .title(getString(R.string.query_feature_marker_title))
                   .snippet(stringBuilder.toString())
@@ -75,13 +75,13 @@ public class QueryFeatureActivity extends AppCompatActivity {
 
               } else {
                 property = getString(R.string.query_feature_marker_snippet);
-                featureMarker = mapboxMap.addMarker(new MarkerViewOptions()
+                featureMarker = mapboxMap.addMarker(new MarkerOptions()
                   .position(point)
                   .snippet(property)
                 );
               }
             } else {
-              featureMarker = mapboxMap.addMarker(new MarkerViewOptions()
+              featureMarker = mapboxMap.addMarker(new MarkerOptions()
                 .position(point)
                 .snippet(getString(R.string.query_feature_marker_snippet))
               );

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/LocationPickerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/LocationPickerActivity.java
@@ -20,7 +20,7 @@ import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.annotations.Icon;
 import com.mapbox.mapboxsdk.annotations.IconFactory;
 import com.mapbox.mapboxsdk.annotations.Marker;
-import com.mapbox.mapboxsdk.annotations.MarkerViewOptions;
+import com.mapbox.mapboxsdk.annotations.MarkerOptions;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.location.LocationSource;
@@ -136,7 +136,7 @@ public class LocationPickerActivity extends AppCompatActivity implements Locatio
 
             // Placing the marker on the mapboxMap as soon as possible causes the illusion
             // that the hovering marker and dropped marker are the same.
-            droppedMarker = mapboxMap.addMarker(new MarkerViewOptions().position(latLng).icon(icon));
+            droppedMarker = mapboxMap.addMarker(new MarkerOptions().position(latLng).icon(icon));
 
             // Finally we get the geocoding information
             reverseGeocode(latLng);


### PR DESCRIPTION
Resolves #554 by switching out the deprecated `MarkerViewOptions()` class for `MarkerOptions()`. Yes, sources and symbol layer should probably be used _everywhere_ , but "ain't nobody got time for"...switching _all_ demo app examples to that (yet). 

The examples in the screenshot below have markers with `.anchor`, which is no longer in the `MarkerOptions()` class, so I'm thinking that I will **have** to use sources/symbolLayer for these examples (let me know if not @tobrun 🙏   Also , if you'd prefer that I handle all of this deprecation differently, please let me know 👍 )


![screen shot 2017-12-15 at 6 05 01 pm](https://user-images.githubusercontent.com/4394910/34066380-8aad94e6-e1c2-11e7-9cc0-ab091b97f806.png)


cc @lilykaiser #projectpp