### PR TITLE
Tweaks to Localization Plugin example

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocalizationPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocalizationPluginActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+import android.widget.Toast;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -80,6 +81,8 @@ public class LocalizationPluginActivity extends AppCompatActivity implements OnM
         }
       }
     });
+
+    Toast.makeText(this, R.string.instruction_description, Toast.LENGTH_LONG).show();
   }
 
   // Add the mapView lifecycle to the activity's lifecycle methods

--- a/MapboxAndroidDemo/src/main/res/layout/activity_localization_plugin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_localization_plugin.xml
@@ -18,27 +18,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+id/instruction_cardview"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:backgroundTint="@color/mapboxBlueDark"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="16dp"
-                android:text="@string/vacation_description"
-                android:textColor="@color/mapboxWhite" />
-
-        </android.support.v7.widget.CardView>
-
         <android.support.v7.widget.CardView
             android:id="@+id/language_one_cardview"
             android:layout_width="wrap_content"
@@ -48,7 +27,7 @@
             app:layout_constraintEnd_toStartOf="@+id/language_two_cardview"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/instruction_cardview">
+            app:layout_constraintTop_toBottomOf="parent">
 
             <TextView
                 android:layout_width="match_parent"

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -215,8 +215,8 @@
     <string name="arabic">Arabic</string>
     <string name="change_device_language_instruction">Change the device\'s language to German and then tap this button. Already in German? Try French</string>
     <string name="try_different_language_instruction">Try setting your phone to a different language. German or French perhaps?</string>
-    <string name="vacation_description">Uh-oh! You\'re lost in NYC. Tap the buttons below to
-        switch the map\'s language so that you can ask for help with directions.</string>
+    <string name="instruction_description">Tap the buttons below to
+        switch the map\'s language.</string>
 
     <!-- Matrix API -->
     <string name="call_error">Oh no! The call to the Directions Matrix API failed!</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -70,7 +70,7 @@
     <string name="activity_plugins_location_plugin_url" translatable="false">https://i.imgur.com/Opfwv6j.png</string>
     <string name="activity_plugins_places_plugin_url" translatable="false">https://i.imgur.com/oKHx3bv.png</string>
     <string name="activity_plugins_geojson_plugin_url" translatable="false">http://i.imgur.com/kju0sKw.jpg</string>
-    <string name="activity_plugins_localization_plugin_url" translatable="false">https://i.imgur.com/vi3D3qf.png</string>
+    <string name="activity_plugins_localization_plugin_url" translatable="false">https://i.imgur.com/tsOM1am.png</string>
     <string name="activity_java_services_simplify_polyline_url" translatable="false">http://i.imgur.com/uATgul1.png</string>
     <string name="activity_java_services_map_matching_url" translatable="false">http://i.imgur.com/bWvVbwC.png</string>
     <string name="activity_image_generator_snapshot_notification_url" translatable="false">https://i.imgur.com/OiveDFG.png</string>


### PR DESCRIPTION
The pr fixes the outdated NYC text in the Localization Plugin example. Also some other cleanup.

![ezgif com-resize 2](https://user-images.githubusercontent.com/4394910/41565816-33663a9e-730d-11e8-9342-bf75b36cdbda.gif)


cc @samfader 