### PR TITLE
bump Mapbox Maps SDK for Android to v7.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ allprojects {
         maven { url "https://jitpack.io" }
         maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
         jcenter()
+        maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
     }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     version = [
 
             // Mapbox
-            mapboxMapSdk             : '7.2.0',
+            mapboxMapSdk             : '7.3.0',
             mapboxTurf               : '4.5.0',
             mapboxServices           : '4.5.0',
             mapboxPluginBuilding     : '0.5.0',


### PR DESCRIPTION
Additionally also bumps to SNAPSHOT version to do some additional testing. 