### PR TITLE
Places plugin geometry –> point casting to replace coordinate extraction

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlacesPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlacesPluginActivity.java
@@ -147,26 +147,6 @@ public class PlacesPluginActivity extends AppCompatActivity implements OnMapRead
     }
   }
 
-  // Extracts latitude from single GeoJSON Feature
-  private double getFeatureLat(CarmenFeature singleFeature) {
-    String[] coordinateValues = singleFeature.geometry()
-        .coordinates().toString().replace("Position [", "")
-        .replace(", altitude=NaN]", "").replace("longitude=", "")
-        .replace("]", "")
-        .split(", ");
-    return Double.valueOf(coordinateValues[1].replace("latitude=", ""));
-  }
-
-  // Extracts longitude from single GeoJSON Feature
-  private double getFeatureLong(CarmenFeature singleFeature) {
-    String[] coordinateValues = singleFeature.geometry()
-        .coordinates().toString().replace("Position [", "")
-        .replace(", altitude=NaN]", "").replace("longitude=", "")
-        .replace("[", "")
-        .split(", ");
-    return Double.valueOf(coordinateValues[0]);
-  }
-
   // Add the mapView lifecycle to the activity's lifecycle methods
   @Override
   public void onResume() {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlacesPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlacesPluginActivity.java
@@ -63,7 +63,7 @@ public class PlacesPluginActivity extends AppCompatActivity implements OnMapRead
 
     // Add the symbol layer icon to map for future use
     Bitmap icon = BitmapFactory.decodeResource(
-      PlacesPluginActivity.this.getResources(), R.drawable.blue_marker_view);
+        PlacesPluginActivity.this.getResources(), R.drawable.blue_marker_view);
     mapboxMap.addImage(symbolIconId, icon);
 
     // Create an empty GeoJSON source using the empty feature collection
@@ -79,14 +79,14 @@ public class PlacesPluginActivity extends AppCompatActivity implements OnMapRead
       @Override
       public void onClick(View view) {
         Intent intent = new PlaceAutocomplete.IntentBuilder()
-          .accessToken(Mapbox.getAccessToken())
-          .placeOptions(PlaceOptions.builder()
-            .backgroundColor(Color.parseColor("#EEEEEE"))
-            .limit(10)
-            .addInjectedFeature(home)
-            .addInjectedFeature(work)
-            .build(PlaceOptions.MODE_CARDS))
-          .build(PlacesPluginActivity.this);
+            .accessToken(Mapbox.getAccessToken())
+            .placeOptions(PlaceOptions.builder()
+                .backgroundColor(Color.parseColor("#EEEEEE"))
+                .limit(10)
+                .addInjectedFeature(home)
+                .addInjectedFeature(work)
+                .build(PlaceOptions.MODE_CARDS))
+            .build(PlacesPluginActivity.this);
         startActivityForResult(intent, REQUEST_CODE_AUTOCOMPLETE);
       }
     });
@@ -94,18 +94,18 @@ public class PlacesPluginActivity extends AppCompatActivity implements OnMapRead
 
   private void addUserLocations() {
     home = CarmenFeature.builder().text("Mapbox SF Office")
-      .geometry(Point.fromLngLat(-122.399854, 37.7884400))
-      .placeName("85 2nd St, San Francisco, CA")
-      .id("mapbox-sf")
-      .properties(new JsonObject())
-      .build();
+        .geometry(Point.fromLngLat(-122.399854, 37.7884400))
+        .placeName("85 2nd St, San Francisco, CA")
+        .id("mapbox-sf")
+        .properties(new JsonObject())
+        .build();
 
     work = CarmenFeature.builder().text("Mapbox DC Office")
-      .placeName("740 15th Street NW, Washington DC")
-      .geometry(Point.fromLngLat(-77.0338348, 38.899750))
-      .id("mapbox-dc")
-      .properties(new JsonObject())
-      .build();
+        .placeName("740 15th Street NW, Washington DC")
+        .geometry(Point.fromLngLat(-77.0338348, 38.899750))
+        .id("mapbox-dc")
+        .properties(new JsonObject())
+        .build();
   }
 
   private void setUpSource() {
@@ -129,7 +129,7 @@ public class PlacesPluginActivity extends AppCompatActivity implements OnMapRead
 
       // Create a new FeatureCollection and add a new Feature to it using selectedCarmenFeature above
       FeatureCollection featureCollection = FeatureCollection.fromFeatures(
-        new Feature[] {Feature.fromJson(selectedCarmenFeature.toJson())});
+          new Feature[]{Feature.fromJson(selectedCarmenFeature.toJson())});
 
       // Retrieve and update the source designated for showing a selected location's symbol layer icon
       GeoJsonSource source = mapboxMap.getSourceAs(geojsonSourceLayerId);
@@ -139,30 +139,31 @@ public class PlacesPluginActivity extends AppCompatActivity implements OnMapRead
 
       // Move map camera to the selected location
       CameraPosition newCameraPosition = new CameraPosition.Builder()
-        .target(new LatLng(getFeatureLat(selectedCarmenFeature), getFeatureLong(selectedCarmenFeature)))
-        .zoom(14)
-        .build();
-      mapboxMap.animateCamera(CameraUpdateFactory.newCameraPosition(newCameraPosition),4000);
+          .target(new LatLng(((Point) selectedCarmenFeature.geometry()).latitude(),
+              ((Point) selectedCarmenFeature.geometry()).longitude()))
+          .zoom(14)
+          .build();
+      mapboxMap.animateCamera(CameraUpdateFactory.newCameraPosition(newCameraPosition), 4000);
     }
   }
 
   // Extracts latitude from single GeoJSON Feature
   private double getFeatureLat(CarmenFeature singleFeature) {
     String[] coordinateValues = singleFeature.geometry()
-      .coordinates().toString().replace("Position [", "")
-      .replace(", altitude=NaN]", "").replace("longitude=", "")
-      .replace("]", "")
-      .split(", ");
+        .coordinates().toString().replace("Position [", "")
+        .replace(", altitude=NaN]", "").replace("longitude=", "")
+        .replace("]", "")
+        .split(", ");
     return Double.valueOf(coordinateValues[1].replace("latitude=", ""));
   }
 
   // Extracts longitude from single GeoJSON Feature
   private double getFeatureLong(CarmenFeature singleFeature) {
     String[] coordinateValues = singleFeature.geometry()
-      .coordinates().toString().replace("Position [", "")
-      .replace(", altitude=NaN]", "").replace("longitude=", "")
-      .replace("[", "")
-      .split(", ");
+        .coordinates().toString().replace("Position [", "")
+        .replace(", altitude=NaN]", "").replace("longitude=", "")
+        .replace("[", "")
+        .split(", ");
     return Double.valueOf(coordinateValues[0]);
   }
 


### PR DESCRIPTION
This pr fixes the places plugin activity by safely casting the CarmenFeature geometry to a Point instead of having methods to extract the coordinates.