### PR TITLE
Adding "snaking" directions route example

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -118,6 +118,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".labs.SnakingDirectionsRouteActivity"
+            android:label="@string/activity_labs_snaking_directions_route_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.plugins.PlacesPluginActivity"
             android:label="@string/activity_plugins_places_plugin_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -103,6 +103,7 @@ import com.mapbox.mapboxandroiddemo.labs.LosAngelesTourismActivity;
 import com.mapbox.mapboxandroiddemo.labs.MarkerFollowingRouteActivity;
 import com.mapbox.mapboxandroiddemo.labs.PictureInPictureActivity;
 import com.mapbox.mapboxandroiddemo.labs.RecyclerViewOnMapActivity;
+import com.mapbox.mapboxandroiddemo.labs.SnakingDirectionsRouteActivity;
 import com.mapbox.mapboxandroiddemo.labs.SpaceStationLocationActivity;
 import com.mapbox.mapboxandroiddemo.labs.SymbolLayerMapillaryActivity;
 import com.mapbox.mapboxandroiddemo.model.ExampleItemModel;
@@ -662,6 +663,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           R.string.activity_labs_gif_on_map_description,
           new Intent(MainActivity.this, AnimatedImageGifActivity.class),
           R.string.activity_labs_gif_on_map_url, false, BuildConfig.MIN_SDK_VERSION
+        ));
+
+        exampleItemModels.add(new ExampleItemModel(
+          R.string.activity_labs_snaking_directions_route_title,
+          R.string.activity_labs_snaking_directions_route_description,
+          new Intent(MainActivity.this, SnakingDirectionsRouteActivity.class),
+          R.string.activity_labs_snaking_directions_route_url, true, BuildConfig.MIN_SDK_VERSION
         ));
         currentCategory = R.id.nav_lab;
         break;

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SnakingDirectionsRouteActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SnakingDirectionsRouteActivity.java
@@ -56,10 +56,7 @@ public class SnakingDirectionsRouteActivity extends AppCompatActivity
   private static final String TAG = "SnakingRouteActivity";
   private MapView mapView;
   private MapboxMap map;
-  private DirectionsRoute currentRoute;
   private MapboxDirections client;
-  private List<Feature> drivingRoutePolyLineFeatureList;
-  private FeatureCollection drivingRouteFeatureCollection;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -101,9 +98,8 @@ public class SnakingDirectionsRouteActivity extends AppCompatActivity
   }
 
   private void initDrivingRouteSourceAndLayer() {
-    drivingRouteFeatureCollection = FeatureCollection.fromFeatures(new Feature[] {});
     GeoJsonSource drivingRouteGeoJsonSource = new GeoJsonSource(DRIVING_ROUTE_POLYLINE_SOURCE_ID,
-      drivingRouteFeatureCollection);
+      FeatureCollection.fromFeatures(new Feature[] {}));
     map.addSource(drivingRouteGeoJsonSource);
     LineLayer drivingRouteLineLayer = new LineLayer(DRIVING_ROUTE_POLYLINE_LINE_LAYER_ID,
       DRIVING_ROUTE_POLYLINE_SOURCE_ID)
@@ -119,7 +115,8 @@ public class SnakingDirectionsRouteActivity extends AppCompatActivity
 
   /**
    * Build the Mapbox Directions API request
-   * @param origin The starting point for the directions route
+   *
+   * @param origin      The starting point for the directions route
    * @param destination The final point for the directions route
    */
   private void getDirectionsRoute(Point origin, Point destination) {
@@ -148,7 +145,7 @@ public class SnakingDirectionsRouteActivity extends AppCompatActivity
         }
 
         // Get the route from the Mapbox Directions API
-        currentRoute = response.body().routes().get(0);
+        DirectionsRoute currentRoute = response.body().routes().get(0);
         List<Point> directionsPointsForLineLayer = new ArrayList<>();
         for (int i = 0; i < currentRoute.legs().size(); i++) {
           RouteLeg leg = currentRoute.legs().get(i);
@@ -159,20 +156,17 @@ public class SnakingDirectionsRouteActivity extends AppCompatActivity
             for (int k = 0; k < intersections.size(); k++) {
               Point location = intersections.get(k).location();
               directionsPointsForLineLayer.add(Point.fromLngLat(location.longitude(), location.latitude()));
-              drivingRoutePolyLineFeatureList = new ArrayList<>();
+              List<Feature> drivingRoutePolyLineFeatureList = new ArrayList<>();
               LineString lineString = LineString.fromLngLats(directionsPointsForLineLayer);
               List<Point> coordinates = lineString.coordinates();
               for (int x = 0; x < coordinates.size(); x++) {
                 drivingRoutePolyLineFeatureList.add(Feature.fromGeometry(LineString.fromLngLats(coordinates)));
               }
 
-              // set drivingRouteFeatureCollection to a new list of Features
-              drivingRouteFeatureCollection = FeatureCollection.fromFeatures(drivingRoutePolyLineFeatureList);
-
               // Update the GeoJSON source
               GeoJsonSource source = map.getSourceAs(DRIVING_ROUTE_POLYLINE_SOURCE_ID);
               if (source != null) {
-                source.setGeoJson(drivingRouteFeatureCollection);
+                source.setGeoJson(FeatureCollection.fromFeatures(drivingRoutePolyLineFeatureList));
               }
             }
           }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SnakingDirectionsRouteActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SnakingDirectionsRouteActivity.java
