### PR TITLE
Adding draw on map for search example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -111,7 +111,7 @@ import com.mapbox.mapboxandroiddemo.examples.plugins.TrafficPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.BuildingOutlineActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.ClickOnLayerActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.FeatureCountActivity;
-import com.mapbox.mapboxandroiddemo.examples.query.FingerDrawActivity;
+import com.mapbox.mapboxandroiddemo.examples.query.FingerDrawQueryActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.HighlightedLineActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.QueryFeatureActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.RedoSearchInAreaActivity;
@@ -906,7 +906,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       R.id.nav_query_map,
       R.string.activity_lab_drag_draw_title,
       R.string.activity_lab_drag_draw_description,
-      new Intent(MainActivity.this, FingerDrawActivity.class),
+      new Intent(MainActivity.this, FingerDrawQueryActivity.class),
       null,
       R.string.activity_lab_drag_draw_url, true, BuildConfig.MIN_SDK_VERSION));
 

--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -111,6 +111,7 @@ import com.mapbox.mapboxandroiddemo.examples.plugins.TrafficPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.BuildingOutlineActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.ClickOnLayerActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.FeatureCountActivity;
+import com.mapbox.mapboxandroiddemo.examples.query.FingerDrawActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.HighlightedLineActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.QueryFeatureActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.RedoSearchInAreaActivity;
@@ -900,6 +901,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, HighlightedLineActivity.class),
       null,
       R.string.activity_query_highlighted_line_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_query_map,
+      R.string.activity_lab_drag_draw_title,
+      R.string.activity_lab_drag_draw_description,
+      new Intent(MainActivity.this, FingerDrawActivity.class),
+      null,
+      R.string.activity_lab_drag_draw_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_java_services,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -23,9 +23,9 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:launchMode="singleTop"
-        android:usesCleartextTraffic="true"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
 
         <uses-library
             android:name="com.google.android.wearable"
@@ -676,6 +676,14 @@
         <activity
             android:name=".examples.dds.SymbolSwitchOnZoomActivity"
             android:label="@string/activity_dds_symbol_zoom_switch_title">
+
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
+            android:name=".examples.query.FingerDrawActivity"
+            android:label="@string/activity_lab_drag_draw_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -682,7 +682,7 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
-            android:name=".examples.query.FingerDrawActivity"
+            android:name=".examples.query.FingerDrawQueryActivity"
             android:label="@string/activity_lab_drag_draw_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/MapboxAndroidDemo/src/main/assets/albuquerque_locations.geojson
