### PR TITLE
Maps SDK bump to 6.0.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     version = [
             // Mapbox
-            mapboxMapSdk             : '6.0.0-beta.7',
+            mapboxMapSdk             : '6.0.2',
             mapboxTurf               : '3.0.1',
             mapboGeoJson             : '3.0.1',
             mapboxPluginBuilding     : '0.2.0-SNAPSHOT',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
 
     version = [
             // Mapbox
-            mapboxMapSdk             : '6.0.2',
+            mapboxMapSdk             : '6.0.1',
             mapboxTurf               : '3.0.1',
             mapboGeoJson             : '3.0.1',
             mapboxPluginBuilding     : '0.2.0-SNAPSHOT',


### PR DESCRIPTION
Part of the Mapbox Maps SDK for Android 6.0.1 release: https://github.com/mapbox/mapbox-gl-native/issues/11712