### PR TITLE
Added manifest declaration to use CleartextTraffic

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:launchMode="singleTop"
+        android:usesCleartextTraffic="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme">
 


### PR DESCRIPTION
This pr resolves https://github.com/mapbox/mapbox-android-demo/issues/955 by adding `android:usesCleartextTraffic="true"` to the manifest. Based on advice in https://stackoverflow.com/q/41650965/6358488

I opened this branch on an emulated Pixel 2 on API 28 and confirmed that the examples listed in https://github.com/mapbox/mapbox-android-demo/issues/955 are now working.