### PR TITLE
moved GeoJsonClusteringActivity example

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -411,8 +411,8 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
-            android:name=".examples.styles.GeoJsonClusteringActivity"
-            android:label="@string/activity_styles_data_clusters_title">
+            android:name=".examples.dds.GeoJsonClusteringActivity"
+            android:label="@string/activity_styles_dds_geojson_clusters_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -81,7 +81,7 @@ import com.mapbox.mapboxandroiddemo.examples.styles.AdjustLayerOpacityActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.BasicSymbolLayerActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.ColorSwitcherActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.DefaultStyleActivity;
-import com.mapbox.mapboxandroiddemo.examples.styles.GeoJsonClusteringActivity;
+import com.mapbox.mapboxandroiddemo.examples.dds.GeoJsonClusteringActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.GeojsonLayerInStackActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.HillShadeActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.ImageSourceActivity;
@@ -275,12 +275,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           R.string.activity_styles_basic_symbol_layer_description,
           new Intent(MainActivity.this, BasicSymbolLayerActivity.class),
           R.string.activity_styles_symbol_layer_url, false, BuildConfig.MIN_SDK_VERSION));
-
-        exampleItemModels.add(new ExampleItemModel(
-          R.string.activity_styles_data_clusters_title,
-          R.string.activity_styles_create_data_cluster_description,
-          new Intent(MainActivity.this, GeoJsonClusteringActivity.class),
-          R.string.activity_styles_create_cluster_data_points_url, false, BuildConfig.MIN_SDK_VERSION));
 
         exampleItemModels.add(new ExampleItemModel(
           R.string.activity_styles_line_layer_title,
@@ -683,6 +677,12 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           R.string.activity_dds_multiple_heatmap_styling_description,
           new Intent(MainActivity.this, MultipleHeatmapStylingActivity.class),
           R.string.activity_dds_multiple_heatmap_styling_url, true, BuildConfig.MIN_SDK_VERSION));
