### PR TITLE
Remove Transfuser Errata

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/AnimatedMarkerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/AnimatedMarkerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.annotations;
 
-// #-code-snippet: animated-marker-activity full-java
-
 import android.animation.ObjectAnimator;
 import android.animation.TypeEvaluator;
 import android.animation.ValueAnimator;
@@ -131,4 +129,3 @@ public class AnimatedMarkerActivity extends AppCompatActivity implements OnMapRe
     }
   }
 }
-// #-end-code-snippet: animated-marker-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/DrawCustomMarkerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/DrawCustomMarkerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.annotations;
 
-// #-code-snippet: draw-custom-marker-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -94,4 +92,3 @@ public class DrawCustomMarkerActivity extends AppCompatActivity {
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: draw-custom-marker-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/DrawGeojsonLineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/DrawGeojsonLineActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.annotations;
 
-// #-code-snippet: draw-geojson-line-activity full-java
-
 import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -163,4 +161,3 @@ public class DrawGeojsonLineActivity extends AppCompatActivity implements OnMapR
     }
   }
 }
-// #-end-code-snippet: draw-geojson-line-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/DrawMarkerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/DrawMarkerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.annotations;
 
-// #-code-snippet: draw-marker-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -87,4 +85,3 @@ public class DrawMarkerActivity extends AppCompatActivity {
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: draw-marker-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/DrawPolygonActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/DrawPolygonActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.annotations;
 
-// #-code-snippet: draw-polygon-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -107,4 +105,3 @@ public class DrawPolygonActivity extends AppCompatActivity {
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: draw-polygon-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/PolygonHolesActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/annotations/PolygonHolesActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.annotations;
 
-// #-code-snippet: polygon-holes-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -152,4 +150,3 @@ public class PolygonHolesActivity extends AppCompatActivity implements OnMapRead
     };
   }
 }
-// #-end-code-snippet: polygon-holes-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/MapboxMapOptionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/MapboxMapOptionActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.basics;
 
-// #-code-snippet: mapbox-map-option-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -94,4 +92,3 @@ public class MapboxMapOptionActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: mapbox-map-option-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/SimpleMapViewActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/SimpleMapViewActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.basics;
 
-// #-code-snippet: simple-map-view-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -84,4 +82,3 @@ public class SimpleMapViewActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: simple-map-view-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/SupportMapFragmentActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/SupportMapFragmentActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.basics;
 
-// #-code-snippet: support-map-fragment-activity full-java
-
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
@@ -67,4 +65,3 @@ public class SupportMapFragmentActivity extends AppCompatActivity {
     });
   }
 }
-// #-end-code-snippet: support-map-fragment-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/AnimateMapCameraActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/AnimateMapCameraActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.camera;
 
-// #-code-snippet: animate-map-camera-activity full-java
-
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -122,4 +120,3 @@ public class AnimateMapCameraActivity extends AppCompatActivity implements OnMap
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: animate-map-camera-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/BoundingBoxCameraActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/BoundingBoxCameraActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.camera;
 
-// #-code-snippet: bounding-box-camera-activity full-java
-
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -126,4 +124,3 @@ public class BoundingBoxCameraActivity extends AppCompatActivity implements OnMa
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: bounding-box-camera-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/RestrictCameraActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/RestrictCameraActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.camera;
 
-// #-code-snippet: restrict-camera-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -125,4 +123,3 @@ public class RestrictCameraActivity extends AppCompatActivity implements OnMapRe
     mapView.onLowMemory();
   }
 }
-// #-end-code-snippet: restrict-camera-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/AddRainFallStyleActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/AddRainFallStyleActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: add-rain-fall-style-activity full-java
-
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
@@ -157,4 +155,3 @@ public class AddRainFallStyleActivity extends AppCompatActivity implements OnMap
     }
   }
 }
-// #-end-code-snippet: add-rain-fall-style-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ChoroplethJsonVectorMixActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ChoroplethJsonVectorMixActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: choropleth-json-vector-mix-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -168,4 +166,3 @@ public class ChoroplethJsonVectorMixActivity extends AppCompatActivity implement
     return sb;
   }
 }
