### PR TITLE
maps sdk bump to 6.1.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     version = [
 
             // Mapbox
-            mapboxMapSdk             : '6.1.1',
+            mapboxMapSdk             : '6.1.2',
             mapboxTurf               : '3.1.0',
             mapboxGeoJson            : '3.1.0',
             mapboxPluginBuilding     : '0.3.0',


### PR DESCRIPTION
Part of the 6.1.2 release of the Maps SDK for Android

