### PR TITLE
Localization plugin camera change

### DIFF
--- a/MapboxAndroidDemo/src/main/res/layout/activity_localization_plugin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_localization_plugin.xml
@@ -9,9 +9,9 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:mapbox_cameraTargetLat="40.745565"
-        app:mapbox_cameraTargetLng="-73.982058"
-        app:mapbox_cameraZoom="11.316102"
+        app:mapbox_cameraTargetLat="35.830744"
+        app:mapbox_cameraTargetLng="136.711369"
+        app:mapbox_cameraZoom="4.5257"
         app:mapbox_styleUrl="@string/mapbox_style_mapbox_streets" />
 
     <android.support.constraint.ConstraintLayout
@@ -93,7 +93,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_margin="16dp"
-                android:text="@string/mandarin"
+                android:text="@string/chinese"
                 android:textColor="@color/mapboxWhite" />
 
         </android.support.v7.widget.CardView>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -210,7 +210,7 @@
     <string name="map_localized">Map localized to device language</string>
     <string name="camera_bounds_focus">Camera bounds for country associated with language tag: %1$s</string>
     <string name="change_language_instruction">Make sure that the device\'s default language is not English</string>
-    <string name="mandarin">Mandarin</string>
+    <string name="chinese">Chinese</string>
     <string name="russian">Russian</string>
     <string name="arabic">Arabic</string>
     <string name="change_device_language_instruction">Change the device\'s language to German and then tap this button. Already in German? Try French</string>


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/724 by fixing the initial camera position for the localization plugin example

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/40735946-6dee8886-63f1-11e8-93ba-83a482eca44a.gif)
