### PR TITLE
adding LoadingActivity back to manifest

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -686,6 +686,10 @@
                     android:scheme="mapbox-android-dev-preview" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".account.LoadingActivity"
+            android:screenOrientation="portrait" />
     </application>
 
 </manifest>


### PR DESCRIPTION
LoadingActivity was accidentally removed in https://github.com/mapbox/mapbox-android-demo/commit/d0e61bc5286be13a700fc1a840b357e702ff8330#commitcomment-30978034. This pr adds it back to to the manifest.