### PR TITLE
Adding Tilequery API example

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -123,6 +123,7 @@ dependencies {
     chinaImplementation dependenciesList.mapboxChinaPlugin
     globalImplementation dependenciesList.mapboxMapSdk
     implementation dependenciesList.mapboxTurf
+    implementation dependenciesList.mapboxServices
 
     // Mapbox plugins
     implementation dependenciesList.mapboxPluginBuilding

--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -71,6 +71,7 @@ import com.mapbox.mapboxandroiddemo.examples.javaservices.MatrixApiActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.OptimizationActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.SimplifyPolylineActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.StaticImageActivity;
+import com.mapbox.mapboxandroiddemo.examples.javaservices.TilequeryActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.AnimatedImageGifActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.CalendarIntegrationActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.DashedLineDirectionsPickerActivity;
@@ -297,6 +298,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
           models.add(model);
         }
       }
+
     }
 
     adapter.updateDataSet(models, currentCategory);
@@ -868,6 +870,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, IsochroneActivity.class),
       null,
       R.string.activity_java_services_isochrone_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_java_services,
+      R.string.activity_java_services_tilequery_title,
+      R.string.activity_java_services_tilequery_description,
+      new Intent(MainActivity.this, TilequeryActivity.class),
+      null,
+      R.string.activity_java_services_tilequery_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_snapshot_image_generator,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -135,6 +135,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.javaservices.TilequeryActivity"
+            android:label="@string/activity_java_services_tilequery_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.SnakingDirectionsRouteActivity"
             android:label="@string/activity_labs_snaking_directions_route_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TilequeryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TilequeryActivity.java
