### PR TITLE
Adjusted mapbox java to stable 3.0.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,8 +10,8 @@ ext {
     version = [
             // Mapbox
             mapboxMapSdk             : '5.5.1',
-            mapboxTurf               : '3.0.0-beta.4',
-            mapboGeoJson             : '3.0.0-beta.4',
+            mapboxTurf               : '3.0.0',
+            mapboGeoJson             : '3.0.0',
             mapboxPluginBuilding     : '0.1.0',
             mapboxPluginGeoJson      : '0.1.0',
             mapboxPluginLocationLayer: '0.4.0',


### PR DESCRIPTION
Part of the 3.0.0 Mapbox Java SDK release: https://github.com/mapbox/mapbox-java/issues/774
