### PR TITLE
Symbol switch based on zoom level example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -57,6 +57,7 @@ import com.mapbox.mapboxandroiddemo.examples.dds.PolygonHolesActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.SatelliteLandSelectActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.StyleCirclesCategoricallyActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.StyleLineIdentityPropertyActivity;
+import com.mapbox.mapboxandroiddemo.examples.dds.SymbolSwitchOnZoomActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.AdjustExtrusionLightActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.Indoor3DMapActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.MarathonExtrusionActivity;
@@ -1213,6 +1214,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, SatelliteLandSelectActivity.class),
       null,
       R.string.activity_dds_satellite_land_select_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_dds,
+      R.string.activity_dds_symbol_zoom_switch_title,
+      R.string.activity_dds_symbol_zoom_switch_description,
+      new Intent(MainActivity.this, SymbolSwitchOnZoomActivity.class),
+      null,
+      R.string.activity_dds_symbol_zoom_switch_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_basics,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -629,6 +629,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.dds.SymbolSwitchOnZoomActivity"
+            android:label="@string/activity_dds_symbol_zoom_switch_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.camera.RestrictCameraActivity"
             android:label="@string/activity_camera_restrict_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolSwitchOnZoomActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolSwitchOnZoomActivity.java
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
-import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -17,6 +16,7 @@ import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.step;
@@ -55,73 +55,63 @@ public class SymbolSwitchOnZoomActivity extends AppCompatActivity implements OnM
 
   @Override
   public void onMapReady(final MapboxMap mapboxMap) {
-    mapboxMap.setStyle(Style.OUTDOORS, new Style.OnStyleLoaded() {
-      @Override
-      public void onStyleLoaded(@NonNull Style style) {
-        initLayerIcons(style);
-        addDataToMap(style);
-        Toast.makeText(SymbolSwitchOnZoomActivity.this,
-          R.string.zoom_map_in_and_out_icon_switch_instruction, Toast.LENGTH_SHORT).show();
-      }
-    });
-  }
 
-  /**
-   * Add images to the map so that the SymbolLayers can reference the images.
-   */
-  private void initLayerIcons(@NonNull Style loadedMapStyle) {
-    loadedMapStyle.addImage(BLUE_PERSON_ICON_ID, BitmapFactory.decodeResource(
-      getResources(), R.drawable.ic_person));
-    loadedMapStyle.addImage(BLUE_PIN_ICON_ID, BitmapFactory.decodeResource(
-      getResources(), R.drawable.blue_marker));
-  }
+    mapboxMap.setStyle(new Style.Builder().fromUrl(Style.OUTDOORS)
 
-  /**
-   * Add the data, source, and SymbolLayer to the map
-   */
-  private void addDataToMap(@NonNull Style loadedMapStyle) {
-    // Add random data to the GeoJsonSource and then add the GeoJsonSource to the map
-    loadedMapStyle.addSource(
-      new GeoJsonSource("source-id",
-        FeatureCollection.fromFeatures(new Feature[] {
-          Feature.fromGeometry(Point.fromLngLat(
-            9.205394983291626,
-            45.47661043757903)),
-          Feature.fromGeometry(Point.fromLngLat(
-            9.223880767822266,
-            45.47623240235297)),
-          Feature.fromGeometry(Point.fromLngLat(
-            9.15530204772949,
-            45.4706650227671)),
-          Feature.fromGeometry(Point.fromLngLat(
-            9.153714179992676,
-            45.48625229963004)),
-          Feature.fromGeometry(Point.fromLngLat(
-            9.158306121826172,
-            45.482731998239636)),
-          Feature.fromGeometry(Point.fromLngLat(
-            9.188523888587952,
-            45.4923746929562)),
-          Feature.fromGeometry(Point.fromLngLat(
-            9.20929491519928,
-            45.45314676076135)),
-          Feature.fromGeometry(Point.fromLngLat(
-            9.177778959274292,
-            45.45569808340158))
-        })
-      )
+        // Add images to the map so that the SymbolLayers can reference the images.
+        .withImage(BLUE_PERSON_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+          getResources().getDrawable(R.drawable.ic_person)))
+        .withImage(BLUE_PIN_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+          getResources().getDrawable(R.drawable.blue_marker)))
+
+        // Add random data to the GeoJsonSource and then add the GeoJsonSource to the map
+        .withSource(new GeoJsonSource("source-id",
+          FeatureCollection.fromFeatures(new Feature[] {
+            Feature.fromGeometry(Point.fromLngLat(
+              9.205394983291626,
+              45.47661043757903)),
+            Feature.fromGeometry(Point.fromLngLat(
+              9.223880767822266,
+              45.47623240235297)),
+            Feature.fromGeometry(Point.fromLngLat(
+              9.15530204772949,
+              45.4706650227671)),
+            Feature.fromGeometry(Point.fromLngLat(
+              9.153714179992676,
+              45.48625229963004)),
+            Feature.fromGeometry(Point.fromLngLat(
+              9.158306121826172,
+              45.482731998239636)),
+            Feature.fromGeometry(Point.fromLngLat(
+              9.188523888587952,
+              45.4923746929562)),
+            Feature.fromGeometry(Point.fromLngLat(
+              9.20929491519928,
+              45.45314676076135)),
+            Feature.fromGeometry(Point.fromLngLat(
+              9.177778959274292,
+              45.45569808340158))
+          })
+        )), new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style style) {
+
+            // Create a SymbolLayer and use the {@link com.mapbox.mapboxsdk.style.expressions.Expression.step()}
+            // to adjust the SymbolLayer icon based on the zoom level. The blue person icon is set as the default
+            // icon and then a step is used to switch to the blue person icon at a certain map camera zoom level.
+            SymbolLayer singleLayer = new SymbolLayer("symbol-layer-id", "source-id");
+            singleLayer.setProperties(
+              iconImage(step(zoom(), literal(BLUE_PERSON_ICON_ID),
+                stop(ZOOM_LEVEL_FOR_SWITCH, BLUE_PIN_ICON_ID))),
+              iconIgnorePlacement(true),
+              iconAllowOverlap(true));
+            style.addLayer(singleLayer);
+
+            Toast.makeText(SymbolSwitchOnZoomActivity.this,
+              R.string.zoom_map_in_and_out_icon_switch_instruction, Toast.LENGTH_SHORT).show();
+          }
+        }
     );
