### PR TITLE
fixing crash with multiDexEnabled = true

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -29,6 +29,8 @@ android {
         buildConfigField "int", "MIN_SDK_VERSION", "$minSdkVersion.apiLevel"
 
         playAccountConfig = playAccountConfigs.defaultAccountConfig
+
+        multiDexEnabled true
     }
 
     flavorDimensions "default"


### PR DESCRIPTION
Fixing the crash that is blocking recent prs such as https://github.com/mapbox/mapbox-android-demo/pull/751 and https://github.com/mapbox/mapbox-android-demo/pull/752