### PR TITLE
Java SDK bump to 4.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,8 +11,8 @@ ext {
 
             // Mapbox
             mapboxMapSdk             : '7.1.2',
-            mapboxTurf               : '4.3.0',
-            mapboxServices           : '4.3.0',
+            mapboxTurf               : '4.5.0',
+            mapboxServices           : '4.5.0',
             mapboxPluginBuilding     : '0.5.0',
             mapboxPluginPlaces       : '0.7.0',
             mapboxPluginLocalization : '0.8.0',


### PR DESCRIPTION
Part of the 4.5.0 Java SDK release: https://github.com/mapbox/mapbox-java/issues/969