### PR TITLE
Fix proguard issues

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -51,8 +51,8 @@ android {
         }
 
         release {
-            minifyEnabled false
-            shrinkResources false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
@@ -98,9 +98,6 @@ dependencies {
 
     // Mapbox Android UI
     implementation dependenciesList.mapboxAndroidUI
-
-    // lost
-    implementation dependenciesList.lost
 
     // Firebase
     implementation dependenciesList.firebaseCrash

--- a/MapboxAndroidWearDemo/build.gradle
+++ b/MapboxAndroidWearDemo/build.gradle
@@ -25,8 +25,8 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
-            shrinkResources false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
@@ -47,9 +47,6 @@ dependencies {
 
     // Mapbox dependencies
     api (dependenciesList.mapboxMapSdk)
-
-    // lost
-    implementation dependenciesList.lost
 
     // Firebase
     implementation dependenciesList.firebaseCrash

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,11 +18,8 @@ ext {
             mapboxPluginBuilding      : '0.1.0',
             mapboxPluginGeoJson       : '0.1.0',
             mapboxPluginLocationLayer : '0.2.0',
-            mapboxPluginTraffic       : '0.3.0',
+            mapboxPluginTraffic       : '0.4.0-SNAPSHOT',
             mapboxPluginMarkerCluster : '0.1.0',
-
-            //  lost
-            lost                   : '3.0.4',
 
             // Support
             supportLib         : '26.1.0',
@@ -63,9 +60,6 @@ ext {
             mapboxPluginTraffic       : "com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:${version.mapboxPluginTraffic}",
             mapboxPluginGeoJson       : "com.mapbox.mapboxsdk:mapbox-android-plugin-geojson:${version.mapboxPluginGeoJson}",
             mapboxPluginMarkerCluster : "com.mapbox.mapboxsdk:mapbox-android-plugin-cluster-utils:${version.mapboxPluginMarkerCluster}",
-
-            // lost
-            lost                   : "com.mapzen.android:lost:${version.lost}",
 
             // support
             supportV4              : "com.android.support:support-v4:${version.supportLib}",


### PR DESCRIPTION
- Remove unnecessary Lost dependency (implicitly added when including [`mapbox-android-ui` dependency](https://github.com/mapbox/mapbox-android-demo/blob/master/MapboxAndroidDemo/build.gradle#L100)) 👉  revert #581
  - Lost dependency is still needed because `LostLocationEngine` is used in
    - [`LocationPickerActivity`](https://github.com/mapbox/mapbox-android-demo/blob/master/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/LocationPickerActivity.java#L310)
    - [`LocationPluginActivity`](https://github.com/mapbox/mapbox-android-demo/blob/master/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java#L77)

- Fixes #583 
  - Bumping traffic plugin version to `0.4.0-SNAPSHOT`

- We should release a new version of the traffic plugin, update the [traffic demo app dependency](https://github.com/mapbox/mapbox-android-demo/blob/master/gradle/dependencies.gradle#L21) and publish a new version of the demo app

👀 @LukasPaczos @langsmith 
