### PR TITLE
Maps SDK 5.5.1 bump

### DIFF
--- a/MapboxAndroidDemo/src/gpservices/play/en-US/whatsnew
+++ b/MapboxAndroidDemo/src/gpservices/play/en-US/whatsnew
@@ -1,1 +1,5 @@
-This update is in line with the 5.5.0 release of the Mapbox Maps SDK for Android.
+This update is in line with the 5.5.1 release of the Mapbox Maps SDK for Android. Changes include:
+
+	• Location layer plugin update
+	• Several small hot fixes
+	• Mapbox Java SDK upgrade

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     version = [
             // Mapbox
-            mapboxMapSdk             : '5.5.0',
+            mapboxMapSdk             : '5.5.1',
             mapboxTurf               : '3.0.0-beta.4',
             mapboGeoJson             : '3.0.0-beta.4',
             mapboxPluginBuilding     : '0.1.0',


### PR DESCRIPTION
Part of the Mapbox Maps SDK for Android 5.5.1 release: mapbox/mapbox-gl-native#11525 (comment)