-// #-end-code-snippet: choropleth-json-vector-mix-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ChoroplethZoomChangeActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ChoroplethZoomChangeActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: choropleth-zoom-change-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -158,4 +156,3 @@ public class ChoroplethZoomChangeActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: choropleth-zoom-change-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleLayerClusteringActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleLayerClusteringActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: geojson-clustering-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
@@ -219,4 +217,3 @@ public class CircleLayerClusteringActivity extends AppCompatActivity {
 
   }
 }
-// #-end-code-snippet: geojson-clustering-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CreateHotspotsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CreateHotspotsActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: create-hotspots-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -154,4 +152,3 @@ public class CreateHotspotsActivity extends AppCompatActivity {
     }
   }
 }
-// #-end-code-snippet: create-hotspots-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ExpressionIntegrationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ExpressionIntegrationActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: temperature-change-activity full-java
-
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
@@ -409,4 +407,3 @@ public class ExpressionIntegrationActivity
     return -1;
   }
 }
-// #-end-code-snippet: temperature-change-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/HeatmapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/HeatmapActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: heatmap-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -233,4 +231,3 @@ public class HeatmapActivity extends AppCompatActivity {
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: heatmap-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ImageClusteringActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ImageClusteringActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: image-cluster-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -192,4 +190,3 @@ public class ImageClusteringActivity extends AppCompatActivity implements OnMapR
     mapboxMap.addLayer(count);
   }
 }
-// #-end-code-snippet: image-cluster-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/InfoWindowSymbolLayerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/InfoWindowSymbolLayerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: info-window-symbol-layer-activity full-java
-
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -453,4 +451,3 @@ public class InfoWindowSymbolLayerActivity extends AppCompatActivity implements
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: info-window-symbol-layer-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/MultipleGeometriesActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/MultipleGeometriesActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: multiple-geometries-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -139,4 +137,3 @@ public class MultipleGeometriesActivity extends AppCompatActivity implements OnM
     }
   }
 }
-// #-end-code-snippet: multiple-geometries-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/MultipleHeatmapStylingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/MultipleHeatmapStylingActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: multiple-heatmap-styling-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -428,4 +426,3 @@ public class MultipleHeatmapStylingActivity extends AppCompatActivity
     }
   }
 }
-// #-end-code-snippet: multiple-heatmap-styling-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/StyleCirclesCategoricallyActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/StyleCirclesCategoricallyActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: style-circles-categorically-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -118,4 +116,3 @@ public class StyleCirclesCategoricallyActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: style-circles-categorically-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/StyleLineIdentityPropertyActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/StyleLineIdentityPropertyActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-// #-code-snippet: style-line-identity-property-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -133,4 +131,3 @@ public class StyleLineIdentityPropertyActivity extends AppCompatActivity {
 
   }
 }
-// #-end-code-snippet: style-line-identity-property-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/AdjustExtrusionLightActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/AdjustExtrusionLightActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.extrusions;
 
-// #-code-snippet: adjust-extrusion-light-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -180,4 +178,3 @@ public class AdjustExtrusionLightActivity extends AppCompatActivity {
   }
 
 }
-// #-end-code-snippet: adjust-extrusion-light-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/Indoor3DMapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/Indoor3DMapActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.extrusions;
 
-// #-code-snippet: indoor-3d-map-activity full-java
-
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
@@ -124,4 +122,3 @@ public class Indoor3DMapActivity extends AppCompatActivity {
     }
   }
 }
-// #-end-code-snippet: indoor-3d-map-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/MarathonExtrusionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/MarathonExtrusionActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.extrusions;
 
-// #-code-snippet: marathon-extrusion-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -127,4 +125,3 @@ public class MarathonExtrusionActivity extends AppCompatActivity implements OnMa
     }
   }
 }
-// #-end-code-snippet: marathon-extrusion-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/PopulationDensityExtrusionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/PopulationDensityExtrusionActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.extrusions;
 
-// #-code-snippet: population-density-extrusion-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -214,4 +212,3 @@ public class PopulationDensityExtrusionActivity extends AppCompatActivity implem
   }
 
 }
