### PR TITLE
Pulsing SymbolLayer textField size

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -135,6 +135,7 @@ import com.mapbox.mapboxandroiddemo.examples.styles.LineLayerActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.LocalStyleSourceActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.MapboxStudioStyleActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.MissingIconActivity;
+import com.mapbox.mapboxandroiddemo.examples.styles.PulsingTextSizeActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.RotatingTextAnchorPositionActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.ShowHideLayersActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.SatelliteOpacityOnZoomActivity;
@@ -668,6 +669,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, VariableLabelPlacementActivity.class),
             null,
        R.string.activity_styles_variable_label_placement_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_styles,
+      R.string.activity_styles_pulsing_text_size_title,
+      R.string.activity_styles_pulsing_text_size_description,
+      new Intent(MainActivity.this, PulsingTextSizeActivity.class),
+      null,
+      R.string.activity_styles_pulsing_text_size_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_extrusions,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -496,6 +496,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.styles.PulsingTextSizeActivity"
+            android:label="@string/activity_styles_pulsing_text_size_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.styles.ImageSourceTimeLapseActivity"
             android:label="@string/activity_style_image_source_time_lapse_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/PulsingTextSizeActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/PulsingTextSizeActivity.java
@@ -1,0 +1,128 @@
+package com.mapbox.mapboxandroiddemo.examples.styles;
+
+import android.animation.ValueAnimator;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.view.animation.LinearInterpolator;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
+
+public class PulsingTextSizeActivity extends AppCompatActivity {
+
+  private static final float DESIRED_MAX_TEXT_SIZE = 22;
+  private static final long SIZE_CHANGE_SPEED_MILLISECONDS = 3000;
+  private MapView mapView;
+  private Layer stateLabelSymbolLayer;
+  private ValueAnimator animator;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_lab_pulsing_text_size);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+        mapboxMap.setStyle(Style.MAPBOX_STREETS, new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style style) {
+
+            // Adjust to 7-19 for symbol rank
+            stateLabelSymbolLayer = style.getLayer("state-label");
+
+            stateLabelSymbolLayer.setProperties(
+              textIgnorePlacement(true),
+              textAllowOverlap(true)
+            );
+            initAnimation();
+          }
+        });
+      }
+    });
+  }
+
+  /**
+   * Initialize and start the animation.
+   */
+  private void initAnimation() {
+    animator = ValueAnimator.ofFloat(8, DESIRED_MAX_TEXT_SIZE);
+    animator.setDuration(SIZE_CHANGE_SPEED_MILLISECONDS);
+    animator.setInterpolator(new LinearInterpolator());
+    animator.setRepeatMode(ValueAnimator.REVERSE);
+    animator.setRepeatCount(ValueAnimator.INFINITE);
+    animator.setStartDelay(1000);
+    animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+      @Override
+      public void onAnimationUpdate(ValueAnimator valueAnimator) {
+        stateLabelSymbolLayer.setProperties(textSize((Float) valueAnimator.getAnimatedValue()));
+      }
+    });
+    animator.start();
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+    if (animator != null) {
+      animator.cancel();
+    }
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}
+

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/PulsingTextSizeActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/PulsingTextSizeActivity.java
@@ -4,6 +4,7 @@ import android.animation.ValueAnimator;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.animation.LinearInterpolator;
 
 import com.mapbox.mapboxandroiddemo.R;
@@ -20,7 +21,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
 
 public class PulsingTextSizeActivity extends AppCompatActivity {
 
-  private static final float DESIRED_MAX_TEXT_SIZE = 22;
+  private static final float DESIRED_MAX_TEXT_SIZE = 13;
   private static final long SIZE_CHANGE_SPEED_MILLISECONDS = 3000;
   private MapView mapView;
   private Layer stateLabelSymbolLayer;
@@ -50,8 +51,8 @@ public class PulsingTextSizeActivity extends AppCompatActivity {
             stateLabelSymbolLayer = style.getLayer("state-label");
 
             stateLabelSymbolLayer.setProperties(
-              textIgnorePlacement(true),
-              textAllowOverlap(true)
+              /*textIgnorePlacement(true),
+              textAllowOverlap(true)*/
             );
             initAnimation();
           }
@@ -73,6 +74,9 @@ public class PulsingTextSizeActivity extends AppCompatActivity {
     animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
       @Override
       public void onAnimationUpdate(ValueAnimator valueAnimator) {
+        Log.d("PulsingTextSizeActivity", "onAnimationUpdate: (Float) valueAnimator.getAnimatedValue()) = " +
+          (Float) valueAnimator.getAnimatedValue());
+
         stateLabelSymbolLayer.setProperties(textSize((Float) valueAnimator.getAnimatedValue()));
       }
     });

