### PR TITLE
Update Mapbox Maps SDK for Android to v6.7.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     version = [
 
             // Mapbox
-            mapboxMapSdk             : '6.6.0',
+            mapboxMapSdk             : '6.6.7-alpha.1',
             mapboxTurf               : '4.0.0',
             mapboxPluginBuilding     : '0.3.0',
             mapboxPluginPlaces       : '0.6.0',


### PR DESCRIPTION
This PR is part of our QA process upstream in GL-native:
 - [x] alpha.1
 - [ ] alpha.2
 - [ ] beta.1
 - [ ] final 