### PR TITLE
Added LoadingActivity back to global flavor manifest

### DIFF
--- a/MapboxAndroidDemo/src/global/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/global/AndroidManifest.xml
@@ -357,7 +357,10 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity"/>
         </activity>
-
+        <activity
+            android:name=".account.LoadingActivity"
+            android:screenOrientation="portrait">
+        </activity>
         <activity
             android:name=".account.LandingActivity"
             android:screenOrientation="portrait">


### PR DESCRIPTION
Added 

```
<activity
            android:name=".account.LoadingActivity"
            android:screenOrientation="portrait">
        </activity>
```
back into the manifest file for the app's global flavor. This fixes an account sign in crash.