--- a/MapboxAndroidDemo/src/main/res/layout/activity_lab_pulsing_text_size.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_lab_pulsing_text_size.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="34.0444"
+        mapbox:mapbox_cameraTargetLng="-118.2536"
+        mapbox:mapbox_cameraZoom="15" />
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -37,6 +37,7 @@
     <string name="activity_styles_rotating_anchor_text_description">Adjust the anchor position of SymbolLayer text fields.</string>
     <string name="activity_styles_missing_icon_description">Provide an icon when a Style failed to load one.</string>
     <string name="activity_styles_variable_label_placement_description">To increase the chance of high-priority labels staying visible, provide the map renderer a list of preferred text anchor positions.</string>
+    <string name="activity_styles_pulsing_text_size_description">Use an Android ValueAnimator to pulse SymbolLayer text.</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_description">Use data-driven styling and GeoJSON data to set extrusions\' heights.</string>
     <string name="activity_extrusions_population_density_extrusions_description">Use extrusions to display 3D building height based on imported vector data.</string>
     <string name="activity_extrusions_adjust_extrusions_description">Change the location and color of the light shined on extrusions.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -34,6 +34,7 @@
     <string name="activity_styles_rotating_anchor_text_title">Text anchor position</string>
     <string name="activity_styles_missing_icon_title">Style with missing icon</string>
     <string name="activity_styles_variable_label_placement_title">Variable label placement</string>
+    <string name="activity_styles_pulsing_text_size_title">Pulsing text size</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_title">Use GeoJSON data to set extrusion height</string>
     <string name="activity_extrusions_population_density_extrusions_title">Display 3D building height based on vector data</string>
     <string name="activity_extrusions_adjust_extrusions_title">Adjust light location and color</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -36,6 +36,7 @@
     <string name="activity_styles_rotating_anchor_text_url" translatable="false">https://i.imgur.com/w8cP6Wn.png</string>
     <string name="activity_styles_missing_icon_url" translatable="false">https://i.imgur.com/lSk2tDB.png</string>
     <string name="activity_styles_variable_label_placement_url" translatable="false">https://i.imgur.com/vLgFvlZ.jpg</string>
+    <string name="activity_styles_pulsing_text_size_url" translatable="false">https://i.imgur.com/fwsDR5X.png</string>
     <string name="activity_extrusions_population_density_extrusions_url" translatable="false">http://i.imgur.com/se1z8Wb.png</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_url" translatable="false">http://i.imgur.com/6j848JL.jpg</string>
     <string name="activity_extrusions_adjust_extrusions_url" translatable="false">http://i.imgur.com/XNTyIO5.png</string>


### PR DESCRIPTION
This pr uses `ValueAnimator` to oscillate the size of textField size.  Related to the ongoing effort to add more examples related to `textField`: https://github.com/mapbox/mapbox-android-demo/issues/984

My current implementation seems to cause tile loading to lag. Also, the `state-label` layer's text lags and it doesn't seem that the map can update the text size in accordance with the `ValueAnimator` 😕  

@mapbox/maps-android , any suggestions on how to change/adjust the implementation so that things are smoother? Because I'm using `animator.setRepeatMode(ValueAnimator.REVERSE);`,
I thought the size would smoothly increase/decrease with the map responding accordingly. ([More about ValueAnimator.REVERSE](https://developer.android.com/reference/android/animation/ValueAnimator#REVERSE))


![ezgif com-resize (1)](https://user-images.githubusercontent.com/4394910/55018611-76f33700-4fb0-11e9-8661-2e5b86fca1f6.gif)
