### PR TITLE
Fixed heatmap example card URL

### DIFF
--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -32,7 +32,7 @@
     <string name="activity_extrusions_indoor_3d_url" translatable="false">http://i.imgur.com/1at7cMf.png</string>
     <string name="activity_extrusions_rotate_extrusions_url" translatable="false">http://i.imgur.com/OzcCsB2.png</string>
     <string name="activity_dds_style_circle_categorically_url" translatable="false">http://i.imgur.com/C3mtfgF.png</string>
-    <string name="activity_dds_heatmap_url" translatable="false">http://i.imgur.com/C3mtfgF.png</string>
+    <string name="activity_dds_heatmap_url" translatable="false">https://i.imgur.com/VektJUJ.png</string>
     <string name="activity_dds_choropleth_zoom_change_url" translatable="false">http://i.imgur.com/sPNpLEP.png</string>
     <string name="activity_dds_style_line_identity_property_url" translatable="false">http://i.imgur.com/wgpKvZM.png</string>
     <string name="activity_dds_json_vector_mix_url">http://i.imgur.com/1IXkw80.png</string>


### PR DESCRIPTION
Heatmap example had the same URL as a different example.


![device-2018-04-23-171617](https://user-images.githubusercontent.com/4394910/39159407-37e8cc90-471a-11e8-9cf8-0bf6fd593b79.png)
