### PR TITLE
Adding rotating camera example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -37,6 +37,7 @@ import com.mapbox.mapboxandroiddemo.examples.basics.SupportMapFragmentActivity;
 import com.mapbox.mapboxandroiddemo.examples.camera.AnimateMapCameraActivity;
 import com.mapbox.mapboxandroiddemo.examples.camera.BoundingBoxCameraActivity;
 import com.mapbox.mapboxandroiddemo.examples.camera.RestrictCameraActivity;
+import com.mapbox.mapboxandroiddemo.examples.camera.SlowlyRotatingCameraActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.AddRainFallStyleActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.BathymetryActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.ChoroplethJsonVectorMixActivity;
@@ -757,6 +758,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, RestrictCameraActivity.class),
       null,
       R.string.activity_camera_restrict_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_camera,
+      R.string.activity_camera_slowly_rotating_title,
+      R.string.activity_camera_slowly_rotating_description,
+      new Intent(MainActivity.this, SlowlyRotatingCameraActivity.class),
+      null,
+      R.string.activity_camera_slowly_rotating_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_offline,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -636,6 +636,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.camera.SlowlyRotatingCameraActivity"
+            android:label="@string/activity_camera_slowly_rotating_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.plugins.BuildingPluginActivity"
             android:label="@string/activity_plugins_building_plugin_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/SlowlyRotatingCameraActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/SlowlyRotatingCameraActivity.java
