### PR TITLE
Dotted directions route place picker example

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -177,6 +177,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".labs.DottedLineDirectionsPickerActivity"
+            android:label="@string/activity_dotted_line_directions_picker_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.dds.MultipleGeometriesActivity"
             android:label="@string/activity_dds_multiple_geometries_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -97,6 +97,7 @@ import com.mapbox.mapboxandroiddemo.examples.styles.StyleFadeSwitchActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.VectorSourceActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.ZoomDependentFillColorActivity;
 import com.mapbox.mapboxandroiddemo.labs.AnimatedImageGifActivity;
+import com.mapbox.mapboxandroiddemo.labs.DottedLineDirectionsPickerActivity;
 import com.mapbox.mapboxandroiddemo.labs.IndoorMapActivity;
 import com.mapbox.mapboxandroiddemo.labs.InsetMapActivity;
 import com.mapbox.mapboxandroiddemo.labs.LocationPickerActivity;
@@ -663,6 +664,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           R.string.activity_labs_gif_on_map_description,
           new Intent(MainActivity.this, AnimatedImageGifActivity.class),
           R.string.activity_labs_gif_on_map_url, false, BuildConfig.MIN_SDK_VERSION
+        ));
+
+        exampleItemModels.add(new ExampleItemModel(
+            R.string.activity_dotted_line_directions_picker_title,
+            R.string.activity_dotted_line_directions_picker_description,
+            new Intent(MainActivity.this, DottedLineDirectionsPickerActivity.class),
+            R.string.activity_dotted_line_directions_picker_url, true, BuildConfig.MIN_SDK_VERSION
         ));
         currentCategory = R.id.nav_lab;
         break;

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/DottedLineDirectionsPickerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/DottedLineDirectionsPickerActivity.java
@@ -1,0 +1,291 @@
+package com.mapbox.mapboxandroiddemo.labs;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.Gravity;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.Toast;
+
+import com.mapbox.android.core.permissions.PermissionsListener;
+import com.mapbox.android.core.permissions.PermissionsManager;
+import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.MapboxDirections;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.CameraMode;
+import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import static com.mapbox.core.constants.Constants.PRECISION_6;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineDasharray;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineTranslate;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+
+/**
+ * Drag the map to automatically draw a directions route to wherever the map is centered.
+ */
+public class DottedLineDirectionsPickerActivity extends AppCompatActivity
+  implements PermissionsListener, OnMapReadyCallback,
+  MapboxMap.OnCameraIdleListener {
+
+  private static final String TAG = "DottedLinePickActivity";
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private PermissionsManager permissionsManager;
+  private LocationLayerPlugin locationPlugin;
+  private FeatureCollection dottedLineDirectionsFeatureCollection;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_place_picker_dotted_directions_route);
+
+    // Initialize the mapboxMap view
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @SuppressWarnings( {"MissingPermission"})
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    DottedLineDirectionsPickerActivity.this.mapboxMap = mapboxMap;
+
+    // Enable the Mapbox Location Layer plugin so that the device location "puck" is displayed on the map.
+    enableLocationPlugin();
+
+    if (locationPlugin.getLastKnownLocation() == null) {
+      Log.d(TAG, "onMapReady: locationPlugin.getLastKnownLocation() == null");
+      CameraUpdateFactory.newLatLngZoom(new LatLng(38.89983, -77.03406
+      ), 14);
+    }
+
+    // Add a marker on the map's center/"target" for the place picker UI
+    ImageView hoveringMarker = new ImageView(this);
+    hoveringMarker.setImageResource(R.drawable.red_marker);
+    FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+      ViewGroup.LayoutParams.WRAP_CONTENT,
+      ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.CENTER);
+    hoveringMarker.setLayoutParams(params);
+    mapView.addView(hoveringMarker);
+
+    initDottedLineLayer();
+    mapboxMap.addOnCameraIdleListener(this);
+  }
+
+  @Override
+  public void onCameraIdle() {
+    if (mapboxMap != null) {
+      Point destinationPoint = Point.fromLngLat(
+        mapboxMap.getCameraPosition().target.getLongitude(),
+        mapboxMap.getCameraPosition().target.getLatitude());
+      getRoute(destinationPoint);
+    }
+  }
+
+  /**
+   * Set up a GeoJsonSource and LineLayer in order to show the directions route from the device location
+   * to the place picker location
+   */
+  private void initDottedLineLayer() {
+    dottedLineDirectionsFeatureCollection = FeatureCollection.fromFeatures(new Feature[] {});
+    GeoJsonSource geoJsonSource = new GeoJsonSource("SOURCE_ID", dottedLineDirectionsFeatureCollection);
+    mapboxMap.addSource(geoJsonSource);
+    LineLayer dottedDirectionsRouteLayer = new LineLayer(
+      "DIRECTIONS_LAYER_ID", "SOURCE_ID");
+    dottedDirectionsRouteLayer.withProperties(
+      lineWidth(4.5f),
+      lineColor(Color.BLACK),
+      lineTranslate(new Float[] {0f, 4f}),
+      lineDasharray(new Float[] {1.2f, 1.2f})
+    );
+    mapboxMap.addLayerBelow(dottedDirectionsRouteLayer, "road-label-small");
+  }
+
+  /**
+   * Make a call to the Mapbox Directions API to get the route from the device location to the
+   * place picker location
+   *
+   * @param destination the location chosen by moving the map to the desired destination location
+   */
+  @SuppressWarnings( {"MissingPermission"})
+  private void getRoute(Point destination) {
+    MapboxDirections client = MapboxDirections.builder()
+      .origin(locationPlugin.getLastKnownLocation() != null
+        ? Point.fromLngLat(locationPlugin.getLastKnownLocation().getLongitude(),
+        locationPlugin.getLastKnownLocation().getLatitude())
+        : Point.fromLngLat(-122.3997, 37.78835029))
+      .destination(destination)
+      .overview(DirectionsCriteria.OVERVIEW_FULL)
+      .profile(DirectionsCriteria.PROFILE_WALKING)
+      .accessToken(getString(R.string.access_token))
+      .build();
+
+    client.enqueueCall(new Callback<DirectionsResponse>() {
+      @Override
+      public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
+        System.out.println(call.request().url().toString());
+
+        // You can get the generic HTTP info about the response
+        Log.d(TAG, "Response code: " + response.code());
+        if (response.body() == null) {
+          Log.d(TAG, "No routes found, make sure you set the right user and access token.");
+          return;
+        } else if (response.body().routes().size() < 1) {
+          Log.d(TAG, "No routes found");
+          return;
+        }
+
+        drawNavigationPolylineRoute(response.body().routes().get(0));
+      }
+
+      @Override
+      public void onFailure(Call<DirectionsResponse> call, Throwable throwable) {
+        Log.d(TAG, "Error: " + throwable.getMessage());
+        if (!throwable.getMessage().equals("Coordinate is invalid: 0,0")) {
+          Toast.makeText(DottedLineDirectionsPickerActivity.this,
+            "Error: " + throwable.getMessage(), Toast.LENGTH_SHORT).show();
+        }
+      }
+    });
+  }
+
+  /**
+   * Update the GeoJson data that's part of the LineLayer.
+   *
+   * @param route The route to be drawn in the map's LineLayer that was set up above.
+   */
+  private void drawNavigationPolylineRoute(DirectionsRoute route) {
+    List<Feature> directionsRouteFeatureList = new ArrayList<>();
+    LineString lineString = LineString.fromPolyline(route.geometry(), PRECISION_6);
+    List<Point> coordinates = lineString.coordinates();
+    for (int i = 0; i < coordinates.size(); i++) {
+      directionsRouteFeatureList.add(Feature.fromGeometry(LineString.fromLngLats(coordinates)));
+    }
+    dottedLineDirectionsFeatureCollection = FeatureCollection.fromFeatures(directionsRouteFeatureList);
+    GeoJsonSource source = mapboxMap.getSourceAs("SOURCE_ID");
+    if (source != null) {
+      source.setGeoJson(dottedLineDirectionsFeatureCollection);
+    }
+  }
+
+  @Override
+  @SuppressWarnings( {"MissingPermission"})
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                         @NonNull int[] grantResults) {
+    permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
+  }
+
+  @Override
+  public void onExplanationNeeded(List<String> permissionsToExplain) {
+    Toast.makeText(this, R.string.user_location_permission_explanation,
+      Toast.LENGTH_LONG).show();
+  }
+
+  @Override
+  public void onPermissionResult(boolean granted) {
+    if (granted) {
+      enableLocationPlugin();
+    } else {
+      Toast.makeText(this, R.string.user_location_permission_not_granted, Toast.LENGTH_LONG).show();
+      finish();
+    }
+  }
+
+  /**
+   * Enable the Mapbox Location Layer Plugin
+   */
+  @SuppressWarnings( {"MissingPermission"})
+  private void enableLocationPlugin() {
+    // Check if permissions are enabled and if not request
+    if (PermissionsManager.areLocationPermissionsGranted(this)) {
+
+      // Create an instance of the plugin. Adding in LocationLayerOptions is also an optional
+      // parameter
+      locationPlugin = new LocationLayerPlugin(mapView, mapboxMap);
+
+      // Set the plugin's camera mode
+      locationPlugin.setRenderMode(RenderMode.NORMAL);
+      locationPlugin.setCameraMode(CameraMode.TRACKING);
+      getLifecycle().addObserver(locationPlugin);
+    } else {
+      permissionsManager = new PermissionsManager(this);
+      permissionsManager.requestLocationPermissions(this);
+    }
+  }
+
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_place_picker_dotted_directions_route.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_place_picker_dotted_directions_route.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraZoom="14"
+        mapbox:mapbox_styleUrl="@string/mapbox_style_light"/>
+
+</RelativeLayout>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -86,4 +86,5 @@
     <string name="activity_lab_symbol_layer_and_mapillary_on_map_description">Add markers via SymbolLayer and manipulate the data in real time. A Mapillary integration is also showcased in this example.</string>
     <string name="activity_labs_inset_map_description">Show a smaller inset map fragment and link it to a larger map for two map interaction. Great for gaming!</string>
     <string name="activity_labs_gif_on_map_description">Show an animated image (GIF) anywhere on the map</string>
