### PR TITLE
String naming changes to Mapbox Maps SDK

### DIFF
--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -4,12 +4,12 @@
     <!-- ****** These strings are of individual example descriptions which appear in
     each example's recyclerview card ****** -->
 
-    <string name="activity_basic_simple_mapview_description">Show a map in your app using the Mapbox Android SDK.</string>
+    <string name="activity_basic_simple_mapview_description">Show a map in your app using the Mapbox Maps SDK.</string>
     <string name="activity_basic_support_map_frag_description">Include a map fragment within your app using Android support library.</string>
     <string name="activity_basic_mapbox_options_description">Add a mapview in a dynamically created layout.</string>
     <string name="activity_styles_mapbox_studio_description">Use a custom Mapbox-hosted style.</string>
     <string name="activity_style_raster_description">Use legacy raster tiles in your app.</string>
-    <string name="activity_styles_default_description">Use a variety of professionally designed styles with the Mapbox Android SDK.</string>
+    <string name="activity_styles_default_description">Use a variety of professionally designed styles with the Mapbox Maps SDK.</string>
     <string name="activity_styles_show_hide_layer_description">Create a custom layer switcher to display different datasets.</string>
     <string name="activity_styles_language_switch_description">Switch the maps language dynamically.</string>
     <string name="activity_styles_color_switcher_description">"Using layer set to change a layer's fill color."</string>
@@ -18,7 +18,7 @@
     <string name="activity_styles_vector_source_description">Add a vector source to a map and display it as a layer.</string>
     <string name="activity_styles_add_wms_source_description">Adding an external Web Map Service layer to the map.</string>
     <string name="activity_styles_zoom_dependent_fill_color_description">Make a property depend on the map zoom level, in this case, the water layers fill color.</string>
-    <string name="activity_dds_create_hotspots_points_description">Use the Mapbox Android SDK to visualize point data as hotspots.</string>
+    <string name="activity_dds_create_hotspots_points_description">Use the Mapbox Maps SDK to visualize point data as hotspots.</string>
     <string name="activity_styles_create_data_cluster_description">Use GeoJSON to visualize point data in clusters.</string>
     <string name="activity_styles_line_layer_description">Create a GeoJSON line source, style it using properties, and add the layer to the map.</string>
     <string name="activity_styles_basic_symbol_layer_description">Display markers on the map by adding a symbol layer. Query the map and animate the icon size if clicked on.</string>
@@ -36,17 +36,17 @@
     <string name="activity_dds_time_lapse_rainfall_points_description">Use data-driven styling to visualize point data with a time lapse effect; rainfall in China in this example.</string>
     <string name="activity_dds_multiple_geometries_description">Draw multiple geometries from a single GeoJSON file.</string>
     <string name="activity_annotation_marker_description">Create a default marker with an InfoWindow.</string>
-    <string name="activity_annotation_custom_marker_description">Create a marker with a custom icon using the Mapbox Android SDK.</string>
-    <string name="activity_annotation_geojson_line_description">Draw a polyline by parsing a GeoJSON file with the Mapbox Android SDK.</string>
-    <string name="activity_annotation_polygon_description">Draw a vector polygon on a map with the Mapbox Android SDK.</string>
-    <string name="activity_annotation_polygon_holes_description">Draw a vector polygon with holes on a map using the Mapbox Android SDK.</string>
+    <string name="activity_annotation_custom_marker_description">Create a marker with a custom icon using the Mapbox Maps SDK.</string>
+    <string name="activity_annotation_geojson_line_description">Draw a polyline by parsing a GeoJSON file with the Mapbox Maps SDK.</string>
+    <string name="activity_annotation_polygon_description">Draw a vector polygon on a map with the Mapbox Maps SDK.</string>
+    <string name="activity_annotation_polygon_holes_description">Draw a vector polygon with holes on a map using the Mapbox Maps SDK.</string>
     <string name="activity_annotation_marker_view_description">Attach a view to a given position on the map.</string>
     <string name="activity_annotation_custom_info_window_description">Use an info window adapter to customize the info window.</string>
     <string name="activity_annotation_animated_marker_description">Animate the marker to a new position on the map.</string>
     <string name="activity_camera_animate_description">"Animate the map's camera position, tilt, bearing, and zoom."</string>
     <string name="activity_camera_bounding_box_description">Position the camera so that all the given markers are in view.</string>
     <string name="activity_camera_restrict_description">Prevent a map from being panned to a different place.</string>
-    <string name="activity_offline_simple_description">Download and view an offline map using the Mapbox Android SDK.</string>
+    <string name="activity_offline_simple_description">Download and view an offline map using the Mapbox Maps SDK.</string>
     <string name="activity_offline_manager_description">Download, view, navigate to, and delete an offline region.</string>
     <string name="activity_description">Download, view, navigate to, and delete an offline region.</string>
     <string name="activity_query_feature_description">Click the map to add a marker at the location and display the maps property information for that feature.</string>


### PR DESCRIPTION
This pr changes certain strings to say `Mapbox Maps SDK` instead of `Mapbox Android SDK`