-// #-end-code-snippet: population-density-extrusion-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/RotationExtrusionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/RotationExtrusionActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.extrusions;
 
-// #-code-snippet: rotation-extrusion-activity full-java
-
 import android.content.Context;
 import android.graphics.Color;
 import android.hardware.Sensor;
@@ -194,4 +192,3 @@ public class RotationExtrusionActivity extends AppCompatActivity implements Sens
     }
   }
 }
-// #-end-code-snippet: rotation-extrusion-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/DirectionsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/DirectionsActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.javaservices;
 
-// #-code-snippet: directions-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -192,4 +190,3 @@ public class DirectionsActivity extends AppCompatActivity {
     mapView.onLowMemory();
   }
 }
-// #-end-code-snippet: directions-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/GeocodingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/GeocodingActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.javaservices;
 
-// #-code-snippet: geocoding-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.ListPopupWindow;
@@ -263,4 +261,3 @@ public class GeocodingActivity extends AppCompatActivity implements OnMapReadyCa
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: geocoding-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MapMatchingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MapMatchingActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.javaservices;
 
-// #-code-snippet: map-matching-activity full-java
-
 import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -222,4 +220,3 @@ public class MapMatchingActivity extends AppCompatActivity {
     }
   }
 }
-// #-end-code-snippet: map-matching-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MatrixApiActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MatrixApiActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.javaservices;
 
-// #-code-snippet: matrix-api-activity full-java
-
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -349,4 +347,3 @@ public class MatrixApiActivity extends AppCompatActivity {
     }
   }
 }
-// #-end-code-snippet: matrix-api-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/OptimizationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/OptimizationActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.javaservices;
 
-// #-code-snippet: optimization-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -246,4 +244,3 @@ public class OptimizationActivity extends AppCompatActivity implements OnMapRead
     mapView.onLowMemory();
   }
 }
-// #-end-code-snippet: optimization-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/SimplifyPolylineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/SimplifyPolylineActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.javaservices;
 
-// #-code-snippet: simplify-polyline-activity full-java
-
 import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -194,4 +192,3 @@ public class SimplifyPolylineActivity extends AppCompatActivity {
       .width(4));
   }
 }
-// #-end-code-snippet: simplify-polyline-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/StaticImageActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/StaticImageActivity.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.javaservices;
 
-// #-code-snippet: static-image-activity full-java
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -159,4 +158,3 @@ public class StaticImageActivity extends AppCompatActivity implements
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: static-image-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/CalendarIntegrationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/CalendarIntegrationActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: calendar-integration-activity full-java
-
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
@@ -354,4 +352,3 @@ public class CalendarIntegrationActivity extends AppCompatActivity implements
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: calendar-integration-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/DashedLineDirectionsPickerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/DashedLineDirectionsPickerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: dashed-directions-line-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -220,4 +218,3 @@ public class DashedLineDirectionsPickerActivity extends AppCompatActivity
     mapView.onLowMemory();
   }
 }
-// #-end-code-snippet: dashed-directions-line-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/InsetMapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/InsetMapActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: inset-mini-map-activity full-java
-
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -301,4 +299,3 @@ public class InsetMapActivity extends AppCompatActivity implements OnMapReadyCal
     }
   }
 }
-// #-end-code-snippet: inset-mini-map-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/LocationPickerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/LocationPickerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: location-picker-activity full-java
-
 import android.graphics.PointF;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -277,4 +275,3 @@ public class LocationPickerActivity extends AppCompatActivity implements Permiss
     }
   }
 }
-// #-end-code-snippet: location-picker-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MarkerFollowingRouteActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MarkerFollowingRouteActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: marker-following-activity full-java
-
 import android.animation.ObjectAnimator;
 import android.animation.TypeEvaluator;
 import android.animation.ValueAnimator;
@@ -266,4 +264,3 @@ public class MarkerFollowingRouteActivity extends AppCompatActivity {
     }
   }
 }
-// #-end-code-snippet: marker-following-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/PictureInPictureActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/PictureInPictureActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: picture-in-picture-activity full-java
-
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
@@ -111,4 +109,3 @@ public class PictureInPictureActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: picture-in-picture-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/PulsingLayerOpacityColorActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/PulsingLayerOpacityColorActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: la-tourism-activity full-java
-
 import android.animation.ArgbEvaluator;
 import android.animation.ValueAnimator;
 import android.graphics.Color;
