### PR TITLE
Refactoring LocationComponent examples to use LocationComponentActivationOptions

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/KotlinLocationComponentActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/KotlinLocationComponentActivity.kt
@@ -1,8 +1,8 @@
 package com.mapbox.mapboxandroiddemo.examples.location
 
 import android.annotation.SuppressLint
+import android.graphics.Color
 import android.os.Bundle
-import android.support.annotation.NonNull
 import android.support.v4.content.ContextCompat
 import android.support.v7.app.AppCompatActivity
 import android.widget.Toast
@@ -10,6 +10,7 @@ import com.mapbox.android.core.permissions.PermissionsListener
 import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.mapboxandroiddemo.R
 import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
 import com.mapbox.mapboxsdk.location.LocationComponentOptions
 import com.mapbox.mapboxsdk.location.modes.CameraMode
 import com.mapbox.mapboxsdk.location.modes.RenderMode
@@ -55,27 +56,31 @@ class KotlinLocationComponentActivity : AppCompatActivity(), OnMapReadyCallback,
     // Check if permissions are enabled and if not request
     if (PermissionsManager.areLocationPermissionsGranted(this)) {
 
-      val options = LocationComponentOptions.builder(this)
+      // Create and customize the LocationComponent's options
+      val customLocationComponentOptions = LocationComponentOptions.builder(this)
               .trackingGesturesManagement(true)
               .accuracyColor(ContextCompat.getColor(this, R.color.mapboxGreen))
               .build()
 
-      // Get an instance of the component
-      val locationComponent = mapboxMap.locationComponent
+      val locationComponentActivationOptions = LocationComponentActivationOptions.builder(this, loadedMapStyle)
+              .locationComponentOptions(customLocationComponentOptions)
+              .build()
 
-      // Activate the component
-      locationComponent.activateLocationComponent(this, loadedMapStyle)
+      // Get an instance of the LocationComponent and then adjust its settings
+      mapboxMap.locationComponent.apply {
 
-      // Apply the options to the LocationComponent
-      locationComponent.applyStyle(options)
+        // Activate the LocationComponent with options
+        activateLocationComponent(locationComponentActivationOptions)
 
-      // Enable to make component visible
-      locationComponent.isLocationComponentEnabled = true
+        // Enable to make the LocationComponent visible
+        isLocationComponentEnabled = true
 
-      // Set the component's camera mode
-      locationComponent.cameraMode = CameraMode.TRACKING
-      locationComponent.renderMode = RenderMode.COMPASS
+        // Set the LocationComponent's camera mode
+        cameraMode = CameraMode.TRACKING
 
+        // Set the LocationComponent's render mode
+        renderMode = RenderMode.COMPASS
+      }
 
     } else {
       permissionsManager = PermissionsManager(this)

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentActivity.java
@@ -10,6 +10,7 @@ import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapView;
@@ -67,7 +68,8 @@ public class LocationComponentActivity extends AppCompatActivity implements
       LocationComponent locationComponent = mapboxMap.getLocationComponent();
 
       // Activate with options
-      locationComponent.activateLocationComponent(this, loadedMapStyle);
+      locationComponent.activateLocationComponent(
+        LocationComponentActivationOptions.builder(this, loadedMapStyle).build());
 
       // Enable to make component visible
       locationComponent.setLocationComponentEnabled(true);

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentFragmentActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentFragmentActivity.java
@@ -13,6 +13,7 @@ import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -44,7 +45,7 @@ public class LocationComponentFragmentActivity extends AppCompatActivity impleme
       // Create fragment
       final FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
-      // Build mapboxMap
+      // Build a Mapbox map
       MapboxMapOptions options = new MapboxMapOptions();
       options.camera(new CameraPosition.Builder()
         .target(new LatLng(38.899895, -77.03401))
@@ -79,12 +80,21 @@ public class LocationComponentFragmentActivity extends AppCompatActivity impleme
   private void enableLocationComponent(@NonNull Style loadedMapStyle) {
     // Check if permissions are enabled and if not request
     if (PermissionsManager.areLocationPermissionsGranted(this)) {
-      // Get an instance of the location component. Adding in LocationComponentOptions is also an optional
-      // parameter
+
+      // Get an instance of the LocationComponent.
       LocationComponent locationComponent = mapboxMap.getLocationComponent();
-      locationComponent.activateLocationComponent(this, loadedMapStyle);
+
+      // Activate the LocationComponent
+      locationComponent.activateLocationComponent(
+        LocationComponentActivationOptions.builder(this, loadedMapStyle).build());
+
+      // Enable the LocationComponent so that it's actually visible on the map
       locationComponent.setLocationComponentEnabled(true);
+
+      // Set the LocationComponent's camera mode
       locationComponent.setCameraMode(CameraMode.TRACKING);
+
+      // Set the LocationComponent's render mode
       locationComponent.setRenderMode(RenderMode.NORMAL);
     } else {
       permissionsManager = new PermissionsManager(this);

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentOptionsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentOptionsActivity.java
@@ -12,6 +12,7 @@ import com.mapbox.android.core.permissions.PermissionsManager;
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.LocationComponentOptions;
 import com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener;
 import com.mapbox.mapboxsdk.location.OnLocationClickListener;
@@ -69,7 +70,7 @@ public class LocationComponentOptionsActivity extends AppCompatActivity implemen
     if (PermissionsManager.areLocationPermissionsGranted(this)) {
 
       // Create and customize the LocationComponent's options
-      LocationComponentOptions options = LocationComponentOptions.builder(this)
+      LocationComponentOptions customLocationComponentOptions = LocationComponentOptions.builder(this)
         .elevation(5)
         .accuracyAlpha(.6f)
         .accuracyColor(Color.RED)
@@ -79,8 +80,13 @@ public class LocationComponentOptionsActivity extends AppCompatActivity implemen
       // Get an instance of the component
       locationComponent = mapboxMap.getLocationComponent();
 
+      LocationComponentActivationOptions locationComponentActivationOptions =
+        LocationComponentActivationOptions.builder(this, loadedMapStyle)
+          .locationComponentOptions(customLocationComponentOptions)
+          .build();
+
       // Activate with options
-      locationComponent.activateLocationComponent(this, loadedMapStyle, options);
+      locationComponent.activateLocationComponent(locationComponentActivationOptions);
 
       // Enable to make component visible
       locationComponent.setLocationComponentEnabled(true);


### PR DESCRIPTION
Now that `master` has `7.3.0` of the Maps SDK, it was time to refactor the `location` package examples to use the `LocationComponentActivationOptions` builder way of activating the `LocationComponent.` This pr does that.