### PR TITLE
re-added traffic plugin

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -115,6 +115,7 @@ dependencies {
     implementation dependenciesList.mapboxPluginMarkerCluster
     implementation dependenciesList.mapboxPluginPlaces
     implementation dependenciesList.mapboxPluginLocalization
+    implementation dependenciesList.mapboxPluginTraffic
 
     // Firebase
     implementation dependenciesList.firebaseCrash

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -453,6 +453,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.plugins.TrafficPluginActivity"
+            android:label="@string/activity_plugins_traffic_plugin_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.extrusions.PopulationDensityExtrusionActivity"
             android:label="@string/activity_extrusions_population_density_extrusions_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -68,6 +68,7 @@ import com.mapbox.mapboxandroiddemo.examples.plugins.LocalizationPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.MarkerClustersPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.PlacesPluginActivity;
+import com.mapbox.mapboxandroiddemo.examples.plugins.TrafficPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.ClickOnLayerActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.FeatureCountActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.QueryFeatureActivity;
@@ -393,6 +394,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         break;
 
       case R.id.nav_plugins:
+
+        exampleItemModels.add(new ExampleItemModel(
+            R.string.activity_plugins_traffic_plugin_title,
+            R.string.activity_plugins_traffic_plugin_description,
+            new Intent(MainActivity.this, TrafficPluginActivity.class),
+            R.string.activity_plugins_traffic_plugin_url, false, BuildConfig.MIN_SDK_VERSION));
+
         exampleItemModels.add(new ExampleItemModel(
           R.string.activity_plugins_building_plugin_title,
           R.string.activity_plugins_building_plugin_description,

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java
@@ -1,0 +1,97 @@
+package com.mapbox.mapboxandroiddemo.examples.plugins;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.plugins.traffic.TrafficPlugin;
+
+/**
+ * Toggle the Mapbox Traffic plugin to display real-time traffic data on top
+ * of your map (not all regions supported at the moment).
+ */
+public class TrafficPluginActivity extends AppCompatActivity {
+
+  private MapView mapView;
+  private MapboxMap map;
+  private TrafficPlugin trafficPlugin;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_traffic_plugin);
+
+    mapView = (MapView) findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(MapboxMap mapboxMap) {
+        map = mapboxMap;
+        trafficPlugin = new TrafficPlugin(mapView, mapboxMap);
+        TrafficPluginActivity.this.trafficPlugin.setVisibility(true); // Enable the traffic view by default
+      }
+    });
+
+    findViewById(R.id.traffic_toggle_fab).setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View view) {
+        if (map != null) {
+          trafficPlugin.setVisibility(!trafficPlugin.isVisible());
+        }
+      }
+    });
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,6 +18,7 @@ ext {
             mapboxPluginMarkerCluster: '0.2.0',
             mapboxPluginPlaces       : '0.3.0',
             mapboxPluginLocalization : '0.2.0',
+            mapboxPluginTraffic      : '0.5.0',
 
             // Support
             supportLib               : '26.1.0',
@@ -60,6 +61,7 @@ ext {
             mapboxPluginMarkerCluster: "com.mapbox.mapboxsdk:mapbox-android-plugin-cluster-utils:${version.mapboxPluginMarkerCluster}",
             mapboxPluginPlaces       : "com.mapbox.mapboxsdk:mapbox-android-plugin-places:${version.mapboxPluginPlaces}",
             mapboxPluginLocalization : "com.mapbox.mapboxsdk:mapbox-android-plugin-localization:${version.mapboxPluginLocalization}",
+            mapboxPluginTraffic      : "com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:${version.mapboxPluginTraffic}",
 
             // Support
             supportV4                : "com.android.support:support-v4:${version.supportLib}",


### PR DESCRIPTION
This pr resolves #672 and re-adds the traffic plugin after it was removed in preparation for the 6.0.0 release of the Maps SDK. The plugin's now working again and the 0.5.0 version is what this pr adds. The example's layout file and strings were left in the project, which is why they're not part of this pr.