### PR TITLE
Set content for PulsingLayerOpacityActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/PulsingLayerOpacityColorActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/PulsingLayerOpacityColorActivity.java
@@ -51,7 +51,7 @@ public class PulsingLayerOpacityColorActivity extends AppCompatActivity implemen
     Mapbox.getInstance(this, getString(R.string.access_token));
 
     // This contains the MapView in XML and needs to be called after the access token is configured.
-
+    setContentView(R.layout.activity_lab_pulsing_layer_opacity_color);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
     mapView.getMapAsync(this);


### PR DESCRIPTION
The `PulsingLayerOpacityActivity` crashes on startup because there is no content view set.