### PR TITLE
Temporarily disable proguard to resolve dependency issues

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -51,8 +51,8 @@ android {
         }
 
         release {
-            minifyEnabled true
-            shrinkResources true
+            minifyEnabled false
+            shrinkResources false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }

--- a/MapboxAndroidWearDemo/build.gradle
+++ b/MapboxAndroidWearDemo/build.gradle
@@ -25,8 +25,8 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled true
-            shrinkResources true
+            minifyEnabled false
+            shrinkResources false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }


### PR DESCRIPTION
Unblocking `5.3.0` release, being blocked by https://github.com/mapbox/mapbox-android-demo/issues/583.