### PR TITLE
Changed publish track from production to alpha

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -80,7 +80,7 @@ android {
     }
 
     play {
-        track = 'production'
+        track = 'alpha'
         untrackOld = true
     }
     compileOptions {


### PR DESCRIPTION
Publishing _straight_ to `production` made me nervous. This pr changes the publish plugin's track to `alpha`