+++ b/MapboxAndroidDemo/src/main/assets/albuquerque_locations.geojson
@@ -1,0 +1,1661 @@
+{
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.67333,
+          35.085179
+        ],
+        "type": "Point"
+      },
+      "id": "03c3999cb804f022bee2b0c4f89065dc"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.691459,
+          35.087
+        ],
+        "type": "Point"
+      },
+      "id": "05d0bbcfc0a4a59104efed203672ff6b"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.64474,
+          35.075496
+        ],
+        "type": "Point"
+      },
+      "id": "06b7da6ae54d023eebe1f18f2984b3c2"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.617333,
+          35.074082
+        ],
+        "type": "Point"
+      },
+      "id": "07cbc905e96138fb20438e0cf890b0d9"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.639794,
+          35.073235
+        ],
+        "type": "Point"
+      },
+      "id": "0a08c16fde185fa9d22c404df24b3c07"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.680096,
+          35.07277
+        ],
+        "type": "Point"
+      },
+      "id": "0b4193909d968fde3f67d8572e5703d5"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.657022,
+          35.088423
+        ],
+        "type": "Point"
+      },
+      "id": "0ca3367aea6873c46379d0619d3cceee"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.674468,
+          35.076539
+        ],
+        "type": "Point"
+      },
+      "id": "0d77afa0a92af7c38baf6ae781d2efb2"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.659255,
+          35.080429
+        ],
+        "type": "Point"
+      },
+      "id": "12e0510fd207be739f53cd1d7e6cd6b9"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.671363,
+          35.107451
+        ],
+        "type": "Point"
+      },
+      "id": "12fc6ff3957679448cb6f45c94c6585c"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.622922,
+          35.095596
+        ],
+        "type": "Point"
+      },
+      "id": "13f8d5622cf6ad04833185a9c3acf66d"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.635507,
+          35.08746
+        ],
+        "type": "Point"
+      },
+      "id": "1406c270e5d59a23f31e7d5313cac490"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.629225,
+          35.081436
+        ],
+        "type": "Point"
+      },
+      "id": "187d4458af63c0fb3401e1f1f867ab0d"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.665463,
+          35.103726
+        ],
+        "type": "Point"
+      },
+      "id": "190146587d708d6630720206977b884a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.644038,
+          35.099746
+        ],
+        "type": "Point"
+      },
+      "id": "19bcda7a47ff673d0049fb3532209e45"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.668906,
+          35.070515
+        ],
+        "type": "Point"
+      },
+      "id": "1e47e58fd8f7eae2687f2ba597607e9e"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.633396,
+          35.092962
+        ],
+        "type": "Point"
+      },
+      "id": "211a55fa64d0cd726caefe96b833ba98"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.647385,
+          35.056987
+        ],
+        "type": "Point"
+      },
+      "id": "22867787ff5fda91eb0fe4ac5065cec4"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.650865,
+          35.085975
+        ],
+        "type": "Point"
+      },
+      "id": "278a04471e8f8631ccfe54ed9abd9e8a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.629225,
+          35.081436
+        ],
+        "type": "Point"
+      },
+      "id": "2a0616eeb2c08c8323f0e3e0c6c2175a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.684572,
+          35.076574
+        ],
+        "type": "Point"
+      },
+      "id": "2ba6a42db6cdcfed3f9c6570fe5c1d59"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.643043,
+          35.077603
+        ],
+        "type": "Point"
+      },
+      "id": "2c35ea091c236d32f1931a1edf457e1a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.648074,
+          35.04092
+        ],
+        "type": "Point"
+      },
+      "id": "2ca6db8971f9e60732e7274cce379106"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.6459,
+          35.073144
+        ],
+        "type": "Point"
+      },
+      "id": "2df4a94c8790064f6ba4f6816d919291"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.65984,
+          35.0754
+        ],
+        "type": "Point"
+      },
+      "id": "2fc12f75928f90c189d8bf44653c1502"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.611537,
+          35.078233
+        ],
+        "type": "Point"
+      },
+      "id": "30250ecad8c200eb4230c6c0c6ee0c5c"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.646108,
+          35.101609
+        ],
+        "type": "Point"
+      },
+      "id": "3089afc35de09aff6107113d72881edb"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.677169,
+          35.097987
+        ],
+        "type": "Point"
+      },
+      "id": "30c23bc3cf4986c44cabe3ad07db7839"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.634427,
+          35.077179
+        ],
+        "type": "Point"
+      },
+      "id": "31ecb0ffec1b96bf20ff85c53b55c432"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.642589,
+          35.101947
+        ],
+        "type": "Point"
+      },
+      "id": "320122b63631bfecb68db2c0d77fb962"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.627242,
+          35.059524
+        ],
+        "type": "Point"
+      },
+      "id": "3844b45bc6da945314fd562a241c614a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.684056,
+          35.107706
+        ],
+        "type": "Point"
+      },
+      "id": "3939fa958be8720107f8d3e5ea9fce03"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.640499,
+          35.053182
+        ],
+        "type": "Point"
+      },
+      "id": "3a04c9ebec41fbe76941056d1fce853d"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.612675,
+          35.086703
+        ],
+        "type": "Point"
+      },
+      "id": "3a17d45ea508cce1b31b908e7d6a2ab8"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.674468,
+          35.08069
+        ],
+        "type": "Point"
+      },
+      "id": "3c42f50d2e2681543c9c7713e88a810a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.651801,
+          35.097459
+        ],
+        "type": "Point"
+      },
+      "id": "4174333824c6f2db629b82919a3bf1fb"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.660288,
+          35.109399
+        ],
+        "type": "Point"
+      },
+      "id": "4574817af198c40d3ea607f12165b6b9"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.667741,
+          35.092462
+        ],
+        "type": "Point"
+      },
+      "id": "46a541c240a571a4ccab43fcd9fe2d3e"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.639541,
+          35.099517
+        ],
+        "type": "Point"
+      },
+      "id": "46c3dcb63c1a8523fd1637973f0a40f8"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.622249,
+          35.072347
+        ],
+        "type": "Point"
+      },
+      "id": "4941770f5137fae8af2979ec072a97fa"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.670846,
+          35.10254
+        ],
+        "type": "Point"
+      },
+      "id": "494279aab7ef495562a096c64299ebed"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.667328,
+          35.088755
+        ],
+        "type": "Point"
+      },
+      "id": "49c792ab8a7d1ad4b5026c43dfa3cf03"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.609674,
+          35.076115
+        ],
+        "type": "Point"
+      },
+      "id": "4faaf656cf68693fba919a0d1db03daa"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.641592,
+          35.075813
+        ],
+        "type": "Point"
+      },
+      "id": "5281ed4c552ac187a0c59e9946aa3bbe"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.650828,
+          35.061074
+        ],
+        "type": "Point"
+      },
+      "id": "530b9c91e6b793389a98537bbe4fe1b4"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.651212,
+          35.080392
+        ],
+        "type": "Point"
+      },
+      "id": "54176b11502d385d705d6694dfd4fafc"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.672177,
+          35.070093
+        ],
+        "type": "Point"
+      },
+      "id": "5b7d0a20974738db709e8bc663f90a66"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.666395,
+          35.085179
+        ],
+        "type": "Point"
+      },
+      "id": "5ebf16c9086b705ebe5a559b013d18ad"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.665153,
+          35.109992
+        ],
+        "type": "Point"
+      },
+      "id": "64312d3c2942f8a2e47197b9daca39ca"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.664014,
+          35.090006
+        ],
+        "type": "Point"
+      },
+      "id": "650d2ad059d5e513587d8fcc5399c536"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.631581,
+          35.077902
+        ],
+        "type": "Point"
+      },
+      "id": "65d3bb1c40e511486194108ae1217d42"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.669086,
+          35.075184
+        ],
+        "type": "Point"
+      },
+      "id": "67398f54a29bfc01821522e9b4fa4b3d"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.655837,
+          35.079334
+        ],
+        "type": "Point"
+      },
+      "id": "68d994b980d00b3d25b4652caf325e0c"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.640151,
+          35.084478
+        ],
+        "type": "Point"
+      },
+      "id": "6a5ed81f4df5a794f5a6152006e81bfa"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.633936,
+          35.082239
+        ],
+        "type": "Point"
+      },
+      "id": "6a5fe4c2d5a6a0e8376b78a8421ff0ea"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.649316,
+          35.089837
+        ],
+        "type": "Point"
+      },
+      "id": "6d7c7b9429884139ea23a16f89b5e182"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.624315,
+          35.062201
+        ],
+        "type": "Point"
+      },
+      "id": "700d1037ff0f5d09b283dd907d06d3a9"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.687327,
+          35.099114
+        ],
+        "type": "Point"
+      },
+      "id": "708e496d380859b712b248139b7b592e"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.665634,
+          35.082632
+        ],
+        "type": "Point"
+      },
+      "id": "717eef1233d290fa43da4d804e128f2a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.649107,
+          35.051068
+        ],
+        "type": "Point"
+      },
+      "id": "7235a5966db809d502557777db062ba9"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.614642,
+          35.095173
+        ],
+        "type": "Point"
+      },
+      "id": "73a87ccc294df3746215e8bd540f0a92"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.668362,
+          35.1105
+        ],
+        "type": "Point"
+      },
+      "id": "7416a8a54f8d1d34ecdc286369304932"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.694213,
+          35.07601
+        ],
+        "type": "Point"
+      },
+      "id": "75b5ccd096fd84ef54daf0d4d263eac7"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.682162,
+          35.097846
+        ],
+        "type": "Point"
+      },
+      "id": "75fef3c5378b59c228092c7bcfbde4b4"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.6207,
+          35.065302
+        ],
+        "type": "Point"
+      },
+      "id": "76735347e778b7f46dab20a9edcc3722"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.701616,
+          35.081928
+        ],
+        "type": "Point"
+      },
+      "id": "768d757d5fc72d2751dcb3b63788094d"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.641554,
+          35.096782
+        ],
+        "type": "Point"
+      },
+      "id": "76de57a2a5fa5fa5a7eb51c645df7709"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.637799,
+          35.091107
+        ],
+        "type": "Point"
+      },
+      "id": "802c81e347ef61b7a5cbafedada9e40d"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.642392,
+          35.067979
+        ],
+        "type": "Point"
+      },
+      "id": "85ec8ef52dc3aac941b5b281e7796510"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.657597,
+          35.104064
+        ],
+        "type": "Point"
+      },
+      "id": "890decbfd2fde67ca027615ce0b2d3e4"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.639541,
+          35.099517
+        ],
+        "type": "Point"
+      },
+      "id": "8924ac3355c2ead393e43b40aa4135f4"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.639638,
+          35.058115
+        ],
+        "type": "Point"
+      },
+      "id": "8a21fcfae4adb46bb25b21c785d9f382"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.623854,
+          35.080605
+        ],
+        "type": "Point"
+      },
+      "id": "8c8d88c5c66df42bc5fde4c94163f5a5"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.662772,
+          35.107197
+        ],
+        "type": "Point"
+      },
+      "id": "8ff1201652d26e8b0b107d7c57eb77c1"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.665153,
+          35.088651
+        ],
+        "type": "Point"
+      },
+      "id": "909f6d300d110a36499c31483628056d"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.658529,
+          35.1116
+        ],
+        "type": "Point"
+      },
+      "id": "90dd07e59159e9a2bf64133ef8c6b299"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.637764,
+          35.076375
+        ],
+        "type": "Point"
+      },
+      "id": "9190c16a244b9cdb370a6b015f3b571b"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.642342,
+          35.092549
+        ],
+        "type": "Point"
+      },
+      "id": "93961cdb5ce42976c1c85c6b53e17338"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.648071,
+          35.077661
+        ],
+        "type": "Point"
+      },
+      "id": "95618f28cec6b5e21021fbd4af878936"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.64198,
+          35.078491
+        ],
+        "type": "Point"
+      },
+      "id": "9985822b8e601ef4954ad3df4b93f3ab"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.649066,
+          35.100984
+        ],
+        "type": "Point"
+      },
+      "id": "99cf70b55d8cdd90b355cbff00f72eb8"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.657079,
+          35.073828
+        ],
+        "type": "Point"
+      },
+      "id": "9abab8e928c0c344589c85d974d6cd2b"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.69714,
+          35.082914
+        ],
+        "type": "Point"
+      },
+      "id": "9c89226e58fa6e214f6bd5d75719d64c"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.638966,
+          35.088058
+        ],
+        "type": "Point"
+      },
+      "id": "9e4778e16a56f90763dba46397cdf274"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.649297,
+          35.093459
+        ],
+        "type": "Point"
+      },
+      "id": "a01c3a3e322ee476b8a6a82ca481db61"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.700411,
+          35.092916
+        ],
+        "type": "Point"
+      },
+      "id": "a09e596b251bb59f36d12c490dfd1549"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.651594,
+          35.105673
+        ],
+        "type": "Point"
+      },
+      "id": "a6513e2cc0aa226ef8d83fcdf1f5974d"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.670639,
+          35.097798
+        ],
+        "type": "Point"
+      },
+      "id": "a6e892f71d4025cbaf6f765fa991805f"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.673433,
+          35.097459
+        ],
+        "type": "Point"
+      },
+      "id": "a709babfe56840b19ac0b09c175de5d0"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.701272,
+          35.087845
+        ],
+        "type": "Point"
+      },
+      "id": "a7c577d37848167e5ef0b0e523fe9643"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.648246,
+          35.067697
+        ],
+        "type": "Point"
+      },
+      "id": "aea073d3f775d4a9b8281b3b064df88a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.669086,
+          35.078826
+        ],
+        "type": "Point"
+      },
+      "id": "b97ce727b2f71dd1510beaa35b0c9083"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.629863,
+          35.087862
+        ],
+        "type": "Point"
+      },
+      "id": "bc4fd85dfd2a0edf112839c1966d4918"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.659487,
+          35.08503
+        ],
+        "type": "Point"
+      },
+      "id": "bef1948e29e1f6266701e90842965189"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.657919,
+          35.09154
+        ],
+        "type": "Point"
+      },
+      "id": "bf67ba38d0777b0d380613b82d02d346"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.674882,
+          35.089922
+        ],
+        "type": "Point"
+      },
+      "id": "c09b4001b7e87532c1c464a97a96dccf"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.656769,
+          35.107621
+        ],
+        "type": "Point"
+      },
+      "id": "c9b0c73006e0618950308eb242974742"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.666084,
+          35.097798
+        ],
+        "type": "Point"
+      },
+      "id": "cdea7e62af1d69c72ae5201f1fbcc7e7"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.662772,
+          35.09856
+        ],
+        "type": "Point"
+      },
+      "id": "d05709f79cdc61b0dcdf322bbf3ace3e"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.661841,
+          35.081912
+        ],
+        "type": "Point"
+      },
+      "id": "d306c0e3ea69467c1a28136aed95058f"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.683023,
+          35.086154
+        ],
+        "type": "Point"
+      },
+      "id": "d30a1e3fbcf93b0992a9e444e551115a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.670846,
+          35.082807
+        ],
+        "type": "Point"
+      },
+      "id": "d37eab9e7807b07edf51a3381273765a"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.660297,
+          35.063892
+        ],
+        "type": "Point"
+      },
+      "id": "d5915d5e8d3389c2561594a295d3a8f7"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.668217,
+          35.062624
+        ],
+        "type": "Point"
+      },
+      "id": "d7e90d7ce03f7217b6f0eed0b6e6a4c9"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.64528,
+          35.082129
+        ],
+        "type": "Point"
+      },
+      "id": "d9fbc4a45b7b9909a50e85e96c096c91"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.674261,
+          35.102879
+        ],
+        "type": "Point"
+      },
+      "id": "da3cf5018704541cbcc92bbf623f2798"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.643106,
+          35.10652
+        ],
+        "type": "Point"
+      },
+      "id": "db69c52ffcaf87fc6d073c651bac9b00"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.628408,
+          35.106012
+        ],
+        "type": "Point"
+      },
+      "id": "dd5c5cb235d518fa2cff98f55c0bad27"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.675792,
+          35.057974
+        ],
+        "type": "Point"
+      },
+      "id": "de51d71f3324f11c24c1dfc86a8460b1"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.639276,
+          35.081198
+        ],
+        "type": "Point"
+      },
+      "id": "e055138ba72dcadd581a2beee38b6c96"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.653871,
+          35.102032
+        ],
+        "type": "Point"
+      },
+      "id": "e05e034142c4d1bc5c23a2c3b151e58e"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.629825,
+          35.065865
+        ],
+        "type": "Point"
+      },
+      "id": "e2ab721d83b22283a44fc233bcf2dc12"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.641704,
+          35.063611
+        ],
+        "type": "Point"
+      },
+      "id": "e3b7355c95b3ff5deb4b87e5df907a67"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.661634,
+          35.101778
+        ],
+        "type": "Point"
+      },
+      "id": "e4f7de5dba8a67474bc8ed7e7bc0627e"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.670846,
+          35.095511
+        ],
+        "type": "Point"
+      },
+      "id": "e5ff6ff76d52704227a30901be07d9f0"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.663409,
+          35.077849
+        ],
+        "type": "Point"
+      },
+      "id": "e78c54b7e491ad8e7b88359c28dd480b"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.622422,
+          35.067838
+        ],
+        "type": "Point"
+      },
+      "id": "e79164206067f7fb773686883b6afece"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.680268,
+          35.104185
+        ],
+        "type": "Point"
+      },
+      "id": "e97af59e23c6f7a72649db98ea5380b9"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.645764,
+          35.086818
+        ],
+        "type": "Point"
+      },
+      "id": "ec683af7ec70173cc3c05eb73e0ef64c"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.684228,
+          35.070093
+        ],
+        "type": "Point"
+      },
+      "id": "ed85c684dbbb4999c954e37d9dabbe3c"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.6577,
+          35.101016
+        ],
+        "type": "Point"
+      },
+      "id": "eddc2beee78069074a95577f88bb903f"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.654163,
+          35.077603
+        ],
+        "type": "Point"
+      },
+      "id": "efdf5f7143fb5f5fca78fe79988b56b1"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.673951,
+          35.092378
+        ],
+        "type": "Point"
+      },
+      "id": "f41a933462c5ec08655578fa54057309"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.632652,
+          35.074845
+        ],
+        "type": "Point"
+      },
+      "id": "f60b2c58b681940374a1d09cc61f78a3"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.684572,
+          35.062624
+        ],
+        "type": "Point"
+      },
+      "id": "f7230fa099258cc824e78e0236aca0ba"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.635806,
+          35.097434
+        ],
+        "type": "Point"
+      },
+      "id": "f74e69b8ee210c9ede23e9891c3cb480"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.663409,
+          35.094528
+        ],
+        "type": "Point"
+      },
+      "id": "f7bdce2c8dda310494822524e08069c8"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.655565,
+          35.097958
+        ],
+        "type": "Point"
+      },
+      "id": "f83a619a927a6fd3bdeed1fb81ab58c4"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.644114,
+          35.06206
+        ],
+        "type": "Point"
+      },
+      "id": "f8dd5a0f7cb8e10964bb95838498ffb8"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.637931,
+          35.10906
+        ],
+        "type": "Point"
+      },
+      "id": "fa603cd9ba497160950fba6244462d8e"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.645715,
+          35.095411
+        ],
+        "type": "Point"
+      },
+      "id": "fa8ce971153f952095b9739680d96681"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.68199,
+          35.081787
+        ],
+        "type": "Point"
+      },
+      "id": "fa931e194b900ed7618fa898676d1e05"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.652488,
+          35.074688
+        ],
+        "type": "Point"
+      },
+      "id": "faf723e16b77a5ad7b8ebd6e8f9aa121"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.627373,
+          35.100677
+        ],
+        "type": "Point"
+      },
+      "id": "fb45de18154d0ebf02df4053fa2f8f20"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.639317,
+          35.095025
+        ],
+        "type": "Point"
+      },
+      "id": "fd0b6e98a55cfeb44d3fe33ff8bab5e1"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.606879,
+          35.082807
+        ],
+        "type": "Point"
+      },
+      "id": "fde8af7324de5a3023d9113648010ce4"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.698517,
+          35.097424
+        ],
+        "type": "Point"
+      },
+      "id": "ff926a0d758cf39aaa5b56f476b29a7f"
+    },
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "coordinates": [
+          -106.629864,
+          35.085703
+        ],
+        "type": "Point"
+      },
+      "id": "ff9aefb688c6811ac8944f563ee6629d"
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/FingerDrawActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/FingerDrawActivity.java
@@ -1,0 +1,376 @@
+package com.mapbox.mapboxandroiddemo.examples.query;
+
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.graphics.PointF;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.widget.Toast;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.FillLayer;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.turf.TurfJoins;
+
+import java.io.InputStream;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+import timber.log.Timber;
+
+import static com.mapbox.mapboxsdk.style.layers.Property.LINE_JOIN_ROUND;
+import static com.mapbox.mapboxsdk.style.layers.Property.NONE;
+import static com.mapbox.mapboxsdk.style.layers.Property.VISIBLE;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillOpacity;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
+
+/**
+ * Use the Android system {@link android.view.View.OnTouchListener} to draw
+ * an area and perform a search for features in that area.
+ */
+public class FingerDrawActivity extends AppCompatActivity {
+
+  private static final String SEARCH_DATA_SYMBOL_LAYER_SOURCE_ID = "SEARCH_DATA_SYMBOL_LAYER_SOURCE_ID";
+  private static final String FREEHAND_DRAW_LINE_LAYER_SOURCE_ID = "FREEHAND_DRAW_LINE_LAYER_SOURCE_ID";
+  private static final String MARKER_SYMBOL_LAYER_SOURCE_ID = "MARKER_SYMBOL_LAYER_SOURCE_ID";
+  private static final String FREEHAND_DRAW_FILL_LAYER_SOURCE_ID = "FREEHAND_DRAW_FILL_LAYER_SOURCE_ID";
+  private static final String FREEHAND_DRAW_LINE_LAYER_ID = "FREEHAND_DRAW_LINE_LAYER_ID";
+  private static final String FREEHAND_DRAW_FILL_LAYER_ID = "FREEHAND_DRAW_FILL_LAYER_ID";
+  private static final String SEARCH_DATA_SYMBOL_LAYER_ID = "SEARCH_DATA_SYMBOL_LAYER_ID";
+  private static final String SEARCH_DATA_MARKER_ID = "SEARCH_DATA_MARKER_ID";
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private FeatureCollection searchPointFeatureCollection;
+  private GeoJsonSource drawLineSource;
+  private GeoJsonSource fillPolygonSource;
+  private List<Point> freehandDrawLineLayerPointList;
+  private List<List<Point>> polygonList;
+
+  /**
+   * Customize search UI with these booleans
+   */
+  private boolean fillSearchAreaWithPolygonWhileDrawing = true;
+  private boolean fillSearchAreaWithPolygon = true;
+  private boolean closePolygonSearchAreaOnceDrawingIsDone = true;
+  private boolean showSearchDataLocations = true;
+
+  private View.OnTouchListener customOnTouchListener = new View.OnTouchListener() {
+    @Override
+    public boolean onTouch(View view, MotionEvent motionEvent) {
+
+      LatLng latLngTouchCoordinate = mapboxMap.getProjection().fromScreenLocation(
+        new PointF(motionEvent.getX(), motionEvent.getY()));
+
+      Point touchPoint = Point.fromLngLat(latLngTouchCoordinate.getLongitude(), latLngTouchCoordinate.getLatitude());
+
+      if (freehandDrawLineLayerPointList != null) {
+
+        // Draw the line as drawing on the map happens
+        freehandDrawLineLayerPointList.add(touchPoint);
+        drawLineSource = mapboxMap.getStyle().getSourceAs(FREEHAND_DRAW_LINE_LAYER_SOURCE_ID);
+        drawLineSource.setGeoJson(LineString.fromLngLats(freehandDrawLineLayerPointList));
+
+        if (fillSearchAreaWithPolygonWhileDrawing) {
+          drawSearchFillArea();
+        }
+
+        // Take certain actions when the drawing is done
+        if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
+          if (closePolygonSearchAreaOnceDrawingIsDone) {
+            freehandDrawLineLayerPointList.add(freehandDrawLineLayerPointList.get(0));
+          }
+
+          if (!fillSearchAreaWithPolygonWhileDrawing && fillSearchAreaWithPolygon) {
+            drawSearchFillArea();
+          }
+
+          if (closePolygonSearchAreaOnceDrawingIsDone) {
+            FeatureCollection pointsInSearchAreaFeatureCollection =
+              TurfJoins.pointsWithinPolygon(searchPointFeatureCollection,
+                FeatureCollection.fromFeature(Feature.fromGeometry(
+                  Polygon.fromLngLats(polygonList))));
+            if (VISIBLE.equals(mapboxMap.getStyle().getLayer(
+              SEARCH_DATA_SYMBOL_LAYER_ID).getVisibility().getValue())) {
+              Toast.makeText(FingerDrawActivity.this, String.format(
+                getString(R.string.search_result_size),
+                pointsInSearchAreaFeatureCollection.features().size()), Toast.LENGTH_SHORT).show();
+            }
+          }
+          enableMapMovement();
+        }
+      }
+      return true;
+    }
+  };
+
+  private void drawSearchFillArea() {
+    // Create and show a FillLayer polygon where the search area is
+    fillPolygonSource = mapboxMap.getStyle().getSourceAs(FREEHAND_DRAW_FILL_LAYER_SOURCE_ID);
+    polygonList = new ArrayList<>();
+    polygonList.add(freehandDrawLineLayerPointList);
+    fillPolygonSource.setGeoJson(Polygon.fromLngLats(polygonList));
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_finger_drag_draw);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+        mapboxMap.setStyle(Style.LIGHT, new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style style) {
+
+            FingerDrawActivity.this.mapboxMap = mapboxMap;
+
+            if (showSearchDataLocations) {
+              new LoadGeoJson(FingerDrawActivity.this).execute();
+            } else {
+              setUpExample(null);
+            }
+
+            findViewById(R.id.clear_map_for_new_draw_fab)
+              .setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+
+                  // Reset ArrayLists
+                  polygonList = new ArrayList<>();
+                  freehandDrawLineLayerPointList = new ArrayList<>();
+
+                  // Add empty Feature array to the sources
+                  drawLineSource = mapboxMap.getStyle().getSourceAs(FREEHAND_DRAW_LINE_LAYER_SOURCE_ID);
+                  if (drawLineSource != null) {
+                    drawLineSource.setGeoJson(FeatureCollection.fromFeatures(new Feature[]{}));
+                  }
+
+                  fillPolygonSource = mapboxMap.getStyle().getSourceAs(FREEHAND_DRAW_FILL_LAYER_SOURCE_ID);
+                  if (fillPolygonSource != null) {
+                    fillPolygonSource.setGeoJson(FeatureCollection.fromFeatures(new Feature[]{}));
+                  }
+
+                  // Reset camera position to default location
+                  mapboxMap.easeCamera(CameraUpdateFactory
+                    .newCameraPosition(new CameraPosition.Builder()
+                      .target(new LatLng(35.087497, -106.651261))
+                      .zoom(11.679132)
+                      .tilt(0)
+                      .bearing(0)
+                      .build()));
+
+                  enabledMapDrawing();
+                }
+              });
+          }
+        });
+      }
+    });
+  }
+
+  /**
+   * Enable moving the map
+   */
+  private void enableMapMovement() {
+    mapView.setOnTouchListener(new View.OnTouchListener() {
+      @Override
+      public boolean onTouch(View view, MotionEvent motionEvent) {
+        return false;
+      }
+    });
+    mapboxMap.getUiSettings().setAllGesturesEnabled(true);
+  }
+
+  /**
+   * Enable drawing on the map by setting the custom touch listener on the {@link MapView}
+   */
+  private void enabledMapDrawing() {
+    mapView.setOnTouchListener(customOnTouchListener);
+    mapboxMap.getUiSettings().setAllGesturesEnabled(false);
+  }
+
+  private void setUpExample(FeatureCollection searchDataFeatureCollection) {
+
+    searchPointFeatureCollection = searchDataFeatureCollection;
+
+    Style style = mapboxMap.getStyle();
+
+    if (style != null) {
+      freehandDrawLineLayerPointList = new ArrayList<>();
+
+      style.addImage(SEARCH_DATA_MARKER_ID, BitmapFactory.decodeResource(
+        FingerDrawActivity.this.getResources(), R.drawable.blue_marker_view));
+
+      // Add sources to the map
+      style.addSource(new GeoJsonSource(SEARCH_DATA_SYMBOL_LAYER_SOURCE_ID, searchDataFeatureCollection));
+      style.addSource(new GeoJsonSource(FREEHAND_DRAW_LINE_LAYER_SOURCE_ID));
+      style.addSource(new GeoJsonSource(MARKER_SYMBOL_LAYER_SOURCE_ID));
+      style.addSource(new GeoJsonSource(FREEHAND_DRAW_FILL_LAYER_SOURCE_ID));
+
+      style.addLayer(new SymbolLayer(SEARCH_DATA_SYMBOL_LAYER_ID, SEARCH_DATA_SYMBOL_LAYER_SOURCE_ID).withProperties(
+        iconImage(SEARCH_DATA_MARKER_ID),
+        iconAllowOverlap(true),
+        iconOffset(new Float[]{0f, -8f}),
+        iconIgnorePlacement(true))
+      );
+
+      // Add freehand draw LineLayer to the map
+      style.addLayerBelow(new LineLayer(FREEHAND_DRAW_LINE_LAYER_ID, FREEHAND_DRAW_LINE_LAYER_SOURCE_ID).withProperties(
+        lineWidth(5f),
+        lineJoin(LINE_JOIN_ROUND),
+        lineOpacity(1f),
+        lineColor(Color.parseColor("#a0861c"))), SEARCH_DATA_SYMBOL_LAYER_ID
+      );
+
+      // Add freehand draw polygon FillLayer to the map
+      style.addLayerBelow(new FillLayer(FREEHAND_DRAW_FILL_LAYER_ID, FREEHAND_DRAW_FILL_LAYER_SOURCE_ID).withProperties(
+        fillColor(Color.RED),
+        fillOpacity(.4f)), FREEHAND_DRAW_LINE_LAYER_ID
+      );
+
+      enabledMapDrawing();
+
+      if (showSearchDataLocations) {
+        findViewById(R.id.show_search_data_points_fab).setOnClickListener(new View.OnClickListener() {
+          @Override
+          public void onClick(View view) {
+
+            // Toggle the visibility of the fake data point SymbolLayer icons
+            Layer dataLayer = mapboxMap.getStyle().getLayer(SEARCH_DATA_SYMBOL_LAYER_ID);
+            if (dataLayer != null) {
+              dataLayer.setProperties(
+                VISIBLE.equals(dataLayer.getVisibility().getValue()) ? visibility(NONE) : visibility(VISIBLE));
+            }
+          }
+        });
+      }
+
+      Toast.makeText(FingerDrawActivity.this,
+        getString(R.string.draw_instruction), Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  /**
+   * Use an AsyncTask to retrieve GeoJSON data from a file in the assets folder.
+   */
+  private static class LoadGeoJson extends AsyncTask<Void, Void, FeatureCollection> {
+
+    private WeakReference<FingerDrawActivity> weakReference;
+
+    LoadGeoJson(FingerDrawActivity activity) {
+      this.weakReference = new WeakReference<>(activity);
+    }
+
+    @Override
+    protected FeatureCollection doInBackground(Void... voids) {
+      try {
+        FingerDrawActivity activity = weakReference.get();
+        if (activity != null) {
+          InputStream inputStream = activity.getAssets().open("albuquerque_locations.geojson");
+          return FeatureCollection.fromJson(convertStreamToString(inputStream));
+        }
+      } catch (Exception exception) {
+        Timber.e("Exception Loading GeoJSON: %s", exception.toString());
+      }
+      return null;
+    }
+
+    static String convertStreamToString(InputStream is) {
+      Scanner scanner = new Scanner(is).useDelimiter("\\A");
+      return scanner.hasNext() ? scanner.next() : "";
+    }
+
+    @Override
+    protected void onPostExecute(@Nullable FeatureCollection featureCollection) {
+      super.onPostExecute(featureCollection);
+      FingerDrawActivity activity = weakReference.get();
+      if (activity != null && featureCollection != null) {
+        activity.setUpExample(featureCollection);
+      }
+    }
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/FingerDrawQueryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/FingerDrawQueryActivity.java
@@ -78,7 +78,6 @@ public class FingerDrawQueryActivity extends AppCompatActivity {
   private FeatureCollection searchPointFeatureCollection;
   private List<Point> freehandTouchPointListForPolygon = new ArrayList<>();
   private List<Point> freehandTouchPointListForLine = new ArrayList<>();
-  private Polygon drawnPolygon;
   private boolean showSearchDataLocations = true;
   private boolean drawSingleLineOnly = false;
 
@@ -109,14 +108,14 @@ public class FingerDrawQueryActivity extends AppCompatActivity {
           freehandTouchPointListForPolygon.add(screenTouchPoint);
           freehandTouchPointListForPolygon.add(freehandTouchPointListForPolygon.get(0));
         }
-
-        // Create and show a FillLayer polygon where the search area is
-        GeoJsonSource fillPolygonSource = mapboxMap.getStyle().getSourceAs(FREEHAND_DRAW_FILL_LAYER_SOURCE_ID);
-        List<List<Point>> polygonList = new ArrayList<>();
-        polygonList.add(freehandTouchPointListForPolygon);
-        drawnPolygon = Polygon.fromLngLats(polygonList);
-        fillPolygonSource.setGeoJson(drawnPolygon);
       }
+
+      // Create and show a FillLayer polygon where the search area is
+      GeoJsonSource fillPolygonSource = mapboxMap.getStyle().getSourceAs(FREEHAND_DRAW_FILL_LAYER_SOURCE_ID);
+      List<List<Point>> polygonList = new ArrayList<>();
+      polygonList.add(freehandTouchPointListForPolygon);
+      Polygon drawnPolygon = Polygon.fromLngLats(polygonList);
+      fillPolygonSource.setGeoJson(drawnPolygon);
 
       // Take certain actions when the drawing is done
       if (motionEvent.getAction() == MotionEvent.ACTION_UP) {

--- a/MapboxAndroidDemo/src/main/res/layout/activity_finger_drag_draw.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_finger_drag_draw.xml
@@ -27,6 +27,15 @@
         fab:fab_labelStyle="@style/menu_labels_style">
 
         <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/switch_to_single_line_only_fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/mapboxOrange"
+            fab:fab_colorPressed="@color/mapboxWhite"
+            fab:fab_size="mini"
+            fab:fab_title="@string/toggle_straight_line_drawing"/>
+
+        <com.getbase.floatingactionbutton.FloatingActionButton
             android:id="@+id/clear_map_for_new_draw_fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/MapboxAndroidDemo/src/main/res/layout/activity_finger_drag_draw.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_finger_drag_draw.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:fab="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="35.087497"
+        mapbox:mapbox_cameraZoom="11.679132"
+        mapbox:mapbox_cameraTargetLng="-106.651261"/>
+
+
+    <com.getbase.floatingactionbutton.FloatingActionsMenu
+        android:id="@+id/multiple_actions_parent_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        fab:fab_addButtonColorNormal="@color/mapboxRed"
+        fab:fab_addButtonColorPressed="@color/mapboxWhite"
+        fab:fab_addButtonPlusIconColor="@color/mapboxWhite"
+        fab:fab_labelStyle="@style/menu_labels_style">
+
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/clear_map_for_new_draw_fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/mapboxBlue"
+            fab:fab_colorPressed="@color/mapboxWhite"
+            fab:fab_size="mini"
+            fab:fab_title="@string/clear_map"/>
+
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/show_search_data_points_fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/mapboxGreen"
+            fab:fab_colorPressed="@color/mapboxWhite"
+            fab:fab_size="mini"
+            fab:fab_title="@string/toggle_search_data_points_title"/>
+
+
+    </com.getbase.floatingactionbutton.FloatingActionsMenu>
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -351,4 +351,10 @@
     <!-- Variable label placement-->
     <string name="zoom_map_in_and_out_variable_label_instruction">Zoom in and out to see red labels try to avoid collisions</string>
 
+    <!-- Finger drag to draw -->
+    <string name="draw_instruction">Draw your finger on the map to draw a line.</string>
+    <string name="toggle_search_data_points_title">Toggle searchable data</string>
+    <string name="search_result_size">%1$d locations in drawn search area</string>
+    <string name="clear_map">Clear map for new draw</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -352,9 +352,14 @@
     <string name="zoom_map_in_and_out_variable_label_instruction">Zoom in and out to see red labels try to avoid collisions</string>
 
     <!-- Finger drag to draw -->
-    <string name="draw_instruction">Draw your finger on the map to draw a line.</string>
+    <string name="draw_instruction">Move your finger on the map to draw a search area</string>
     <string name="toggle_search_data_points_title">Toggle searchable data</string>
-    <string name="search_result_size">%1$d locations in drawn search area</string>
+    <string name="search_result_size">Move map around to explore the %1$d locations in the drawn search area</string>
+    <string name="move_map_drawn_line">Move map around to explore your drawn line</string>
     <string name="clear_map">Clear map for new draw</string>
+    <string name="toggle_straight_line_drawing">Toggle drawing single line only</string>
+    <string name="now_drawing">Now drawing %1$s</string>
+    <string name="single_line">single line</string>
+    <string name="polygon">polygon</string>
 
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -120,6 +120,7 @@
     <string name="activity_lab_magic_window_description">Combine two maps for a magic window effect</string>
     <string name="activity_lab_fog_background_description">Add a gradient on top of a MapView to show a background fog effect.</string>
     <string name="activity_lab_animated_interpolator_icon_drop_description">Use Android system interpolators to animate SymbolLayer icons movement.</string>
+    <string name="activity_lab_drag_draw_description">Drag a finger on the map to draw a search area.</string>
     <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
     <string name="activity_lab_home_screen_widget_description">Show the device\'s current location or other information in a homescreen widget.</string>
     <string name="activity_java_turf_ring_description">Use Turf to calculate coordinates to eventually draw a ring around a center coordinate.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -118,6 +118,7 @@
     <string name="activity_lab_fog_background_title">Background fog</string>
     <string name="activity_lab_animated_interpolator_icon_drop_title">Animated icon movement</string>
     <string name="activity_dds_polygon_select_toggle_title">Polygon toggle</string>
+    <string name="activity_lab_drag_draw_title">Drawing search area</string>
     <string name="activity_china_simple_china_mapview_title">China map view</string>
     <string name="activity_lab_home_screen_widget_title">Homescreen geocoding widget</string>
     <string name="activity_java_turf_ring_title">Hollow circle</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -120,6 +120,7 @@
     <string name="activity_lab_magic_window_image_url">https://i.imgur.com/Nw78ZrV.png</string>
     <string name="activity_lab_fog_background_url">https://i.imgur.com/NcSGgD8.png</string>
     <string name="activity_lab_animated_interpolator_icon_drop_url">https://i.imgur.com/JfLf69C.png</string>
+    <string name="activity_lab_drag_draw_url" translatable="false">https://i.imgur.com/vf5uZyS.png</string>
     <string name="activity_lab_home_screen_widget_url" translatable="false">https://i.imgur.com/H5N9jDn.png</string>
     <string name="activity_java_turf_ring_url" translatable="false">https://i.imgur.com/nG8xeXH.png</string>
     <string name="activity_china_simple_china_mapview_url" translatable="false">https://i.imgur.com/KwoEynZ.png</string>


### PR DESCRIPTION
This pr adds an example of using `View.OnTouchListener` to draw a line/polygon on the map. This can be combined with `TurfJoins.pointsWithinPolygon()` to find certain data/`Feature`s within the search polygon. The drawn line could also be combined with the Mapbox MapMatching API to clean up the handdrawn line.


![ezgif com-resize](https://user-images.githubusercontent.com/4394910/58599299-856e0100-8234-11e9-9cbf-c1c21724d91f.gif)