-
-    // Create a SymbolLayer and use the {@link com.mapbox.mapboxsdk.style.expressions.Expression.step()}
-    // to adjust the SymbolLayer icon based on the zoom level. The blue person icon is set as the default
-    // icon and then a step is used to switch to the blue person icon at a certain map camera zoom level.
-    SymbolLayer singleLayer = new SymbolLayer("symbol-layer-id", "source-id");
-    singleLayer.setProperties(
-      iconImage(step(zoom(), literal(BLUE_PERSON_ICON_ID),
-        stop(ZOOM_LEVEL_FOR_SWITCH, BLUE_PIN_ICON_ID))),
-      iconIgnorePlacement(true),
-      iconAllowOverlap(true));
-    loadedMapStyle.addLayer(singleLayer);
   }
 
   @Override

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolSwitchOnZoomActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolSwitchOnZoomActivity.java
@@ -1,0 +1,168 @@
+package com.mapbox.mapboxandroiddemo.examples.dds;
+
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.Toast;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.step;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.stop;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.zoom;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+
+/**
+ * Use the SymbolLayer's setMinZoom and setMaxZoom methods to create the effect of SymbolLayer icons switching
+ * based on the map camera's zoom level.
+ */
+public class SymbolSwitchOnZoomActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private static final float ZOOM_LEVEL_FOR_SWITCH = 12;
+  private static final String BLUE_PERSON_ICON_ID = "blue-car-icon-marker-icon-id";
+  private static final String BLUE_PIN_ICON_ID = "blue-marker-icon-marker-icon-id";
+  private MapView mapView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_zoom_based_icon_switch);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(final MapboxMap mapboxMap) {
+    mapboxMap.setStyle(Style.OUTDOORS, new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        initLayerIcons(style);
+        addDataToMap(style);
+        Toast.makeText(SymbolSwitchOnZoomActivity.this,
+          R.string.zoom_map_in_and_out_icon_switch_instruction, Toast.LENGTH_SHORT).show();
+      }
+    });
+  }
+
+  /**
+   * Add images to the map so that the SymbolLayers can reference the images.
+   */
+  private void initLayerIcons(@NonNull Style loadedMapStyle) {
+    loadedMapStyle.addImage(BLUE_PERSON_ICON_ID, BitmapFactory.decodeResource(
+      getResources(), R.drawable.ic_person));
+    loadedMapStyle.addImage(BLUE_PIN_ICON_ID, BitmapFactory.decodeResource(
+      getResources(), R.drawable.blue_marker));
+  }
+
+  /**
+   * Add the data, source, and SymbolLayer to the map
+   */
+  private void addDataToMap(@NonNull Style loadedMapStyle) {
+    // Add random data to the GeoJsonSource and then add the GeoJsonSource to the map
+    loadedMapStyle.addSource(
+      new GeoJsonSource("source-id",
+        FeatureCollection.fromFeatures(new Feature[] {
+          Feature.fromGeometry(Point.fromLngLat(
+            9.205394983291626,
+            45.47661043757903)),
+          Feature.fromGeometry(Point.fromLngLat(
+            9.223880767822266,
+            45.47623240235297)),
+          Feature.fromGeometry(Point.fromLngLat(
+            9.15530204772949,
+            45.4706650227671)),
+          Feature.fromGeometry(Point.fromLngLat(
+            9.153714179992676,
+            45.48625229963004)),
+          Feature.fromGeometry(Point.fromLngLat(
+            9.158306121826172,
+            45.482731998239636)),
+          Feature.fromGeometry(Point.fromLngLat(
+            9.188523888587952,
+            45.4923746929562)),
+          Feature.fromGeometry(Point.fromLngLat(
+            9.20929491519928,
+            45.45314676076135)),
+          Feature.fromGeometry(Point.fromLngLat(
+            9.177778959274292,
+            45.45569808340158))
+        })
+      )
+    );
+
+    // Create a SymbolLayer and use the {@link com.mapbox.mapboxsdk.style.expressions.Expression.step()}
+    // to adjust the SymbolLayer icon based on the zoom level. The blue person icon is set as the default
+    // icon and then a step is used to switch to the blue person icon at a certain map camera zoom level.
+    SymbolLayer singleLayer = new SymbolLayer("symbol-layer-id", "source-id");
+    singleLayer.setProperties(
+      iconImage(step(zoom(), literal(BLUE_PERSON_ICON_ID),
+        stop(ZOOM_LEVEL_FOR_SWITCH, BLUE_PIN_ICON_ID))),
+      iconIgnorePlacement(true),
+      iconAllowOverlap(true));
+    loadedMapStyle.addLayer(singleLayer);
+  }
+
+  @Override
+  public void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/drawable-anydpi/ic_person.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable-anydpi/ic_person.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#2096F3"
+        android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+</vector>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_zoom_based_icon_switch.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_zoom_based_icon_switch.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.dds.SymbolSwitchOnZoomActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="45.459145"
+        mapbox:mapbox_cameraTargetLng="9.186176"
+        mapbox:mapbox_cameraZoom="10.662822"/>
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -308,4 +308,8 @@
     <string name="light_azimuth_angle">Light azimuthal angle</string>
     <string name="light_polar_angle">Light polar angle</string>
     <string name="building_opacity">Building opacity</string>
