### PR TITLE
Extending MultiDexApplication

### DIFF
--- a/MapboxAndroidDemo/src/gpservices/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
+++ b/MapboxAndroidDemo/src/gpservices/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
@@ -1,6 +1,6 @@
 package com.mapbox.mapboxandroiddemo;
 
-import android.app.Application;
+import android.support.multidex.MultiDexApplication;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -8,7 +8,7 @@ import com.mapbox.mapboxsdk.Mapbox;
 import com.squareup.picasso.OkHttpDownloader;
 import com.squareup.picasso.Picasso;
 
-public class MapboxApplication extends Application {
+public class MapboxApplication extends MultiDexApplication {
 
   @Override
   public void onCreate() {


### PR DESCRIPTION
This pr adjusts `MapboxApplication` to extend `MultiDexApplication` because multidex is true in the Gradle file. 

Related to @DonTomika 's comment in #889 