### PR TITLE
proguard and targetSdkVersion updates

### DIFF
--- a/MapboxAndroidDemo/proguard-rules.pro
+++ b/MapboxAndroidDemo/proguard-rules.pro
@@ -22,9 +22,7 @@
 -dontwarn retrofit.**
 
 # Picasso
--dontwarn com.squareup.okhttp.**
--dontwarn com.squareup.okhttp.MediaType
-
+-dontnote com.squareup.**
 
 -dontwarn android.support.**
 -dontwarn java.lang.**
@@ -63,6 +61,7 @@
 # --- OkHttp ---
 -dontwarn okhttp3.**
 -dontwarn okio.**
+-dontwarn okio.BufferedSink
 -dontwarn javax.annotation.**
 -dontwarn org.conscrypt.**
 # A resource is loaded with a relative path so the package of this class must be preserved.
@@ -85,6 +84,7 @@
 -keepclassmembers class * extends android.arch.lifecycle.ViewModel {
     <init>(...);
 }
+
 # keep Lifecycle State and Event enums values
 -keepclassmembers class android.arch.lifecycle.Lifecycle$State { *; }
 -keepclassmembers class android.arch.lifecycle.Lifecycle$Event { *; }
@@ -105,4 +105,15 @@
 -keep class android.arch.** { *; }
 -dontwarn android.arch.**
 
+
+# Other Mapbox core
+-keep android.arch.lifecycle.MethodCallsLogger
+-keep android.arch.lifecycle.LifecycleOwner
+-keep android.arch.lifecycle.Lifecycle$Event
+-keep com.mapbox.android.core.location.**
+
+# Other Android
+-dontnote android.net.http.*
+-dontnote org.apache.commons.codec.**
+-dontnote org.apache.http.**
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
     androidVersions = [
             minSdkVersion    : 15,
             minWearSdkVersion: 23,
-            targetSdkVersion : 26,
+            targetSdkVersion : 27,
             compileSdkVersion: 27,
             buildToolsVersion: '27.0.3'
     ]


### PR DESCRIPTION
Another attempt to get proguard working for the `6.3.0` Play Store release of the app