+
+        exampleItemModels.add(new ExampleItemModel(
+          R.string.activity_styles_dds_geojson_clusters_title,
+          R.string.activity_styles_dds_geojson_clusters_description,
+          new Intent(MainActivity.this, GeoJsonClusteringActivity.class),
+          R.string.activity_styles_dds_geojson_clusters_url, false, BuildConfig.MIN_SDK_VERSION));
 
         exampleItemModels.add(new ExampleItemModel(
           R.string.activity_dds_style_circle_categorically_title,

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/GeoJsonClusteringActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/GeoJsonClusteringActivity.java
@@ -1,4 +1,4 @@
-package com.mapbox.mapboxandroiddemo.examples.styles;
+package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.graphics.Color;
 import android.os.Bundle;

--- a/MapboxAndroidDemo/src/main/res/layout/activity_geojson_clustering.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_geojson_clustering.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.mapbox.mapboxandroiddemo.examples.styles.GeoJsonClusteringActivity">
+    tools:context="com.mapbox.mapboxandroiddemo.examples.dds.GeoJsonClusteringActivity">
 
 
     <com.mapbox.mapboxsdk.maps.MapView

--- a/MapboxAndroidDemo/src/main/res/values-ca/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-ca/descriptions_strings.xml
@@ -16,7 +16,7 @@
     <string name="activity_styles_add_wms_source_description">Afegiu una capa WMS externa al mapa</string>
     <string name="activity_styles_zoom_dependent_fill_color_description">Feu que una propietat depengui del nivell de zoom del mapa, en aquest cas el color de reomplert de la capa aigua.</string>
     <string name="activity_dds_create_hotspots_points_description">Feu servir l\'SDK Android de Mapbox per visualitzar dades puntuals com mapes de calor.</string>
-    <string name="activity_styles_create_data_cluster_description">Feu servir GeoJSON per visualitzar dades puntuals com agregacions.</string>
+    <string name="activity_styles_dds_geojson_clusters_description">Feu servir GeoJSON per visualitzar dades puntuals com agregacions.</string>
     <string name="activity_styles_line_layer_description">Crear línia amb GeoJSON,  canvia\'n l\'estil emprant les propietats, i afegir la capa al mapa.</string>
     <string name="activity_styles_basic_symbol_layer_description">Mostra marcadors al mapa afegint una capa de de símbols. Consulta el mapa i anima la mida de les icones quan s\'hi faci clic.</string>
     <string name="activity_extrusions_basic_extrusions_description">Utilitza les extrusions per mostrar l\'alçada dels edificis en 3D</string>

--- a/MapboxAndroidDemo/src/main/res/values-ca/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-ca/titles_strings.xml
@@ -16,7 +16,7 @@
     <string name="activity_styles_add_wms_source_title">Afegeix una font WMS</string>
     <string name="activity_styles_zoom_dependent_fill_color_title">El color en funció del nivell de zoom</string>
     <string name="activity_dds_create_hotspots_points_title">Crea un mapa de calor a partir de punts</string>
-    <string name="activity_styles_data_clusters_title">Crea i dona estils a agrupacions de dades</string>
+    <string name="activity_styles_dds_geojson_clusters_title">Crea i dona estils a agrupacions de dades</string>
     <string name="activity_styles_line_layer_title">Crea una capa de línies</string>
     <string name="activity_styles_basic_symbol_layer_title">Capa de símbols marcadors</string>
     <string name="activity_extrusions_basic_extrusions_title">Mostra els edificis en 3D</string>

--- a/MapboxAndroidDemo/src/main/res/values-vi/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values-vi/titles_strings.xml
@@ -18,7 +18,7 @@
     <string name="activity_styles_add_wms_source_title">Thêm nguồn WMS</string>
     <string name="activity_styles_zoom_dependent_fill_color_title">Màu sắc tùy mức thu phóng</string>
     <string name="activity_dds_create_hotspots_points_title">Tạo bản đồ nhiệt từ các điểm</string>
-    <string name="activity_styles_data_clusters_title">Tạo và định kiểu các cụm dữ liệu</string>
+    <string name="activity_styles_dds_geojson_clusters_title">Tạo và định kiểu các cụm dữ liệu</string>
     <string name="activity_styles_line_layer_title">Tạo lớp đường kẻ</string>
     <string name="activity_styles_basic_symbol_layer_title">Lớp dấu ghim</string>
     <string name="activity_styles_local_style_or_raster_source_title">Kiểu địa phương hoặc kiểu raster tùy biến</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -19,7 +19,7 @@
     <string name="activity_styles_add_wms_source_description">Adding an external Web Map Service layer to the map.</string>
     <string name="activity_styles_zoom_dependent_fill_color_description">Make a property depend on the map zoom level, in this case, the water layers fill color.</string>
     <string name="activity_dds_create_hotspots_points_description">Use the Mapbox Maps SDK to visualize point data as hotspots.</string>
-    <string name="activity_styles_create_data_cluster_description">Use GeoJSON to visualize point data in clusters.</string>
+    <string name="activity_styles_dds_geojson_clusters_description">Use GeoJSON to visualize point data in clusters.</string>
     <string name="activity_styles_line_layer_description">Create a GeoJSON line source, style it using properties, and add the layer to the map.</string>
     <string name="activity_styles_basic_symbol_layer_description">Display markers on the map by adding a symbol layer. Query the map and animate the icon size if clicked on.</string>
     <string name="activity_styles_local_style_or_raster_source_description">Load a locally stored map style JSON file or custom raster style via a URL.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -18,7 +18,7 @@
     <string name="activity_styles_add_wms_source_title">Add a WMS source</string>
     <string name="activity_styles_zoom_dependent_fill_color_title">Color dependent on zoom level</string>
     <string name="activity_dds_create_hotspots_points_title">Create hotspots from points</string>
-    <string name="activity_styles_data_clusters_title">Create and style data clusters</string>
+    <string name="activity_styles_dds_geojson_clusters_title">Create and style data clusters</string>
     <string name="activity_styles_line_layer_title">Create a line layer</string>
     <string name="activity_styles_basic_symbol_layer_title">Marker symbol layer</string>
     <string name="activity_styles_local_style_or_raster_source_title">Local style or custom raster style</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -20,7 +20,7 @@
     <string name="activity_styles_vector_source_url" translatable="false">http://i.imgur.com/N0altyP.png</string>
     <string name="activity_styles_add_wms_source_url" translatable="false">http://i.imgur.com/k14WdRG.png</string>
     <string name="activity_dds_create_hotspots_points_url" translatable="false">http://i.imgur.com/pAejKLH.png</string>
-    <string name="activity_styles_create_cluster_data_points_url" translatable="false">http://i.imgur.com/fGeZhcD.png</string>
+    <string name="activity_styles_dds_geojson_clusters_url" translatable="false">http://i.imgur.com/fGeZhcD.png</string>
     <string name="activity_styles_line_layer_url" translatable="false">http://i.imgur.com/Iqxoing.png</string>
     <string name="activity_styles_symbol_layer_url" translatable="false">http://i.imgur.com/TQ4iA0L.png</string>
     <string name="activity_styles_local_style_or_raster_source_url" translatable="false">http://i.imgur.com/9w9m3On.jpg</string>


### PR DESCRIPTION
Resolves #718 by moving the `GeoJsonClusteringActivity` example to the right package. It was in the `styles` folder. It's really a data-driven styling example, so it belongs in the `dds` folder.