@@ -1,0 +1,151 @@
+package com.mapbox.mapboxandroiddemo.examples.camera;
+
+import android.animation.ValueAnimator;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.view.animation.LinearInterpolator;
+import android.widget.Toast;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+
+/**
+ * Animate the map's camera to slowly spin around a single point ont the map.
+ */
+public class SlowlyRotatingCameraActivity extends AppCompatActivity implements OnMapReadyCallback,
+  MapboxMap.OnMapClickListener {
+
+  private static final int DESIRED_NUM_OF_SPINS = 5;
+  private static final int DESIRED_SECONDS_PER_ONE_FULL_360_SPIN = 40;
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private ValueAnimator animator;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_camera_slow_spin);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(final MapboxMap mapboxMap) {
+    mapboxMap.setStyle(Style.SATELLITE_STREETS, new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        SlowlyRotatingCameraActivity.this.mapboxMap = mapboxMap;
+
+        mapboxMap.addOnMapClickListener(SlowlyRotatingCameraActivity.this);
+
+        // Toast instructing user to tap on the map
+        Toast.makeText(
+          SlowlyRotatingCameraActivity.this, getString(R.string.rotating_camera_toast_instruction),
+          Toast.LENGTH_LONG).show();
+
+        startMapCameraSpinningAnimation(mapboxMap.getCameraPosition().target);
+      }
+    });
+  }
+
+  @Override
+  public boolean onMapClick(@NonNull LatLng point) {
+    startMapCameraSpinningAnimation(point);
+    return true;
+  }
+
+  /**
+   * Set up and start the spin animation. The Android system ValueAnimator emits a new value and that value is
+   * used as the map camera's new bearing rotation amount. A smooth "new helicopter" type of effect is created
+   * by using a LinearInterpolator.
+   *
+   * @param mapCameraTargetLocation the map location that the map camera should spin around
+   */
+  private void startMapCameraSpinningAnimation(@NonNull final LatLng mapCameraTargetLocation) {
+    animator = ValueAnimator.ofFloat(0, DESIRED_NUM_OF_SPINS * 360);
+    animator.setDuration(
+      // Multiplying by 1000 to convert to milliseconds
+      DESIRED_NUM_OF_SPINS * DESIRED_SECONDS_PER_ONE_FULL_360_SPIN * 1000);
+    animator.setInterpolator(new LinearInterpolator());
+    animator.setStartDelay(1000);
+    animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+      @Override
+      public void onAnimationUpdate(ValueAnimator valueAnimator) {
+        // Retrieve the new animation number to use as the map camera bearing value
+        Float newBearingValue = (Float) valueAnimator.getAnimatedValue();
+
+        // Use the animation number in a new camera position and then direct the map camera to move to the new position
+        mapboxMap.animateCamera(CameraUpdateFactory
+          .newCameraPosition(new CameraPosition.Builder()
+            .target(new LatLng(mapCameraTargetLocation.getLatitude(), mapCameraTargetLocation.getLongitude()))
+            .bearing(newBearingValue)
+            .build()));
+      }
+    });
+    animator.start();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    if (mapboxMap != null) {
+      mapboxMap.removeOnMapClickListener(this);
+    }
+    if (animator != null) {
+      animator.end();
+    }
+    mapView.onDestroy();
+  }
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/SlowlyRotatingCameraActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/SlowlyRotatingCameraActivity.java
@@ -78,6 +78,9 @@ public class SlowlyRotatingCameraActivity extends AppCompatActivity implements O
    * @param mapCameraTargetLocation the map location that the map camera should spin around
    */
   private void startMapCameraSpinningAnimation(@NonNull final LatLng mapCameraTargetLocation) {
+    if (animator != null) {
+      animator.cancel();
+    }
     animator = ValueAnimator.ofFloat(0, DESIRED_NUM_OF_SPINS * 360);
     animator.setDuration(
       // Multiplying by 1000 to convert to milliseconds
@@ -91,7 +94,7 @@ public class SlowlyRotatingCameraActivity extends AppCompatActivity implements O
         Float newBearingValue = (Float) valueAnimator.getAnimatedValue();
 
         // Use the animation number in a new camera position and then direct the map camera to move to the new position
-        mapboxMap.animateCamera(CameraUpdateFactory
+        mapboxMap.moveCamera(CameraUpdateFactory
           .newCameraPosition(new CameraPosition.Builder()
             .target(new LatLng(mapCameraTargetLocation.getLatitude(), mapCameraTargetLocation.getLongitude()))
             .bearing(newBearingValue)

--- a/MapboxAndroidDemo/src/main/res/layout/activity_camera_slow_spin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_camera_slow_spin.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.camera.BoundingBoxCameraActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="50.075"
+        mapbox:mapbox_cameraTargetLng="14.4302"
+        mapbox:mapbox_cameraTilt="35"
+        mapbox:mapbox_cameraZoom="12.5"
+        mapbox:mapbox_uiCompass="false" />
+
+</RelativeLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -308,4 +308,7 @@
     <string name="light_azimuth_angle">Light azimuthal angle</string>
     <string name="light_polar_angle">Light polar angle</string>
     <string name="building_opacity">Building opacity</string>
+
+    <!-- Rotating camera -->
+    <string name="rotating_camera_toast_instruction">Try tapping on the map and/or adjusting the zoom</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -60,6 +60,7 @@
     <string name="activity_camera_animate_description">"Animate the map's camera position, tilt, bearing, and zoom."</string>
     <string name="activity_camera_bounding_box_description">Position the camera so that all the given markers are in view.</string>
     <string name="activity_camera_restrict_description">Prevent a map from being panned to a different place.</string>
+    <string name="activity_camera_slowly_rotating_description">Slowly have the camera circle around a single point.</string>
     <string name="activity_offline_simple_description">Download and view an offline map using the Mapbox Maps SDK.</string>
     <string name="activity_offline_manager_description">Download, view, navigate to, and delete an offline region.</string>
     <string name="activity_description">Download, view, navigate to, and delete an offline region.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -60,6 +60,7 @@
     <string name="activity_camera_animate_title">Animate the map camera</string>
     <string name="activity_camera_bounding_box_title">Fit camera in bounding box</string>
     <string name="activity_camera_restrict_title">Restrict map panning</string>
+    <string name="activity_camera_slowly_rotating_title">Rotating camera</string>
     <string name="activity_offline_simple_title">A simple offline map</string>
     <string name="activity_offline_manager_title">Offline manager</string>
     <string name="activity_query_feature_title">Query a map feature</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -59,6 +59,7 @@
     <string name="activity_camera_animate_url" translatable="false">http://i.imgur.com/PN3vyNJ.jpg</string>
     <string name="activity_camera_bounding_box_url" translatable="false">http://i.imgur.com/A0JL21Q.png</string>
     <string name="activity_camera_restrict_url" translatable="false">http://i.imgur.com/A227BEs.jpg</string>
+    <string name="activity_camera_slowly_rotating_url" translatable="false">https://i.imgur.com/uuiOK5D.png</string>
     <string name="activity_offline_simple_url" translatable="false">http://i.imgur.com/dV4DgDT.png</string>
     <string name="activity_offline_manager_url" translatable="false">http://i.imgur.com/tDlcNIg.png</string>
     <string name="activity_url" translatable="false">http://i.imgur.com/tDlcNIg.png</string>


### PR DESCRIPTION
This pr adds an example of using a `ValueAnimator` to adjust the camera's bearing value to create a "news helicopter" rotating effect. Could be good for mobile news stories and real estate consumer apps.

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/50122448-62fda380-0211-11e9-929d-9577a91a3ed5.gif)

![ezgif com-optimize 1](https://user-images.githubusercontent.com/4394910/50122645-634a6e80-0212-11e9-87cf-1a157d3e1a06.gif)
