### PR TITLE
Java SDK bump to 3.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,8 +11,8 @@ ext {
 
             // Mapbox
             mapboxMapSdk             : '6.1.3',
-            mapboxTurf               : '3.1.0',
-            mapboxGeoJson            : '3.1.0',
+            mapboxTurf               : '3.2.0',
+            mapboxGeoJson            : '3.2.0',
             mapboxPluginBuilding     : '0.3.0',
             mapboxPluginLocationLayer: '0.5.2',
             mapboxPluginPlaces       : '0.4.0',


### PR DESCRIPTION
Part of the 3.2.0 Java SDK release: https://github.com/mapbox/mapbox-java/issues/828#event-1656255568