+    <string name="activity_dotted_line_directions_picker_description">Show a dotted directions route to a location that\'s based on map movement.</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -84,4 +84,5 @@
     <string name="activity_lab_indoor_map_title">Indoor Map</string>
     <string name="activity_labs_inset_map_title">Inset map</string>
     <string name="activity_labs_gif_on_map_title">Animated image source (GIF)</string>
+    <string name="activity_dotted_line_directions_picker_title">Directions to selected location</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -88,5 +88,6 @@
     <string name="activity_lab_mapillary_url" translatable="false">http://i.imgur.com/w4SSif1.png</string>
     <string name="activity_labs_inset_map_url" translatable="false">https://i.imgur.com/jp4wc24.png</string>
     <string name="activity_labs_gif_on_map_url" translatable="false">https://i.imgur.com/3d810QI.png</string>
+    <string name="activity_dotted_line_directions_picker_url" translatable="false">https://i.imgur.com/0tnlGR6.png</string>
 
 </resources>


### PR DESCRIPTION
This pr adds an example of showing a directions route based on where the map is dragged. The route is part of a `LineLayer`, the activity implements the `MapboxMap.OnCameraIdleListener` interface, the map's target coordinates are used as the destination in a Mapbox Directions API call. 

The Mapbox Location Layer Plugin is also used so that the example starts wherever the user's device location is. 

![ezgif com-resize 1](https://user-images.githubusercontent.com/4394910/41877869-b052e83e-7887-11e8-957d-6de6fcb4a972.gif)
