### PR TITLE
Release 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+
+## 7.2.0
+
+* Added manifest declaration to use CleartextTraffic #980
+* Removing GIF library #979
+* Maps SDK v7.2.0 #978
+* Fix disappearing camera restriction bbox #972
+
 ## 7.1.2
 
 * Localization plugin 0.8.0 bump #960

--- a/MapboxAndroidDemo/src/global/play/en-US/whatsnew
+++ b/MapboxAndroidDemo/src/global/play/en-US/whatsnew
@@ -1,1 +1,1 @@
-This update is in line with the 7.1.2 release of the Mapbox Maps SDK for Android.
+This update is in line with the 7.2.0 release of the Mapbox Maps SDK for Android and includes several improvements.


### PR DESCRIPTION
Addresses https://github.com/mapbox/mapbox-android-demo/issues/990 as part of the 7.2.0 release of the Maps SDK for Android