### PR TITLE
Fix to geocoding example XML to unblock 7.3.0 release

### DIFF
--- a/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_geocoding.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_geocoding.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:mapbox="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"


### PR DESCRIPTION
This pr fixes the geocoding example's XML so that a fatal error doesn't happen when trying to release the `7.3.0` version of this app.