### PR TITLE
Fix to SymbolLayer + mapillary example

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SymbolLayerMapillaryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SymbolLayerMapillaryActivity.java
@@ -929,7 +929,7 @@ public class SymbolLayerMapillaryActivity extends AppCompatActivity implements O
             ),
             circleOpacity(0.6f)
           );
-          clusterLayer.setMaxZoom(14f);
+          clusterLayer.setMaxZoom(17f);
 
           // Add a filter to the cluster layer that hides the circles based on "point_count"
           clusterLayer.setFilter(

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SymbolLayerMapillaryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SymbolLayerMapillaryActivity.java
@@ -252,15 +252,12 @@ public class SymbolLayerMapillaryActivity extends AppCompatActivity implements O
    */
   private void setupLoadingLayer() {
     mapboxMap.addLayerBelow(new CircleLayer(LOADING_LAYER_ID, SOURCE_ID)
-        .withProperties(
-          circleRadius(interpolate(exponential(1), get(PROPERTY_LOADING_PROGRESS), getLoadingAnimationStops())),
-          circleColor(Color.GRAY),
-          circleOpacity(0.6f)
-        )
-        /*.withFilter(eq(PROPERTY_LOADING, true)),*/
-        .withFilter(eq((get(PROPERTY_LOADING)), literal(0))),
-      MAKI_LAYER_ID
-    );
+      .withProperties(
+        circleRadius(interpolate(exponential(1), get(PROPERTY_LOADING_PROGRESS), getLoadingAnimationStops())),
+        circleColor(Color.GRAY),
+        circleOpacity(0.6f)
+      )
+      .withFilter(eq(get(PROPERTY_LOADING), literal(true))), MAKI_LAYER_ID);
   }
 
   private Expression.Stop[] getLoadingAnimationStops() {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SymbolLayerMapillaryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/labs/SymbolLayerMapillaryActivity.java
@@ -930,7 +930,10 @@ public class SymbolLayerMapillaryActivity extends AppCompatActivity implements O
                 stop(16, 20f)
               )
             ),
-            circleOpacity(0.6f));
+            circleOpacity(0.6f)
+          );
+          clusterLayer.setMaxZoom(14f);
+
           // Add a filter to the cluster layer that hides the circles based on "point_count"
           clusterLayer.setFilter(
             i == 0


### PR DESCRIPTION
Resolves #737 

- [x] doesn't display loading circle due to this lines
- [x] doesn't make clustering circles invisible when we zoom close enough to actually see the picture
- [ ] loading process is improperly interruted and persist when changing the POI during the loading animation
- [ ] callout layer "grows" a bit after being initially clicked


![ezgif com-resize 2](https://user-images.githubusercontent.com/4394910/42002319-b61c7c9a-7a1b-11e8-8833-347009379517.gif)