@@ -272,4 +270,3 @@ public class PulsingLayerOpacityColorActivity extends AppCompatActivity implemen
     }
   }
 }
-// #-code-snippet: la-tourism-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/RecyclerViewOnMapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/RecyclerViewOnMapActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: recyclerview-on-map-activity full-java
-
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
@@ -285,4 +283,3 @@ public class RecyclerViewOnMapActivity extends AppCompatActivity implements OnMa
     void onClick(View view, int position);
   }
 }
-// #-end-code-snippet: recyclerview-on-map-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SnakingDirectionsRouteActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SnakingDirectionsRouteActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: snaking-directions-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -230,4 +228,3 @@ public class SnakingDirectionsRouteActivity extends AppCompatActivity
     mapView.onLowMemory();
   }
 }
-// #-end-code-snippet: snaking-directions-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SpaceStationLocationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SpaceStationLocationActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: space-station-activity full-java
-
 import android.animation.ObjectAnimator;
 import android.animation.TypeEvaluator;
 import android.animation.ValueAnimator;
@@ -243,4 +241,3 @@ public class SpaceStationLocationActivity extends AppCompatActivity {
     Call<IssModel> loadLocation();
   }
 }
-// #-end-code-snippet: space-station-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SymbolLayerMapillaryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SymbolLayerMapillaryActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.labs;
 
-// #-code-snippet: mapillary-symbol-layer-activity full-java
-
 import android.animation.Animator;
 import android.animation.AnimatorSet;
 import android.animation.TypeEvaluator;
@@ -1180,4 +1178,3 @@ public class SymbolLayerMapillaryActivity extends AppCompatActivity implements O
     void onClick(View view, int position);
   }
 }
-// #-end-code-snippet: mapillary-symbol-layer-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/offline/OfflineManagerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/offline/OfflineManagerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.offline;
 
-// #-code-snippet: offline-manager-activity full-java
-
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -433,4 +431,3 @@ public class OfflineManagerActivity extends AppCompatActivity {
     Toast.makeText(OfflineManagerActivity.this, message, Toast.LENGTH_LONG).show();
   }
 }
-// #-end-code-snippet: offline-manager-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/offline/SimpleOfflineMapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/offline/SimpleOfflineMapActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.offline;
 
-// #-code-snippet: simple-offline-map-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -242,4 +240,3 @@ public class SimpleOfflineMapActivity extends AppCompatActivity {
     Toast.makeText(SimpleOfflineMapActivity.this, message, Toast.LENGTH_LONG).show();
   }
 }
-// #-end-code-snippet: simple-offline-map-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/BuildingPluginActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.plugins;
 
-// #-code-snippet: building-plugin-activity full-java
-
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -84,4 +82,3 @@ public class BuildingPluginActivity extends AppCompatActivity {
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: building-plugin-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocalizationPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocalizationPluginActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.plugins;
 
-// #-code-snippet: localization-plugin-activity full-java
-
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
@@ -130,4 +128,3 @@ public class LocalizationPluginActivity extends AppCompatActivity implements OnM
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: localization-plugin-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.plugins;
 
-// #-code-snippet: location-plugin-activity full-java
-
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -132,4 +130,3 @@ public class LocationPluginActivity extends AppCompatActivity implements
     mapView.onLowMemory();
   }
 }
-// #-end-code-snippet: location-plugin-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginFragmentActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocationPluginFragmentActivity.java
@@ -25,8 +25,6 @@ import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 
 import java.util.List;
 
-// #-code-snippet: location-plugin-fragment-activity full-java
-
 public class LocationPluginFragmentActivity extends AppCompatActivity implements
   MapFragment.OnMapViewReadyCallback, PermissionsListener {
 
@@ -130,4 +128,3 @@ public class LocationPluginFragmentActivity extends AppCompatActivity implements
     }
   }
 }
-// #-end-code-snippet: location-plugin-fragment-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlaceSelectionPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlaceSelectionPluginActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.plugins;
 
