### PR TITLE
Adding ClickToAddImageActivity example to MainActivity

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -557,6 +557,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       R.string.activity_style_image_source_url, false, BuildConfig.MIN_SDK_VERSION
     ));
     exampleItemModels.add(new ExampleItemModel(
+        R.id.nav_styles,
+        R.string.activity_styles_click_to_add_image_title,
+        R.string.activity_styles_click_to_add_image_description,
+        new Intent(MainActivity.this, ClickToAddImageActivity.class),
+        null,
+        R.string.activity_styles_click_to_add_image_url, false, BuildConfig.MIN_SDK_VERSION
+    ));
+    exampleItemModels.add(new ExampleItemModel(
       R.id.nav_styles,
       R.string.activity_style_image_source_time_lapse_title,
       R.string.activity_style_image_source_time_lapse_description,

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MarkerFollowingRouteActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MarkerFollowingRouteActivity.java
@@ -127,7 +127,6 @@ public class MarkerFollowingRouteActivity extends AppCompatActivity {
             markerIconCurrentLocation = (LatLng) markerIconAnimator.getAnimatedValue();
             markerIconAnimator.cancel();
           }
-
           if (latLngEvaluator != null) {
             markerIconAnimator = ObjectAnimator
               .ofObject(latLngEvaluator, count == 0 ? new LatLng(37.61501, -122.385374)

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ClickToAddImageActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ClickToAddImageActivity.java
@@ -99,7 +99,7 @@ public class ClickToAddImageActivity extends AppCompatActivity implements
 
     boundsFeatureList.add(Feature.fromGeometry(Point.fromLngLat(point.getLongitude(), point.getLatitude())));
 
-    // Add the click point to the circle layer and update the display of the circle layer data
+    // Add the click point to the CircleLayer and update the display of the CircleLayer data
     boundsCirclePointList.add(Point.fromLngLat(point.getLongitude(), point.getLatitude()));
 
     Style style = mapboxMap.getStyle();
@@ -130,7 +130,6 @@ public class ClickToAddImageActivity extends AppCompatActivity implements
       pickPhotoIntent.setType("image/*");
       startActivityForResult(pickPhotoIntent, PHOTO_PICK_CODE);
     }
-
     return true;
   }
 
@@ -172,7 +171,7 @@ public class ClickToAddImageActivity extends AppCompatActivity implements
           @Override
           public void onStyleLoaded(@NonNull Style style) {
             Uri selectedImage = data.getData();
-            InputStream imageStream = null;
+            InputStream imageStream;
             try {
               imageStream = getContentResolver().openInputStream(selectedImage);
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ClickToAddImageActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ClickToAddImageActivity.java
@@ -47,12 +47,12 @@ public class ClickToAddImageActivity extends AppCompatActivity implements
   private static final String ID_IMAGE_SOURCE = "source-id";
   private static final String CIRCLE_SOURCE_ID = "circle-source-id";
   private static final String ID_IMAGE_LAYER = "layer-id";
+  private static int PHOTO_PICK_CODE = 4;
   private MapView mapView;
   private MapboxMap mapboxMap;
   private LatLngQuad quad;
   private List<Feature> boundsFeatureList;
   private List<Point> boundsCirclePointList;
-  private static int PHOTO_PICK_CODE = 4;
   private int imageCountIndex;
 
   @Override


### PR DESCRIPTION
[The `ClickToAddImageActivity` had already been added to the demo app](https://github.com/mapbox/mapbox-android-demo/pull/852). But amidst the restructuring of the app to account for the China flavor, `ClickToAddImageActivity` got removed from the `MainActivity` example list. This pr re-adds it to `MainActivity` so that the example actually appears in the app.

