### PR TITLE
MarathonExtrusionActivity data loading fix

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/MarathonExtrusionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/MarathonExtrusionActivity.java
@@ -12,8 +12,10 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor;
@@ -47,10 +49,18 @@ public class MarathonExtrusionActivity extends AppCompatActivity {
         MarathonExtrusionActivity.this.mapboxMap = mapboxMap;
 
         // Add the marathon route source to the map
-        GeoJsonSource courseRouteGeoJson = new GeoJsonSource(
-          "coursedata", loadJsonFromAsset("marathon_route.geojson"));
-        mapboxMap.addSource(courseRouteGeoJson);
-        addExtrusionsLayerToMap();
+        try {
+          // Create a GeoJsonSource and use the Mapbox Datasets API to retrieve the GeoJSON data
+          // More info about the Datasets API at https://www.mapbox.com/api-documentation/#retrieve-a-dataset
+          GeoJsonSource courseRouteGeoJson = new GeoJsonSource("coursedata",
+            new URL(
+              "https://api.mapbox.com/datasets/v1/appsatmapboxcom/cjhksgac501g5c6qx051jxavj/"
+                + "features?access_token=" + getString(R.string.access_token)));
+          mapboxMap.addSource(courseRouteGeoJson);
+          addExtrusionsLayerToMap();
+        } catch (MalformedURLException malformedUrlException) {
+          Timber.d("Check the URL " + malformedUrlException.getMessage());
+        }
       }
     });
   }
@@ -63,21 +73,5 @@ public class MarathonExtrusionActivity extends AppCompatActivity {
       fillExtrusionOpacity(0.7f),
       fillExtrusionHeight(get("e")));
     mapboxMap.addLayer(courseExtrusionLayer);
-  }
-
-  private String loadJsonFromAsset(String filename) {
-    // Using this method to load in GeoJSON files from the assets folder.
-    try {
-      InputStream is = getAssets().open(filename);
-      int size = is.available();
-      byte[] buffer = new byte[size];
-      is.read(buffer);
-      is.close();
-      return new String(buffer, "UTF-8");
-
-    } catch (IOException ex) {
-      ex.printStackTrace();
-      return null;
-    }
   }
 }


### PR DESCRIPTION
The `MarathonExtrusionActivity` was lagging a ton because it loads a gigantic GeoJSON file being locally stored in the `assets` folder. Instead, I moved the data to a Mapbox account and used the Mapbox Datasets API to retrieve the data. Now, loading the example doesn't lag and freeze the phone.