-// #-code-snippet: place-selection-plugin-activity full-java
-
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -79,4 +77,3 @@ public class PlaceSelectionPluginActivity extends AppCompatActivity {
     }
   }
 }
-// #-end-code-snippet: place-selection-plugin-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlacesPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlacesPluginActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.plugins;
 
-// #-code-snippet: places-plugin-activity full-java
-
 import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
@@ -197,4 +195,3 @@ public class PlacesPluginActivity extends AppCompatActivity implements OnMapRead
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: places-plugin-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/TrafficPluginActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.plugins;
 
-// #-code-snippet: traffic-plugin-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -97,4 +95,3 @@ public class TrafficPluginActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: traffic-plugin-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/BuildingOutlineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/BuildingOutlineActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.query;
 
-// #-code-snippet: building-outline-activity full-java
-
 import android.graphics.Color;
 import android.graphics.PointF;
 import android.os.Bundle;
@@ -193,4 +191,3 @@ public class BuildingOutlineActivity extends AppCompatActivity implements
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: building-outline-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/ClickOnLayerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/ClickOnLayerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.query;
 
-// #-code-snippet: click-on-layer-activity full-java
-
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Bundle;
@@ -144,4 +142,3 @@ public class ClickOnLayerActivity extends AppCompatActivity implements OnMapRead
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: click-on-layer-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/FeatureCountActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/FeatureCountActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.query;
 
-// #-code-snippet: feature-count-activity full-java
-
 import android.graphics.Color;
 import android.graphics.RectF;
 import android.os.Bundle;
@@ -137,4 +135,3 @@ public class FeatureCountActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: feature-count-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/HighlightedLineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/HighlightedLineActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.query;
 
-// #-code-snippet: highlighted-line-activity full-java
-
 import android.graphics.Color;
 import android.graphics.PointF;
 import android.graphics.RectF;
@@ -191,4 +189,3 @@ public class HighlightedLineActivity extends AppCompatActivity implements
     }
   }
 }
-// #-end-code-snippet: highlighted-line-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/QueryFeatureActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/QueryFeatureActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.query;
 
-// #-code-snippet: query-feature-activity full-java
-
 import android.graphics.PointF;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -141,4 +139,3 @@ public class QueryFeatureActivity extends AppCompatActivity implements OnMapRead
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: query-feature-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/RedoSearchInAreaActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/RedoSearchInAreaActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.query;
 
-// #-code-snippet: redo-search-activity full-java
-
 import android.graphics.Color;
 import android.graphics.RectF;
 import android.os.Bundle;
@@ -195,4 +193,3 @@ public class RedoSearchInAreaActivity extends AppCompatActivity implements OnMap
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: redo-search-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/SelectBuildingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/SelectBuildingActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.query;
 
-// #-code-snippet: select-building-activity full-java
-
 import android.graphics.Color;
 import android.graphics.PointF;
 import android.os.Bundle;
@@ -136,4 +134,3 @@ public class SelectBuildingActivity extends AppCompatActivity implements OnMapRe
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: select-building-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotNotificationActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.snapshot;
 
-// #-code-snippet: snapshot-notification-activity full-java
-
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -181,4 +179,3 @@ public class SnapshotNotificationActivity extends AppCompatActivity implements O
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: snapshot-notification-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotShareActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotShareActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.snapshot;
 
-// #-code-snippet: snapshot-share-activity full-java
-
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -190,4 +188,3 @@ public class SnapshotShareActivity extends AppCompatActivity {
     mapView.onDestroy();
   }
 }
