### PR TITLE
Slowed down zoom speed for style fade switch

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/StyleFadeSwitchActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/StyleFadeSwitchActivity.java
@@ -79,7 +79,7 @@ public class StyleFadeSwitchActivity extends AppCompatActivity implements
 
     // Animate the map camera to show the fade in/out UI of the satellite layer
     mapboxMap.animateCamera(
-      CameraUpdateFactory.newCameraPosition(cameraPositionForFragmentMap), 4000);
+      CameraUpdateFactory.newCameraPosition(cameraPositionForFragmentMap), 9000);
   }
 
   // Add the mapView lifecycle to the activity's lifecycle methods


### PR DESCRIPTION
This pr slows down the camera animation speed in the Snapchat-style zoom fade switch example. The map goes from streets to satellite based on the zoom level. By slowing down the camera, the fade is more visible rather than it just looking like a hard switch once the raster images load.

![ezgif com-optimize 2](https://user-images.githubusercontent.com/4394910/45116785-b176ae80-b108-11e8-9ac3-19787f6f0c1a.gif)