@@ -1,0 +1,279 @@
+package com.mapbox.mapboxandroiddemo.examples.javaservices;
+
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.mapbox.android.core.permissions.PermissionsListener;
+import com.mapbox.android.core.permissions.PermissionsManager;
+import com.mapbox.api.tilequery.MapboxTilequery;
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import timber.log.Timber;
+
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
+
+/**
+ * Use the Mapbox Tilequery API to retrieve information about Features on a Vector Tileset. More info about
+ * the Tilequery API can be found at https://www.mapbox.com/api-documentation/#tilequery
+ */
+public class TilequeryActivity extends AppCompatActivity implements
+  OnMapReadyCallback, PermissionsListener, MapboxMap.OnMapClickListener {
+
+  private static final String RESULT_GEOJSON_SOURCE_ID = "RESULT_GEOJSON_SOURCE_ID";
+  private static final String CLICK_CENTER_GEOJSON_SOURCE_ID = "CLICK_CENTER_GEOJSON_SOURCE_ID";
+  private static final String LAYER_ID = "LAYER_ID";
+  private PermissionsManager permissionsManager;
+  private MapboxMap mapboxMap;
+  private MapView mapView;
+  private TextView tilequeryResponseTextView;
+
+  @Override
+
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_javaservices_tilequery);
+
+    tilequeryResponseTextView = findViewById(R.id.tilequery_response_info_textview);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @SuppressWarnings({"MissingPermission"})
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    TilequeryActivity.this.mapboxMap = mapboxMap;
+    addClickLayer();
+    addResultLayer();
+    displayDeviceLocation();
+    mapboxMap.addOnMapClickListener(this);
+    Toast.makeText(this, R.string.click_on_map_instruction, Toast.LENGTH_SHORT).show();
+  }
+
+  /**
+   * Add a map layer which will show a marker icon where the map was clicked
+   */
+  private void addClickLayer() {
+    Bitmap clickSymbolIcon = BitmapFactory.decodeResource(
+      TilequeryActivity.this.getResources(), R.drawable.red_marker);
+    mapboxMap.addImage("CLICK-ICON-ID", clickSymbolIcon);
+
+    GeoJsonSource clickGeoJsonSource = new GeoJsonSource(CLICK_CENTER_GEOJSON_SOURCE_ID,
+      FeatureCollection.fromFeatures(new Feature[]{}));
+    mapboxMap.addSource(clickGeoJsonSource);
+
+    SymbolLayer clickSymbolLayer = new SymbolLayer("click-layer", CLICK_CENTER_GEOJSON_SOURCE_ID);
+    clickSymbolLayer.setProperties(
+      iconImage("CLICK-ICON-ID"),
+      iconOffset(new Float[]{0f, -12f}),
+      iconIgnorePlacement(true),
+      iconAllowOverlap(true)
+    );
+    mapboxMap.addLayer(clickSymbolLayer);
+  }
+
+  /**
+   * Add a map layer which will show marker icons for all of the Tilequery API results
+   */
+  private void addResultLayer() {
+    // Add the marker image to map
+    Bitmap resultSymbolIcon = BitmapFactory.decodeResource(
+      TilequeryActivity.this.getResources(), R.drawable.blue_marker);
+    mapboxMap.addImage("RESULT-ICON-ID", resultSymbolIcon);
+
+    // Retrieve GeoJSON information from the Mapbox Tilequery API
+    GeoJsonSource resultBlueMarkerGeoJsonSource = new GeoJsonSource(RESULT_GEOJSON_SOURCE_ID,
+      FeatureCollection.fromFeatures(new Feature[]{}));
+    mapboxMap.addSource(resultBlueMarkerGeoJsonSource);
+
+    SymbolLayer resultSymbolLayer = new SymbolLayer(LAYER_ID, RESULT_GEOJSON_SOURCE_ID);
+    resultSymbolLayer.setProperties(
+      iconImage("RESULT-ICON-ID"),
+      iconOffset(new Float[]{0f, -12f}),
+      iconIgnorePlacement(true),
+      iconAllowOverlap(true)
+    );
+    mapboxMap.addLayer(resultSymbolLayer);
+  }
+
+
+  @Override
+  public void onMapClick(@NonNull LatLng point) {
+
+    // Move and display the click center layer's red marker icon to wherever the map was clicked on
+    GeoJsonSource clickLocationSource = mapboxMap.getSourceAs(CLICK_CENTER_GEOJSON_SOURCE_ID);
+    if (clickLocationSource != null) {
+      clickLocationSource.setGeoJson(Feature.fromGeometry(Point.fromLngLat(point.getLongitude(), point.getLatitude())));
+    }
+
+    // Use the map click location to make a Tilequery API call
+    makeTilequeryApiCall(point);
+  }
+
+  /**
+   * Use the Java SDK's MapboxTilequery class to build a API request and use the API response
+   *
+   * @param point the center point that the the tilequery will originate from.
+   */
+  private void makeTilequeryApiCall(@NonNull LatLng point) {
+    MapboxTilequery tilequery = MapboxTilequery.builder()
+      .accessToken(getString(R.string.access_token))
+      .mapIds("mapbox.mapbox-streets-v7")
+      .query(Point.fromLngLat(point.getLongitude(), point.getLatitude()))
+      .radius(50)
+      .limit(10)
+      .geometry("polygon")
+      .dedupe(true)
+      .layers("building")
+      .build();
+
+    tilequery.enqueueCall(new Callback<FeatureCollection>() {
+      @Override
+      public void onResponse(Call<FeatureCollection> call, Response<FeatureCollection> response) {
+        tilequeryResponseTextView.setText(response.body().toJson());
+        GeoJsonSource resultSource = mapboxMap.getSourceAs(RESULT_GEOJSON_SOURCE_ID);
+        if (resultSource != null && response.body().features() != null) {
+          resultSource.setGeoJson(FeatureCollection.fromFeatures(response.body().features()));
+        }
+      }
+
+      @Override
+      public void onFailure(Call<FeatureCollection> call, Throwable throwable) {
+        Timber.d("Request failed: %s", throwable.getMessage());
+        Toast.makeText(TilequeryActivity.this, R.string.api_error, Toast.LENGTH_SHORT).show();
+      }
+    });
+  }
+
+  /**
+   * Use the Maps SDK's LocationComponent to display the device location on the map
+   */
+  @SuppressWarnings({"MissingPermission"})
+  private void displayDeviceLocation() {
+    // Check if permissions are enabled and if not request
+    if (PermissionsManager.areLocationPermissionsGranted(this)) {
+
+      // Get an instance of the component
+      LocationComponent locationComponent = mapboxMap.getLocationComponent();
+
+      // Activate with options
+      locationComponent.activateLocationComponent(this);
+
+      // Enable to make component visible
+      locationComponent.setLocationComponentEnabled(true);
+
+      // Set the component's camera mode
+      locationComponent.setCameraMode(CameraMode.TRACKING);
+      locationComponent.setRenderMode(RenderMode.COMPASS);
+
+      // Zoom the camera into the device's current location
+      mapboxMap.animateCamera(CameraUpdateFactory
+        .newCameraPosition(new CameraPosition.Builder()
+          .zoom(17)
+          .build()), 2000);
+    } else {
+      permissionsManager = new PermissionsManager(this);
+      permissionsManager.requestLocationPermissions(this);
+    }
+  }
+
+  // The following three methods are related to showing the device's location via the LocationComponent
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
+  }
+
+  @Override
+  public void onExplanationNeeded(List<String> permissionsToExplain) {
+    Toast.makeText(this, R.string.user_location_permission_explanation, Toast.LENGTH_LONG).show();
+  }
+
+  @Override
+  public void onPermissionResult(boolean granted) {
+    if (granted) {
+      displayDeviceLocation();
+    } else {
+      Toast.makeText(this, R.string.user_location_permission_not_granted, Toast.LENGTH_LONG).show();
+      finish();
+    }
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_tilequery.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_tilequery.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraint_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.javaservices.TilequeryActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="parent"
+        mapbox:mapbox_cameraTargetLat="40.73581"
+        mapbox:mapbox_cameraTargetLng="-73.99155"
+        mapbox:mapbox_cameraZoom="11"
+        mapbox:mapbox_styleUrl="@string/mapbox_style_mapbox_streets" />
+
+    <android.support.v7.widget.CardView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        mapbox:layout_constraintBottom_toBottomOf="@+id/mapView"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="@+id/guideline8">
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginTop="8dp">
+
+            <TextView
+                android:id="@+id/tilequery_response_info_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </ScrollView>
+
+    </android.support.v7.widget.CardView>
+
+    <android.support.constraint.Guideline
+        android:id="@+id/guideline8"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        mapbox:layout_constraintGuide_percent="0.7" />
+
+
+</android.support.constraint.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_tilequery.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_tilequery.xml
@@ -35,12 +35,20 @@
         mapbox:layout_constraintStart_toStartOf="parent"
         mapbox:layout_constraintTop_toTopOf="@+id/guideline8">
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textColor="@color/black_semi_transparent"
+            android:padding="8dp"
+            android:text="@string/api_response" />
+
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginLeft="8dp"
             android:layout_marginRight="8dp"
-            android:layout_marginTop="8dp">
+            android:layout_marginTop="32dp">
 
             <TextView
                 android:id="@+id/tilequery_response_info_textview"

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -285,4 +285,8 @@
 
     <!-- Isochrone change -->
     <string name="click_on_map_instruction">Tap on the map!</string>
+
+    <!-- Tilequery API -->
+    <string name="api_response">Tilequery API response:</string>
+    <string name="api_error">Error with the request. Do you have internet access?</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -77,6 +77,7 @@
     <string name="activity_java_services_matrix_api_description">Use the Directions Matrix API to receive driving times between 2-25 different locations.</string>
     <string name="activity_java_services_geocoding_description">Use the Geocoding API to receive information about specific coordinates.</string>
     <string name="activity_java_services_isochrone_description">Use the Isochrone API to receive information about how far you can travel within a given time.</string>
+    <string name="activity_java_services_tilequery_description">Use the Tilequery API to search for features in a tileset.</string>
     <string name="activity_plugins_traffic_plugin_description">Use the traffic plugin to display live car congestion data on top of a map.</string>
     <string name="activity_plugins_building_plugin_description">Use the building plugin to easily display 3D building height</string>
     <string name="activity_location_location_component_description">Use the location component to easily show a user\'s location on the map</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -77,7 +77,7 @@
     <string name="activity_java_services_matrix_api_description">Use the Directions Matrix API to receive driving times between 2-25 different locations.</string>
     <string name="activity_java_services_geocoding_description">Use the Geocoding API to receive information about specific coordinates.</string>
     <string name="activity_java_services_isochrone_description">Use the Isochrone API to receive information about how far you can travel within a given time.</string>
-    <string name="activity_java_services_tilequery_description">Use the Tilequery API to search for features in a tileset.</string>
+    <string name="activity_java_services_tilequery_description">Use the Tilequery API to search for features in a tileset. This example queries for up to 10 buildings which are within 50 meters of the single map click location.</string>
     <string name="activity_plugins_traffic_plugin_description">Use the traffic plugin to display live car congestion data on top of a map.</string>
     <string name="activity_plugins_building_plugin_description">Use the building plugin to easily display 3D building height</string>
     <string name="activity_location_location_component_description">Use the location component to easily show a user\'s location on the map</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -76,6 +76,7 @@
     <string name="activity_java_services_maxtrix_api_title">Retrieve travel times between many points</string>
     <string name="activity_java_services_geocoding_title">Make a geocode request</string>
     <string name="activity_java_services_isochrone_title">Make a isochrone request</string>
+    <string name="activity_java_services_tilequery_title">Make a tile query</string>
     <string name="activity_plugins_traffic_plugin_title">Display real-time traffic</string>
     <string name="activity_plugins_building_plugin_title">Display buildings in 3D</string>
     <string name="activity_location_location_component_title">Show a user\'s location</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -76,7 +76,7 @@
     <string name="activity_java_services_maxtrix_api_title">Retrieve travel times between many points</string>
     <string name="activity_java_services_geocoding_title">Make a geocode request</string>
     <string name="activity_java_services_isochrone_title">Make a isochrone request</string>
-    <string name="activity_java_services_tilequery_title">Make a tile query</string>
+    <string name="activity_java_services_tilequery_title">Make a tilequery request</string>
     <string name="activity_plugins_traffic_plugin_title">Display real-time traffic</string>
     <string name="activity_plugins_building_plugin_title">Display buildings in 3D</string>
     <string name="activity_location_location_component_title">Show a user\'s location</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -77,6 +77,7 @@
     <string name="activity_java_services_matrix_url" translatable="false">https://i.imgur.com/65RlfRZ.png</string>
     <string name="activity_java_services_geocoding_url" translatable="false">https://i.imgur.com/9xl3EF8.png</string>
     <string name="activity_java_services_isochrone_url" translatable="false">https://i.imgur.com/HKOSK6j.png</string>
+    <string name="activity_java_services_tilequery_url" translatable="false">https://i.imgur.com/nYV0sjJ.png</string>
     <string name="activity_plugins_traffic_plugin_url" translatable="false">http://i.imgur.com/HRriOVR.png</string>
     <string name="activity_plugins_building_plugin_url" translatable="false">http://i.imgur.com/Vcu67UR.png</string>
     <string name="activity_location_location_component_url" translatable="false">https://i.imgur.com/77PVsni.png</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -77,7 +77,7 @@
     <string name="activity_java_services_matrix_url" translatable="false">https://i.imgur.com/65RlfRZ.png</string>
     <string name="activity_java_services_geocoding_url" translatable="false">https://i.imgur.com/9xl3EF8.png</string>
     <string name="activity_java_services_isochrone_url" translatable="false">https://i.imgur.com/HKOSK6j.png</string>
-    <string name="activity_java_services_tilequery_url" translatable="false">https://i.imgur.com/nYV0sjJ.png</string>
+    <string name="activity_java_services_tilequery_url" translatable="false">http://i.imgur.com/VkOCYwq.jpg</string>
     <string name="activity_plugins_traffic_plugin_url" translatable="false">http://i.imgur.com/HRriOVR.png</string>
     <string name="activity_plugins_building_plugin_url" translatable="false">http://i.imgur.com/Vcu67UR.png</string>
     <string name="activity_location_location_component_url" translatable="false">https://i.imgur.com/77PVsni.png</string>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,8 +11,8 @@ ext {
 
             // Mapbox
             mapboxMapSdk             : '6.7.1',
-            mapboxTurf               : '4.1.0',
-            mapboxServices           : '4.1.0',
+            mapboxTurf               : '4.2.0',
+            mapboxServices           : '4.2.0',
             mapboxPluginBuilding     : '0.3.0',
             mapboxPluginPlaces       : '0.6.0',
             mapboxPluginLocalization : '0.5.0',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,12 +11,14 @@ ext {
 
             // Mapbox
             mapboxMapSdk             : '6.7.1',
-            mapboxTurf               : '4.1.1',
+            mapboxTurf               : '4.1.0',
+            mapboxServices           : '4.1.0',
             mapboxPluginBuilding     : '0.3.0',
             mapboxPluginPlaces       : '0.6.0',
             mapboxPluginLocalization : '0.5.0',
             mapboxPluginTraffic      : '0.6.0',
             mapboxChinaPlugin        : '0.4.7',
+            mapboxPluginMarkerView   : '0.1.0',
 
             // Support
             supportLib               : '28.0.0',
@@ -62,6 +64,7 @@ ext {
             // Mapbox
             mapboxMapSdk             : "com.mapbox.mapboxsdk:mapbox-android-sdk:${version.mapboxMapSdk}",
             mapboxTurf               : "com.mapbox.mapboxsdk:mapbox-sdk-turf:${version.mapboxTurf}",
+            mapboxServices           : "com.mapbox.mapboxsdk:mapbox-sdk-services:${version.mapboxServices}",
 
             // Mapbox plugins
             mapboxPluginBuilding     : "com.mapbox.mapboxsdk:mapbox-android-plugin-building:${version.mapboxPluginBuilding}",
@@ -69,6 +72,7 @@ ext {
             mapboxPluginLocalization : "com.mapbox.mapboxsdk:mapbox-android-plugin-localization:${version.mapboxPluginLocalization}",
             mapboxPluginTraffic      : "com.mapbox.mapboxsdk:mapbox-android-plugin-traffic:${version.mapboxPluginTraffic}",
             mapboxChinaPlugin        : "com.mapbox.mapboxsdk:mapbox-android-plugin-china:${version.mapboxChinaPlugin}",
+            mapboxPluginMarkerView   : "com.mapbox.mapboxsdk:mapbox-android-plugin-markerview:${version.mapboxPluginMarkerView}",
 
             // Support
             supportV4                : "com.android.support:support-v4:${version.supportLib}",


### PR DESCRIPTION
Resolves #863 by adding an example of Tilequery API usage.

Tests are crashing because the Java SDK dependency hasn't been updated in the Maps SDK yet, so the `MapboxTilequery` class can't be found by the demo app yet.  Creating a pr anyways so that everyone's aware of this work going on.

cc @osana @zugaldia 