### PR TITLE
Bumped android plugin for gradle to 3.1.0

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/PopulationDensityExtrusionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/PopulationDensityExtrusionActivity.java
@@ -48,6 +48,8 @@ public class PopulationDensityExtrusionActivity extends AppCompatActivity implem
     // Mapbox access token is configured here. This needs to be called either in your application
     // object or in the same activity which contains the mapview.
     Mapbox.getInstance(this, getString(R.string.access_token));
+    Log.d("PopulationDensityExtrusion", "access_token = "
+      + getString(R.string.access_token));
     setContentView(R.layout.activity_population_density_extrusion);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/PopulationDensityExtrusionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/PopulationDensityExtrusionActivity.java
@@ -52,7 +52,6 @@ public class PopulationDensityExtrusionActivity extends AppCompatActivity implem
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);
-
   }
 
   @Override

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ workflows:
 jobs:
   primary:
     docker:
-      - image: mbgl/7d2403f42e:android-ndk-r16b
+      - image: mbgl/92088d7e31:android-ndk-r17-beta2
     working_directory: ~/code
     environment:
       JVM_OPTS: -Xmx3200m
@@ -64,7 +64,7 @@ jobs:
 # ------------------------------------------------------------------------------
   release:
     docker:
-      - image: mbgl/7d2403f42e:android-ndk-r16b
+      - image: mbgl/92088d7e31:android-ndk-r17-beta2
     working_directory: ~/code
     environment:
       JVM_OPTS: -Xmx3200m

--- a/circle.yml
+++ b/circle.yml
@@ -47,11 +47,6 @@ jobs:
             echo "${GCLOUD_SERVICE_ACCOUNT_JSON}" > secret.json
             gcloud auth activate-service-account --key-file secret.json --project mapbox-android-demo
             rm secret.json
-      # - run:
-      #     name: Export secrets for developer-config.xml
-      #     command: |
-      #       #!/bin/bash
-      #       echo "${MAPBOX_DEVELOPER_CONFIG}" > SharedCode/src/main/res/values/developer-config.xml
       - run:
           name: Check code style
           command: make checkstyle

--- a/circle.yml
+++ b/circle.yml
@@ -47,11 +47,11 @@ jobs:
             echo "${GCLOUD_SERVICE_ACCOUNT_JSON}" > secret.json
             gcloud auth activate-service-account --key-file secret.json --project mapbox-android-demo
             rm secret.json
-      - run:
-          name: Export secrets for developer-config.xml
-          command: |
-            #!/bin/bash
-            echo "${MAPBOX_DEVELOPER_CONFIG}" > SharedCode/src/main/res/values/developer-config.xml
+      # - run:
+      #     name: Export secrets for developer-config.xml
+      #     command: |
+      #       #!/bin/bash
+      #       echo "${MAPBOX_DEVELOPER_CONFIG}" > SharedCode/src/main/res/values/developer-config.xml
       - run:
           name: Check code style
           command: make checkstyle

--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,9 @@ jobs:
       IS_LOCAL_DEVELOPMENT: false
     steps:
       - checkout
+      - run:
+          name: Clean gradle
+          command: ./gradlew clean
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "MapboxAndroidDemo/build.gradle" }}
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -83,7 +83,6 @@ jobs:
           name: Export developer-config.xml & Google Play authentication json
           command: |
             #!/bin/bash
-            echo "${MAPBOX_DEVELOPER_CONFIG}" > SharedCode/src/main/res/values/developer-config.xml
             echo "${PLAY_PUBLISH_AUTH_JSON}" > android-gl-native-6d21dd280e7b.json
       - run:
           name: Release to Google Play

--- a/circle.yml
+++ b/circle.yml
@@ -28,11 +28,11 @@ jobs:
       IS_LOCAL_DEVELOPMENT: false
     steps:
       - checkout
+      - restore_cache:
+          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "MapboxAndroidDemo/build.gradle" }}
       - run:
           name: Clean gradle
           command: ./gradlew clean
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "MapboxAndroidDemo/build.gradle" }}
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,8 +3,8 @@ ext {
             minSdkVersion    : 15,
             minWearSdkVersion: 23,
             targetSdkVersion : 26,
-            compileSdkVersion: 26,
-            buildToolsVersion: '26.0.3'
+            compileSdkVersion: 27,
+            buildToolsVersion: '27.0.3'
     ]
 
     version = [
@@ -45,7 +45,7 @@ ext {
     pluginVersion = [
             checkstyle         : '8.2',
             firebase           : '1.1.1',
-            gradle             : '3.0.0',
+            gradle             : '3.1.0',
             gradlePlayPublisher: '1.2.0'
     ]
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 15 13:24:22 EDT 2017
+#Thu Apr 26 12:58:02 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Tried to push a new version of the demo app to the Play Store with [this tag/release](https://github.com/mapbox/mapbox-android-demo/releases/tag/6.0.1) but ran into the following bug/crash:

```
BUILD FAILED in 1m 17s
75 actionable tasks: 75 executed
Exception in thread "Thread-106" java.lang.NoClassDefFoundError: com/android/utils/PathUtils$1
	at com.android.utils.PathUtils.deleteIfExists(PathUtils.java:47)
	at com.android.utils.PathUtils.lambda$addRemovePathHook$0(PathUtils.java:125)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: com.android.utils.PathUtils$1
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 3 more
Exited with code 1
```

Found https://github.com/nextcloud/android/issues/1735#issuecomment-344944787 which points to https://issuetracker.google.com/issues/69380617. Sounds like a newer version of [the Android Plugin for Gradle](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration) would fix this, so this pr bumps some versions with the hope that the bug will go away in CircleCI.