@@ -1,0 +1,236 @@
+package com.mapbox.mapboxandroiddemo.labs;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.MapboxDirections;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.api.directions.v5.models.LegStep;
+import com.mapbox.api.directions.v5.models.RouteLeg;
+import com.mapbox.api.directions.v5.models.StepIntersection;
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.annotations.MarkerOptions;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import static com.mapbox.api.directions.v5.DirectionsCriteria.GEOMETRY_POLYLINE;
+import static com.mapbox.mapboxsdk.style.layers.Property.LINE_CAP_ROUND;
+import static com.mapbox.mapboxsdk.style.layers.Property.LINE_JOIN_ROUND;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+
+/**
+ * Rather than showing the directions all at once, have it "snake" from the origin to destination
+ */
+
+public class SnakingDirectionsRouteActivity extends AppCompatActivity
+  implements OnMapReadyCallback {
+
+  private static final float NAVIGATION_LINE_WIDTH = 6;
+  private static final String DRIVING_ROUTE_POLYLINE_LINE_LAYER_ID = "DRIVING_ROUTE_POLYLINE_LINE_LAYER_ID";
+  private static final String DRIVING_ROUTE_POLYLINE_SOURCE_ID = "DRIVING_ROUTE_POLYLINE_SOURCE_ID";
+  private static final String TAG = "SnakingRouteActivity";
+  private MapView mapView;
+  private MapboxMap map;
+  private DirectionsRoute currentRoute;
+  private MapboxDirections client;
+  private List<Feature> drivingRoutePolyLineFeatureList;
+  private FeatureCollection drivingRouteFeatureCollection;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_javaservices_snaking_directions_route);
+
+    // Setup the MapView
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    this.map = mapboxMap;
+
+    initDrivingRouteSourceAndLayer();
+
+    // Origin point in Paris, France
+    final Point origin = Point.fromLngLat(2.35222, 48.856614);
+
+    // Destination point in Lyon, France
+    final Point destination = Point.fromLngLat(4.83565, 45.76404);
+
+    // Add origin and destination markers to the map
+    mapboxMap.addMarker(new MarkerOptions()
+      .position(new LatLng(origin.latitude(), origin.longitude())));
+    mapboxMap.addMarker(new MarkerOptions()
+      .position(new LatLng(destination.latitude(), destination.longitude())));
+
+    // Get route from API
+    getDirectionsRoute(origin, destination);
+  }
+
+  private void initDrivingRouteSourceAndLayer() {
+    drivingRouteFeatureCollection = FeatureCollection.fromFeatures(new Feature[] {});
+    GeoJsonSource drivingRouteGeoJsonSource = new GeoJsonSource(DRIVING_ROUTE_POLYLINE_SOURCE_ID,
+      drivingRouteFeatureCollection);
+    map.addSource(drivingRouteGeoJsonSource);
+    LineLayer drivingRouteLineLayer = new LineLayer(DRIVING_ROUTE_POLYLINE_LINE_LAYER_ID,
+      DRIVING_ROUTE_POLYLINE_SOURCE_ID)
+      .withProperties(
+        lineWidth(NAVIGATION_LINE_WIDTH),
+        lineOpacity(.3f),
+        lineCap(LINE_CAP_ROUND),
+        lineJoin(LINE_JOIN_ROUND),
+        lineColor(Color.parseColor("#d742f4"))
+      );
+    map.addLayer(drivingRouteLineLayer);
+  }
+
+  /**
+   * Build the Mapbox Directions API request
+   * @param origin The starting point for the directions route
+   * @param destination The final point for the directions route
+   */
+  private void getDirectionsRoute(Point origin, Point destination) {
+    client = MapboxDirections.builder()
+      .origin(origin)
+      .destination(destination)
+      .overview(DirectionsCriteria.OVERVIEW_FULL)
+      .profile(DirectionsCriteria.PROFILE_DRIVING)
+      .geometries(GEOMETRY_POLYLINE)
+      .alternatives(true)
+      .steps(true)
+      .accessToken(getString(R.string.access_token))
+      .build();
+
+    client.enqueueCall(new Callback<DirectionsResponse>() {
+      @Override
+      public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
+
+        // Create log messages in case no response or routes are present
+        if (response.body() == null) {
+          Log.d(TAG, "No routes found, make sure you set the right user and access token.");
+          return;
+        } else if (response.body().routes().size() < 1) {
+          Log.d(TAG, "No routes found");
+          return;
+        }
+
+        // Get the route from the Mapbox Directions API
+        currentRoute = response.body().routes().get(0);
+        List<Point> directionsPointsForLineLayer = new ArrayList<>();
+        for (int i = 0; i < currentRoute.legs().size(); i++) {
+          RouteLeg leg = currentRoute.legs().get(i);
+          List<LegStep> steps = leg.steps();
+          for (int j = 0; j < steps.size(); j++) {
+            LegStep step = steps.get(j);
+            List<StepIntersection> intersections = step.intersections();
+            for (int k = 0; k < intersections.size(); k++) {
+              Point location = intersections.get(k).location();
+              directionsPointsForLineLayer.add(Point.fromLngLat(location.longitude(), location.latitude()));
+              drivingRoutePolyLineFeatureList = new ArrayList<>();
+              LineString lineString = LineString.fromLngLats(directionsPointsForLineLayer);
+              List<Point> coordinates = lineString.coordinates();
+              for (int x = 0; x < coordinates.size(); x++) {
+                drivingRoutePolyLineFeatureList.add(Feature.fromGeometry(LineString.fromLngLats(coordinates)));
+              }
+
+              // set drivingRouteFeatureCollection to a new list of Features
+              drivingRouteFeatureCollection = FeatureCollection.fromFeatures(drivingRoutePolyLineFeatureList);
+
+              // Update the GeoJSON source
+              GeoJsonSource source = map.getSourceAs(DRIVING_ROUTE_POLYLINE_SOURCE_ID);
+              if (source != null) {
+                source.setGeoJson(drivingRouteFeatureCollection);
+              }
+            }
+          }
+        }
+      }
+
+      @Override
+      public void onFailure(Call<DirectionsResponse> call, Throwable throwable) {
+        Log.d("SnakingDirectionsActivity", "Error: " + throwable.getMessage());
+        Toast.makeText(SnakingDirectionsRouteActivity.this,
+          R.string.snaking_directions_activity_error, Toast.LENGTH_SHORT).show();
+      }
+    });
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // Cancel the directions API request
+    if (client != null) {
+      client.cancelCall();
+    }
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_snaking_directions_route.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_snaking_directions_route.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.javaservices.DirectionsActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="47.097562"
+        mapbox:mapbox_cameraTargetLng="3.709416"
+        mapbox:mapbox_styleUrl="@string/mapbox_style_light"
+        mapbox:mapbox_cameraZoom="5.991072"/>
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -71,6 +71,9 @@
     <string name="directions_activity_marker_options_destination_snippet">Plaza del Triunfo</string>
     <string name="directions_activity_toast_message">Route is %1$f meters long.</string>
 
