### PR TITLE
Adding queried building Feature outline

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -376,6 +376,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.query.BuildingOutlineActivity"
+            android:label="@string/activity_query_building_outline_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.styles.LineLayerActivity"
             android:label="@string/activity_styles_line_layer_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -75,6 +75,7 @@ import com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.PlaceSelectionPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.PlacesPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.TrafficPluginActivity;
+import com.mapbox.mapboxandroiddemo.examples.query.BuildingOutlineActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.ClickOnLayerActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.FeatureCountActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.QueryFeatureActivity;
@@ -556,6 +557,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           R.string.activity_query_redo_search_in_area_description,
           new Intent(MainActivity.this, RedoSearchInAreaActivity.class),
           R.string.activity_query_redo_search_in_area_url, true, BuildConfig.MIN_SDK_VERSION));
+
+        exampleItemModels.add(new ExampleItemModel(
+          R.string.activity_query_building_outline_title,
+          R.string.activity_query_building_outline_description,
+          new Intent(MainActivity.this, BuildingOutlineActivity.class),
+          R.string.activity_query_building_outline_url, true, BuildConfig.MIN_SDK_VERSION));
+
         currentCategory = R.id.nav_query_map;
         break;
       case R.id.nav_java_services:

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/BuildingOutlineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/BuildingOutlineActivity.java
@@ -1,0 +1,193 @@
+package com.mapbox.mapboxandroiddemo.examples.query;
+
+import android.graphics.Color;
+import android.graphics.PointF;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.Toast;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mapbox.mapboxsdk.style.layers.Property.LINE_CAP_ROUND;
+import static com.mapbox.mapboxsdk.style.layers.Property.LINE_JOIN_BEVEL;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+
+/**
+ * Query the building layer to draw an outline around the building that is in the middle of the map
+ */
+public class BuildingOutlineActivity extends AppCompatActivity implements
+  OnMapReadyCallback, MapboxMap.OnCameraIdleListener {
+
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private FeatureCollection featureCollection;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_query_building_outline);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    BuildingOutlineActivity.this.mapboxMap = mapboxMap;
+    setUpLineLayer();
+    mapboxMap.addOnCameraIdleListener(this);
+    Toast.makeText(this, R.string.move_map_around_instruction, Toast.LENGTH_SHORT).show();
+  }
+
+  /**
+   * Sets up the source and layer for drawing the building outline
+   */
+  private void setUpLineLayer() {
+    // Create an empty FeatureCollection
+    featureCollection = FeatureCollection.fromFeatures(new Feature[] {});
+
+    // Create a GeoJSONSource from the empty FeatureCollection
+    GeoJsonSource geoJsonSource = new GeoJsonSource("source", featureCollection);
+    mapboxMap.addSource(geoJsonSource);
+
+    // Use runtime styling to adjust the look of the building outline LineLayer
+    LineLayer lineLayer = new LineLayer("lineLayer", "source");
+    lineLayer.withProperties(
+      lineColor(Color.RED),
+      lineWidth(6f),
+      lineCap(LINE_CAP_ROUND),
+      lineJoin(LINE_JOIN_BEVEL)
+    );
+    mapboxMap.addLayer(lineLayer);
+  }
+
+  @Override
+  public void onCameraIdle() {
+    if (mapboxMap != null) {
+      updateOutline();
+    } else {
+      Toast.makeText(this, R.string.building_layer_not_present, Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  /**
+   * Query the map for a building Feature in the map's building layer. The query happens in the middle of the
+   * map ("the target"). If there's a building Feature in the middle of the map, its coordinates are turned
+   * into a list of Point objects so that a LineString can be created.
+   * @return the LineString built via the building's coordinates
+   */
+  private LineString getBuildingFeatureOutline() {
+    // Retrieve the middle of the map
+    final PointF pixel = mapboxMap.getProjection().toScreenLocation(new LatLng(
+      mapboxMap.getCameraPosition().target.getLatitude(),
+      mapboxMap.getCameraPosition().target.getLongitude()
+    ));
+
+    List<Point> pointList = new ArrayList<>();
+
+    // Check whether the map style has a building layer
+    if (mapboxMap.getLayer("building") != null) {
+
+      // Retrieve the building Feature that is displayed in the middle of the map
+      List<Feature> features = mapboxMap.queryRenderedFeatures(pixel, "building");
+      if (features.size() > 0) {
+        Feature buildingFeature = features.get(0);
+        // Build a list of Point objects from the building Feature's coordinates
+        for (int i = 0; i < ((Polygon) buildingFeature.geometry()).coordinates().size(); i++) {
+          for (int j = 0;
+               j < ((Polygon) buildingFeature.geometry()).coordinates().get(i).size(); j++) {
+            pointList.add(Point.fromLngLat(
+              ((Polygon) buildingFeature.geometry()).coordinates().get(i).get(j).longitude(),
+              ((Polygon) buildingFeature.geometry()).coordinates().get(i).get(j).latitude()
+            ));
+          }
+        }
+        // Create a LineString from the list of Point objects
+      }
+    }
+    return LineString.fromLngLats(pointList);
+  }
+
+  /**
+   * Update the FeatureCollection used by the building outline LineLayer. Then refresh the map.
+   */
+  private void updateOutline() {
+    // Update the data source used by the building outline LineLayer and refresh the map
+    featureCollection = FeatureCollection.fromFeatures(new Feature[]
+      {Feature.fromGeometry(getBuildingFeatureOutline())});
+    GeoJsonSource source = mapboxMap.getSourceAs("source");
+    if (source != null) {
+      source.setGeoJson(featureCollection);
+    }
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    if (mapboxMap != null) {
+      mapboxMap.removeOnCameraIdleListener(this);
+    }
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_query_building_outline.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_query_building_outline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        mapbox:mapbox_cameraTargetLat="39.951906"
+        mapbox:mapbox_cameraTargetLng="-75.163690"
+        mapbox:mapbox_cameraZoom="17.34"
+        mapbox:mapbox_styleUrl="@string/mapbox_style_mapbox_streets"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -258,4 +258,8 @@
     <string name="streets_style">Streets</string>
     <string name="create_image">Create static image</string>
     <string name="select_a_style">Select a style button first!</string>
+
+    <!-- Building outline-->
+    <string name="building_layer_not_present">This map style doesn\'t have a building layer</string>
+    <string name="move_map_around_instruction">Move map around</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -62,6 +62,7 @@
     <string name="activity_query_feature_count_description">Get the feature count inside a bounding box and highlight all the buildings.</string>
     <string name="activity_query_click_on_layer_description">Click on and highlight a selected GeoJSON polygon.</string>
     <string name="activity_query_redo_search_in_area_description">Search for certain features once the map is moved. This example finds parks.</string>
+    <string name="activity_query_building_outline_description">Query the building layer and show a building\'s outline</string>
     <string name="activity_java_services_directions_description">Use Mapbox Java Services to request directions.</string>
     <string name="activity_java_services_optimization_description">Use Mapbox\'s Optimization API to retrieve and display the quickest multi-stop route.</string>
     <string name="activity_java_services_static_image_description">Use Mapbox Java Services to build a url and download a static map.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -61,6 +61,7 @@
     <string name="activity_query_redo_search_in_area_title">Redo search</string>
     <string name="activity_query_feature_count_title">Feature count</string>
     <string name="activity_query_click_on_layer_title">Click on single layer</string>
+    <string name="activity_query_building_outline_title">Building outline</string>
     <string name="activity_java_services_directions_title">Show directions on map</string>
     <string name="activity_java_services_optimization_title">Show optimized directions on map</string>
     <string name="activity_java_services_static_image_title">Download a static map</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -63,6 +63,7 @@
     <string name="activity_query_feature_count_url" translatable="false">http://i.imgur.com/phzOt81.png</string>
     <string name="activity_query_click_on_layer_url" translatable="false">https://i.imgur.com/z3aWAqM.png</string>
     <string name="activity_query_redo_search_in_area_url" translatable="false">https://i.imgur.com/42QIsQI.png</string>
+    <string name="activity_query_building_outline_url" translatable="false">https://i.imgur.com/40BSGmJ.png</string>
     <string name="activity_java_services_directions_url" translatable="false">http://i.imgur.com/DhQltqB.jpg</string>
     <string name="activity_java_services_static_image_url" translatable="false">https://i.imgur.com/aHxPYRU.png</string>
     <string name="activity_java_services_optimization_url" translatable="false">http://i.imgur.com/guEQtlP.jpg</string>


### PR DESCRIPTION
Adds an example of drawing a `LineLayer` outline around a `Feature` in the `building` layer. Map style must have the `building` layer.



![ezgif com-resize 1](https://user-images.githubusercontent.com/4394910/42844378-96a73e34-89c7-11e8-98ae-7b560d12c1a4.gif)
