### PR TITLE
updated mapsSdk to 6.4.0-alpha.2

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -108,7 +108,6 @@ dependencies {
     // Mapbox dependencies
     api(dependenciesList.mapboxMapSdk)
     implementation dependenciesList.mapboxTurf
-    implementation dependenciesList.mapboxGeoJson
 
     // Mapbox plugins
     implementation dependenciesList.mapboxPluginLocationLayer

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,9 +10,8 @@ ext {
     version = [
 
             // Mapbox
-            mapboxMapSdk             : '6.3.0',
+            mapboxMapSdk             : '6.4.0-alpha.2',
             mapboxTurf               : '3.3.0',
-            mapboxGeoJson            : '3.3.0',
             mapboxPluginBuilding     : '0.3.0',
             mapboxPluginLocationLayer: '0.7.1',
             mapboxPluginPlaces       : '0.4.0',
@@ -60,7 +59,6 @@ ext {
             // Mapbox
             mapboxMapSdk             : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
             mapboxTurf               : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxTurf}",
-            mapboxGeoJson            : "com.mapbox.mapboxsdk:mapbox-sdk-geojson:${version.mapboxGeoJson}",
 
             // Mapbox plugins
             mapboxPluginLocationLayer: "com.mapbox.mapboxsdk:mapbox-android-plugin-locationlayer:${version.mapboxPluginLocationLayer}",


### PR DESCRIPTION
bump mapsSdk to 6.4.0-alpha.2
mapboxGeoJson should be pulled from mapsSdk. Remove to avoid version clash