### PR TITLE
Adding background fog example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -78,6 +78,7 @@ import com.mapbox.mapboxandroiddemo.examples.labs.IndoorMapActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.InsetMapActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.LocationPickerActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.MagicWindowKotlinActivity;
+import com.mapbox.mapboxandroiddemo.examples.labs.MapFogBackgroundActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.MarkerFollowingRouteActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.PictureInPictureActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.PulsingLayerOpacityColorActivity;
@@ -975,6 +976,15 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, SnakingDirectionsRouteActivity.class),
       null,
       R.string.activity_labs_snaking_directions_route_url, false, BuildConfig.MIN_SDK_VERSION
+    ));
+
+    exampleItemModels.add(new ExampleItemModel(
+        R.id.nav_lab,
+        R.string.activity_lab_fog_background_title,
+        R.string.activity_lab_fog_background_description,
+        new Intent(MainActivity.this, MapFogBackgroundActivity.class),
+        null,
+        R.string.activity_lab_fog_background_url, false, BuildConfig.MIN_SDK_VERSION
     ));
 
     exampleItemModels.add(new ExampleItemModel(

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -702,6 +702,14 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.labs.MapFogBackgroundActivity"
+            android:label="@string/activity_lab_fog_background_title"
+            android:screenOrientation="portrait">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.SimpleChinaMapViewActivity"
             android:label="@string/activity_china_simple_china_mapview_title"
             android:screenOrientation="portrait">

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MapFogBackgroundActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MapFogBackgroundActivity.java
@@ -1,0 +1,86 @@
+package com.mapbox.mapboxandroiddemo.examples.labs;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.plugins.building.BuildingPlugin;
+
+/**
+ * Add a gradient on top of the MapView to create the effect of the map coming out of a
+ * background fog.
+ */
+public class MapFogBackgroundActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private MapView mapView;
+  private BuildingPlugin buildingPlugin;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_map_fog_background);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(MapboxMap mapboxMap) {
+    buildingPlugin = new BuildingPlugin(mapView, mapboxMap);
+    buildingPlugin.setVisibility(true);
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MapFogBackgroundActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MapFogBackgroundActivity.java
@@ -11,7 +11,7 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.plugins.building.BuildingPlugin;
 
 /**
- * Add a gradient on top of the MapView to create the effect of the map coming out of a
+ * Add an ImageView gradient on top of the MapView to create the effect of the map coming out of a
  * background fog.
  */
 public class MapFogBackgroundActivity extends AppCompatActivity implements OnMapReadyCallback {
@@ -37,6 +37,8 @@ public class MapFogBackgroundActivity extends AppCompatActivity implements OnMap
 
   @Override
   public void onMapReady(MapboxMap mapboxMap) {
+
+    // Using the Mapbox Building Plugin to easily display 3D extrusions on the map
     buildingPlugin = new BuildingPlugin(mapView, mapboxMap);
     buildingPlugin.setVisibility(true);
   }

--- a/MapboxAndroidDemo/src/main/res/drawable/fog_background_gradient.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable/fog_background_gradient.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle">
+
+    <gradient
+        android:angle="90"
+        android:centerColor="#D8E8F6"
+        android:endColor="#73ABDD"
+        android:startColor="#00ffffff"/>
+
+    <corners android:radius="0dp"/>
+</shape>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_map_fog_background.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_map_fog_background.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="-23.5485"
+        mapbox:mapbox_cameraTargetLng="-46.6217"
+        mapbox:mapbox_cameraTilt="59"
+        mapbox:mapbox_cameraZoom="17.17"
+        mapbox:mapbox_cameraZoomMax="18.02"
+        mapbox:mapbox_styleUrl="@string/mapbox_style_mapbox_streets"/>
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="250dp"
+        android:src="@drawable/fog_background_gradient"/>
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -104,6 +104,7 @@
     <string name="activity_dashed_line_directions_picker_description">Show a dotted directions route to a location that\'s based on map movement.</string>
     <string name="activity_lab_calendar_integration_description">Show calendar event locations on the map.</string>
     <string name="activity_lab_magic_window_description">Combine two maps for a magic window effect</string>
+    <string name="activity_lab_fog_background_description">Add a gradient on top of a MapView to show a background fog effect.</string>
     <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
 
 

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -102,6 +102,7 @@
     <string name="activity_dashed_line_directions_picker_title">Directions to selected location</string>
     <string name="activity_lab_calendar_integration_title">Calendar integration</string>
     <string name="activity_lab_magic_window_title">Magic Window</string>
+    <string name="activity_lab_fog_background_title">Background fog</string>
     <string name="activity_china_simple_china_mapview_title">China map view</string>
 
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -105,6 +105,7 @@
     <string name="activity_dashed_line_directions_picker_url" translatable="false">https://i.imgur.com/0dpCI14.png</string>
     <string name="activity_lab_calendar_integration_url" translatable="false">https://i.imgur.com/M8TU7nH.png</string>
     <string name="activity_lab_magic_window_image_url">https://i.imgur.com/Nw78ZrV.png</string>
+    <string name="activity_lab_fog_background_url">https://i.imgur.com/NcSGgD8.png</string>
     <string name="activity_china_simple_china_mapview_url" translatable="false">https://i.imgur.com/KwoEynZ.png</string>
 
 </resources>


### PR DESCRIPTION
This pr shows how to add "background fog" to the map experience. It creates a rough effect of the buildings coming out of fog, similar to what Baidu Maps does.

**Baidu:**
![ezgif com-resize-1](https://user-images.githubusercontent.com/4394910/49026967-f9c7ca80-f153-11e8-8fde-2ea8ac081547.gif)

**Demo app:**
![ezgif com-optimize](https://user-images.githubusercontent.com/4394910/49026974-fb918e00-f153-11e8-983c-e9eae70b8a19.gif)
