### PR TITLE
added compileOptions to wearable 

### DIFF
--- a/MapboxAndroidWearDemo/build.gradle
+++ b/MapboxAndroidWearDemo/build.gradle
@@ -37,6 +37,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Standard `Static interface methods are only supported starting with Android N (--min-api 24):` crash happened when trying to release to Play Store. Wearable was missing the Java 8 `compileOptions` section