### PR TITLE
Dropped gradle from 3.2.1 to 3.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ ext {
     pluginVersion = [
             checkstyle         : '8.2',
             firebase           : '1.1.1',
-            gradle             : '3.2.1',
+            gradle             : '3.1.0',
             gradlePlayPublisher: '1.2.0',
             kotlin             : '1.2.71'
     ]


### PR DESCRIPTION
I'm trying to push a new release of the app to the Play Store. CI test is throwing memory size issues after [tagging this release](https://github.com/mapbox/mapbox-android-demo/releases/tag/6.7.0-2). 

Tobrun found and recommended the suggestions at https://stackoverflow.com/questions/52793948/android-studio-build-error-with-error-log-of-process-unexpectedly-exit-in-ubun . This pr drops the Gradle tools version down. 