### PR TITLE
Use Kotlin-Android-Extensions to remove extra code

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -154,3 +154,4 @@ dependencies {
 }
 
 apply from: "${rootDir}/gradle/checkstyle.gradle"
+apply plugin: 'kotlin-android-extensions'

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/KotlinSimpleMapViewActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/KotlinSimpleMapViewActivity.kt
@@ -6,14 +6,12 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import com.mapbox.mapboxandroiddemo.R
 import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.maps.MapView
+import kotlinx.android.synthetic.main.activity_basic_simple_kotlin.*
 
 /**
  * The most basic example of adding a map to an activity with Kotlin code
  */
 class SimpleMapViewActivityKotlin : AppCompatActivity() {
-
-    private lateinit var mapView: MapView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,7 +23,6 @@ class SimpleMapViewActivityKotlin : AppCompatActivity() {
         // This contains the MapView in XML and needs to be called after the access token is configured.
         setContentView(R.layout.activity_basic_simple_kotlin)
 
-        mapView = findViewById(R.id.mapView)
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync {
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/KotlinStyleCirclesCategoricallyActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/KotlinStyleCirclesCategoricallyActivity.kt
@@ -4,18 +4,17 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import com.mapbox.mapboxandroiddemo.R
 import com.mapbox.mapboxsdk.Mapbox
-import com.mapbox.mapboxsdk.maps.MapView
 import com.mapbox.mapboxsdk.style.expressions.Expression.*
 import com.mapbox.mapboxsdk.style.layers.CircleLayer
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius
 import com.mapbox.mapboxsdk.style.sources.VectorSource
+import kotlinx.android.synthetic.main.activity_dds_kotlin_style_circles_categorically.*
 
 /**
  * Kotlin example of using data-driven styling to set circles' colors based on imported vector data.
  */
 class KotlinStyleCirclesCategoricallyActivity : AppCompatActivity() {
-    private lateinit var mapView: MapView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,7 +26,6 @@ class KotlinStyleCirclesCategoricallyActivity : AppCompatActivity() {
         // This contains the MapView in XML and needs to be called after the access token is configured.
         setContentView(R.layout.activity_dds_kotlin_style_circles_categorically)
 
-        mapView = findViewById(R.id.mapView)
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync { mapboxMap ->
             val vectorSource = VectorSource(


### PR DESCRIPTION
Add `kotlin-android-extensions` plugin and remove unnecessary `lateinit` and `findViewById`

Addresses this comment: https://github.com/mapbox/mapbox-android-demo/pull/872#discussion_r222623503