### PR TITLE
Proguard rules fix/addition

### DIFF
--- a/MapboxAndroidDemo/proguard-rules.pro
+++ b/MapboxAndroidDemo/proguard-rules.pro
@@ -42,10 +42,10 @@
 -dontwarn com.google.android.gms.**
 
 
-
 # Consumer proguard rules for plugins
 
 -dontwarn com.mapbox.mapboxandroiddemo.examples.plugins.**
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 
 # --- AutoValue ---
 # AutoValue annotations are retained but dependency is compileOnly.
@@ -119,6 +119,3 @@
 -dontnote org.xmlpull.v1.**
 -keep class org.xmlpull.** { *; }
 -keepclassmembers class org.xmlpull.** { *; }
-
-
--dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement

--- a/MapboxAndroidDemo/proguard-rules.pro
+++ b/MapboxAndroidDemo/proguard-rules.pro
@@ -42,7 +42,10 @@
 -dontwarn com.google.android.gms.**
 
 
+
 # Consumer proguard rules for plugins
+
+-dontwarn com.mapbox.mapboxandroiddemo.examples.plugins.**
 
 # --- AutoValue ---
 # AutoValue annotations are retained but dependency is compileOnly.
@@ -55,6 +58,7 @@
 -keepclassmembernames interface * {
     @retrofit2.http.* <methods>;
 }
+
 # Ignore annotation used for build tooling.
 -dontwarn org.codehaus.mojo.animal_sniffer.*
 
@@ -116,3 +120,5 @@
 -keep class org.xmlpull.** { *; }
 -keepclassmembers class org.xmlpull.** { *; }
 
+
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement


### PR DESCRIPTION
App couldn't be installed on device via Android Studio, because of a proguard issue

```
Warning: com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity$1: can't find referenced method 'com.mapbox.mapboxsdk.maps.MapboxMap access$002(com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity,com.mapbox.mapboxsdk.maps.MapboxMap)' in program class com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity
```

```
com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity$1: can't find referenced method 'void access$100(com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity)' in program class com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity	


Exception while processing task java.io.IOException: proguard.ParseException: Unexpected keyword 'com.mapbox.mapboxandroiddemo.examples.plugins.LocationPluginActivity*' in line 44 of file '/Users/langstonsmith/Documents/Mapbox_Work/mapbox-android-demo/MapboxAndroidDemo/proguard-rules.pro'	
```