### PR TITLE
Snapshot notification fix

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
@@ -105,28 +105,11 @@ public class SnapshotNotificationActivity extends AppCompatActivity {
    * @param bitmap to set as large icon
    */
   private void createNotification(Bitmap bitmap) {
-    // Create a PendingIntent so that when the notification is pressed, the
-    // SnapshotNotificationActivity is reopened
-
-   /* // Create the notification
-    NotificationCompat.Builder builder =
-        new NotificationCompat.Builder(SnapshotNotificationActivity.this, "123")
-            .setSmallIcon(R.drawable.ic_circle)
-            .setContentTitle(getString(R.string.activity_image_generator_snapshot_notification_title))
-            .setContentText(getString(R.string.activity_image_generator_snapshot_notification_description))
-            .setContentIntent(pendingIntent)
-            .setLargeIcon(bitmap);
-
-    // Trigger the notification
-    ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE)).notify(1, builder.build());
-*/
 
     final int NOTIFY_ID = 1002;
-
     String name = "channel_name";
     String id = "channel_id";
     String description = "channel_description";
-
     Intent intent;
     NotificationCompat.Builder builder;
     PendingIntent pendingIntent;
@@ -136,47 +119,30 @@ public class SnapshotNotificationActivity extends AppCompatActivity {
         (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     }
 
+    builder = new NotificationCompat.Builder(this, id);
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      int importance = NotificationManager.IMPORTANCE_HIGH;
       NotificationChannel notificationChannel = notificationManager.getNotificationChannel(id);
       if (notificationChannel == null) {
-        notificationChannel = new NotificationChannel(id, name, importance);
+        notificationChannel = new NotificationChannel(id, name, NotificationManager.IMPORTANCE_HIGH);
         notificationChannel.setDescription(description);
         notificationManager.createNotificationChannel(notificationChannel);
       }
-      builder = new NotificationCompat.Builder(this, id);
-
-      intent = new Intent(this, MainActivity.class);
-      intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-      pendingIntent = getActivity(this, 0, intent, 0);
-
-      builder.setContentTitle("content")
-        .setSmallIcon(R.drawable.ic_circle)
-        .setContentTitle(getString(R.string.activity_image_generator_snapshot_notification_title))
-        .setContentText(getString(R.string.activity_image_generator_snapshot_notification_description))
-        .setContentIntent(pendingIntent)
-        .setLargeIcon(bitmap);
-    } else {
-
-      builder = new NotificationCompat.Builder(this);
-
-      intent = new Intent(this, MainActivity.class);
-      intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-      pendingIntent = getActivity(this, 0, intent, 0);
-
-
-
-      builder.setContentTitle("content")                           // required
-        .setSmallIcon(R.drawable.ic_circle)
-        .setContentTitle(getString(R.string.activity_image_generator_snapshot_notification_title))
-        .setContentText(getString(R.string.activity_image_generator_snapshot_notification_description))
-        .setContentIntent(pendingIntent)
-        .setLargeIcon(bitmap);
     }
+
+    intent = new Intent(this, MainActivity.class);
+    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+    pendingIntent = getActivity(this, 0, intent, 0);
+
+    builder.setContentTitle("content")
+      .setSmallIcon(R.drawable.ic_circle)
+      .setContentTitle(getString(R.string.activity_image_generator_snapshot_notification_title))
+      .setContentText(getString(R.string.activity_image_generator_snapshot_notification_description))
+      .setContentIntent(pendingIntent)
+      .setLargeIcon(bitmap);
 
     Notification notification = builder.build();
     notificationManager.notify(NOTIFY_ID, notification);
-
   }
 
   @Override

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
@@ -105,42 +105,34 @@ public class SnapshotNotificationActivity extends AppCompatActivity {
    * @param bitmap to set as large icon
    */
   private void createNotification(Bitmap bitmap) {
-
     final int NOTIFY_ID = 1002;
-    String name = "channel_name";
     String id = "channel_id";
-    String description = "channel_description";
     Intent intent;
-    NotificationCompat.Builder builder;
-    PendingIntent pendingIntent;
 
+    PendingIntent pendingIntent;
     if (notificationManager == null) {
       notificationManager =
         (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
     }
-
-    builder = new NotificationCompat.Builder(this, id);
-
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       NotificationChannel notificationChannel = notificationManager.getNotificationChannel(id);
       if (notificationChannel == null) {
-        notificationChannel = new NotificationChannel(id, name, NotificationManager.IMPORTANCE_HIGH);
-        notificationChannel.setDescription(description);
+        notificationChannel = new NotificationChannel(id, "channel_name", NotificationManager.IMPORTANCE_HIGH);
+        notificationChannel.setDescription("channel_description");
         notificationManager.createNotificationChannel(notificationChannel);
       }
     }
-
     intent = new Intent(this, MainActivity.class);
     intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
     pendingIntent = getActivity(this, 0, intent, 0);
 
-    builder.setContentTitle("content")
+    NotificationCompat.Builder builder = new NotificationCompat.Builder(this, id)
+      .setContentTitle("content")
       .setSmallIcon(R.drawable.ic_circle)
       .setContentTitle(getString(R.string.activity_image_generator_snapshot_notification_title))
       .setContentText(getString(R.string.activity_image_generator_snapshot_notification_description))
       .setContentIntent(pendingIntent)
       .setLargeIcon(bitmap);
-
     Notification notification = builder.build();
     notificationManager.notify(NOTIFY_ID, notification);
   }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
@@ -105,11 +105,8 @@ public class SnapshotNotificationActivity extends AppCompatActivity {
    * @param bitmap to set as large icon
    */
   private void createNotification(Bitmap bitmap) {
-    final int NOTIFY_ID = 1002;
+    final int notifyId = 1002;
     String id = "channel_id";
-    Intent intent;
-
-    PendingIntent pendingIntent;
     if (notificationManager == null) {
       notificationManager =
         (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
@@ -122,19 +119,17 @@ public class SnapshotNotificationActivity extends AppCompatActivity {
         notificationManager.createNotificationChannel(notificationChannel);
       }
     }
-    intent = new Intent(this, MainActivity.class);
-    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
-    pendingIntent = getActivity(this, 0, intent, 0);
-
+    Intent intent = new Intent(this, MainActivity.class)
+      .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
     NotificationCompat.Builder builder = new NotificationCompat.Builder(this, id)
       .setContentTitle("content")
       .setSmallIcon(R.drawable.ic_circle)
       .setContentTitle(getString(R.string.activity_image_generator_snapshot_notification_title))
       .setContentText(getString(R.string.activity_image_generator_snapshot_notification_description))
-      .setContentIntent(pendingIntent)
+      .setContentIntent(getActivity(this, 0, intent, 0))
       .setLargeIcon(bitmap);
     Notification notification = builder.build();
-    notificationManager.notify(NOTIFY_ID, notification);
+    notificationManager.notify(notifyId, notification);
   }
 
   @Override

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
@@ -3,7 +3,6 @@ package com.mapbox.mapboxandroiddemo.examples.snapshot;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;

--- a/MapboxAndroidWearDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/MapFragmentActivity.java
+++ b/MapboxAndroidWearDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/MapFragmentActivity.java
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxandroiddemo.examples;
 
 import android.app.FragmentTransaction;
-import android.location.Location;
 import android.os.Bundle;
 import android.support.wearable.activity.WearableActivity;
 
@@ -10,13 +9,10 @@ import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.constants.Style;
 import com.mapbox.mapboxsdk.geometry.LatLng;
-import com.mapbox.mapboxsdk.location.LocationSource;
 import com.mapbox.mapboxsdk.maps.MapFragment;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.MapboxMapOptions;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.services.android.telemetry.location.LocationEngine;
-import com.mapbox.services.android.telemetry.location.LocationEngineListener;
 
 /**
  * Include a map fragment within your app using Android support library.


### PR DESCRIPTION
The snapshot notification example was no longer working on Oreo devices.

This pr adds notification channel code to account for new Oreo-level security changes around notifications. 