+    <!--Marker strings for DirectionsActivity activity-->
+    <string name="snaking_directions_activity_error">Direction route retrieval failed</string>
+
     <!--Strings for OfflineManager activity-->
     <string name="dialog_title">Name new region</string>
     <string name="dialog_message">Downloads the map region you currently are viewing</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -85,4 +85,5 @@
     <string name="activity_lab_symbol_layer_and_mapillary_on_map_description">Add markers via SymbolLayer and manipulate the data in real time. A Mapillary integration is also showcased in this example.</string>
     <string name="activity_labs_inset_map_description">Show a smaller inset map fragment and link it to a larger map for two map interaction. Great for gaming!</string>
     <string name="activity_labs_gif_on_map_description">Show an animated image (GIF) anywhere on the map</string>
+    <string name="activity_labs_snaking_directions_route_description">Rather than showing the directions route all at once, have it "snake" from the origin to destination.</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -83,4 +83,5 @@
     <string name="activity_lab_indoor_map_title">Indoor Map</string>
     <string name="activity_labs_inset_map_title">Inset map</string>
     <string name="activity_labs_gif_on_map_title">Animated image source (GIF)</string>
+    <string name="activity_labs_snaking_directions_route_title">Snaking directions</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -87,5 +87,6 @@
     <string name="activity_lab_mapillary_url" translatable="false">http://i.imgur.com/w4SSif1.png</string>
     <string name="activity_labs_inset_map_url" translatable="false">https://i.imgur.com/jp4wc24.png</string>
     <string name="activity_labs_gif_on_map_url" translatable="false">https://i.imgur.com/3d810QI.png</string>
+    <string name="activity_labs_snaking_directions_route_url" translatable="false">https://i.imgur.com/6jWEFJi.png</string>
 
 </resources>


### PR DESCRIPTION
This pr adds an example of drawing a "snaking" directions route. This example uses the Mapbox Directions API as well as a LineLayer (data-driven styling).

![ezgif com-resize 5](https://user-images.githubusercontent.com/4394910/41613106-857bccda-73a9-11e8-9a9f-a3edc9db066d.gif)
