### PR TITLE
CI Play Store gradle release name update

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -93,5 +93,5 @@ jobs:
             echo "${PLAY_PUBLISH_AUTH_JSON}" > android-gl-native-6d21dd280e7b.json
       - run:
           name: Release to Google Play
-          command: ./gradlew publishGpservicesRelease
+          command: ./gradlew publishGlobalRelease
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The naming of the app's flavors changed recently. We forgot to update the Play Store release task name. This pr updates it. 

`./gradlew tasks` shows that `publishGlobalRelease` is the one to go with:

![screen shot 2018-11-09 at 11 35 18 am](https://user-images.githubusercontent.com/4394910/48284194-8dd72980-e413-11e8-8e51-32ba942c3fa7.png)