+
+    <!-- Zoom based icon change -->
+    <string name="zoom_map_in_and_out_icon_switch_instruction">Zoom in and out to see the icons change</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -51,6 +51,7 @@
     <string name="activity_dds_info_window_symbol_layer_description">Use SymbolLayer and icons to show data in a BubbleLayout "info window".</string>
     <string name="activity_dds_expression_integration_description">Use multiple expressions to visualize unit change in data.</string>
     <string name="activity_dds_satellite_land_select_description">View satellite photos and click to outline an area of land.</string>
+    <string name="activity_dds_symbol_zoom_switch_description">Change SymbolLayer icons based on the camera\'s zoom level.</string>
     <string name="activity_annotation_marker_description">Create a default marker with an InfoWindow.</string>
     <string name="activity_dds_geojson_line_description">Draw a polyline by parsing a GeoJSON file with the Mapbox Maps SDK.</string>
     <string name="activity_dds_polygon_description">Draw a vector polygon on a map with the Mapbox Maps SDK.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -51,6 +51,7 @@
     <string name="activity_dds_expression_integration_title">Temperature change</string>
     <string name="activity_dds_satellite_land_select_title">Satellite land select</string>
     <string name="activity_dds_line_gradient_title">Line gradient</string>
+    <string name="activity_dds_symbol_zoom_switch_title">Zoom-based icon switch</string>
     <string name="activity_annotation_marker_title">Draw a marker</string>
     <string name="activity_dds_geojson_line_title">Draw a GeoJSON line</string>
     <string name="activity_dds_polygon_title">Draw a polygon</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -50,6 +50,7 @@
     <string name="activity_dds_image_clustering_url" translatable="false">https://i.imgur.com/KjgNcS0.png</string>
     <string name="activity_dds_expression_integration_url" translatable="false">https://imgur.com/YiBeH0I.png</string>
     <string name="activity_dds_satellite_land_select_url" translatable="false">https://i.imgur.com/tfbO1m4.png</string>
+    <string name="activity_dds_symbol_zoom_switch_url" translatable="false">https://i.imgur.com/sbWU4Ui.png</string>
     <string name="activity_annotation_marker_url" translatable="false">http://i.imgur.com/X59UoaY.png</string>
     <string name="activity_dds_geojson_line_url" translatable="false">https://i.imgur.com/Bs0X98z.png</string>
     <string name="activity_dds_polygon_url" translatable="false">http://i.imgur.com/v9X28id.png</string>


### PR DESCRIPTION
This pr resolves https://github.com/mapbox/mapbox-android-demo/issues/810 and shows how to use `SymbolLayer`s to give the effect of an icon switching based on a particular zoom level.


![ezgif com-optimize](https://user-images.githubusercontent.com/4394910/49617271-c57cb700-f968-11e8-9daf-bb64baac937e.gif)