-// #-end-code-snippet: snapshot-share-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/AddWmsSourceActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/AddWmsSourceActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: add-wms-source-activity full-java
-
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
@@ -96,4 +94,3 @@ public class AddWmsSourceActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: add-wms-source-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/AdjustLayerOpacityActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/AdjustLayerOpacityActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: adjust-layer-opacity-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.widget.SeekBar;
@@ -125,4 +123,3 @@ public class AdjustLayerOpacityActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: adjust-layer-opacity-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/BasicSymbolLayerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/BasicSymbolLayerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: basic-symbol-layer-activity full-java
-
 import android.animation.ValueAnimator;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -206,4 +204,3 @@ public class BasicSymbolLayerActivity extends AppCompatActivity implements
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: basic-symbol-layer-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ColorSwitcherActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ColorSwitcherActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: color-switcher-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -205,4 +203,3 @@ public class ColorSwitcherActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: color-switcher-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/DefaultStyleActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/DefaultStyleActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: default-style-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
@@ -124,4 +122,3 @@ public class DefaultStyleActivity extends AppCompatActivity {
     }
   }
 }
-// #-end-code-snippet: default-style-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/GeojsonLayerInStackActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/GeojsonLayerInStackActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: geojson-layer-in-stack-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -106,4 +104,3 @@ public class GeojsonLayerInStackActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: geojson-layer-in-stack-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/HillShadeActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/HillShadeActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: hill-shade-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -106,4 +104,3 @@ public class HillShadeActivity extends AppCompatActivity implements
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: hill-shade-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ImageSourceActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ImageSourceActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: image-source-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -108,4 +106,3 @@ public class ImageSourceActivity extends AppCompatActivity implements OnMapReady
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: image-source-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ImageSourceTimeLapseActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ImageSourceTimeLapseActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: image-source-time-lapse-activity full-java
-
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
@@ -137,4 +135,3 @@ public class ImageSourceTimeLapseActivity extends AppCompatActivity implements O
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: image-source-time-lapse-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LanguageSwitchActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LanguageSwitchActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: language-switch-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
@@ -122,4 +120,3 @@ public class LanguageSwitchActivity extends AppCompatActivity {
     return super.onOptionsItemSelected(item);
   }
 }
-// #-end-code-snippet: language-switch-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LineLayerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LineLayerActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: line-layer-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -180,4 +178,3 @@ public class LineLayerActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: line-layer-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LocalStyleSourceActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LocalStyleSourceActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: local-style-source-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -101,4 +99,3 @@ public class LocalStyleSourceActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: local-style-source-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/MapboxStudioStyleActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/MapboxStudioStyleActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: mapbox-studio-style-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -83,4 +81,3 @@ public class MapboxStudioStyleActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: mapbox-studio-style-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ShowHideLayersActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ShowHideLayersActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: show-hide-layers-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.design.widget.FloatingActionButton;
@@ -130,4 +128,3 @@ public class ShowHideLayersActivity extends AppCompatActivity {
     }
   }
 }
-// #-end-code-snippet: show-hide-layers-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/StyleFadeSwitchActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/StyleFadeSwitchActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: style-fade-switch-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -125,4 +123,3 @@ public class StyleFadeSwitchActivity extends AppCompatActivity implements
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: style-fade-switch-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/TransparentBackgroundActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/TransparentBackgroundActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: transparent-surface-activity full-java
-
 import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
@@ -140,4 +138,3 @@ public class TransparentBackgroundActivity extends AppCompatActivity implements 
     return json;
   }
 }
-// #-end-code-snippet: transparent-surface-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/VectorSourceActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/VectorSourceActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: vector-source-activity full-java
-
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -104,4 +102,3 @@ public class VectorSourceActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: vector-source-activity full-java

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ZoomDependentFillColorActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ZoomDependentFillColorActivity.java
@@ -1,7 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-// #-code-snippet: zoom-dependent-fill-color-activity full-java
-
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 
@@ -107,4 +105,3 @@ public class ZoomDependentFillColorActivity extends AppCompatActivity {
     mapView.onSaveInstanceState(outState);
   }
 }
-// #-end-code-snippet: zoom-dependent-fill-color-activity full-java


### PR DESCRIPTION
Per @colleenmcginnis's [comment](https://github.com/mapbox/android-docs/pull/639#pullrequestreview-160543264) in mapbox/android-docs#639. This PR removes the code comments that were required to use the [`example-transfuser`](https://github.com/mapbox/example-transfuser). Now that the docs are referencing submodules, those comments are no longer necessary and if anything would only be contributing needless noise to our code snippets.

cc: @mapbox/maps-android 