### PR TITLE
Maps SDK 6.0.0-beta.7 release

### DIFF
--- a/MapboxAndroidDemo/src/gpservices/play/en-US/whatsnew
+++ b/MapboxAndroidDemo/src/gpservices/play/en-US/whatsnew
@@ -1,5 +1,4 @@
-This update is in line with the 5.5.1 release of the Mapbox Maps SDK for Android. Changes include:
+This update is in line with the 6.0.0-beta.7 release of the Mapbox Maps SDK for Android. Changes include:
 
-	• Location layer plugin update
-	• Several small hot fixes
-	• Mapbox Java SDK upgrade
+	• Updates to data-driven styling examples to account for expressions
+	• Mapbox Java SDK updates

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     version = [
             // Mapbox
-            mapboxMapSdk             : '6.0.0-beta.6',
+            mapboxMapSdk             : '6.0.0-beta.7',
             mapboxTurf               : '3.0.1',
             mapboGeoJson             : '3.0.1',
             mapboxPluginBuilding     : '0.2.0-SNAPSHOT',


### PR DESCRIPTION
Part of the 6.0.0-beta.7 release of the Mapbox Maps SDK for Android: https://github.com/mapbox/mapbox-gl-native/issues/11662

This pr bumps the Maps SDK dependency and updates the `whatsnew` file