### PR TITLE
Tile loading performance measurement

### DIFF
--- a/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
+++ b/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
@@ -2,9 +2,13 @@ package com.mapbox.mapboxandroiddemo;
 
 import android.app.Application;
 
+import com.mapbox.mapboxandroiddemo.utils.TileLoadingInterceptor;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.module.http.HttpRequestUtil;
 import com.squareup.picasso.OkHttpDownloader;
 import com.squareup.picasso.Picasso;
+
+import okhttp3.OkHttpClient;
 
 public class MapboxApplication extends Application {
 
@@ -13,6 +17,8 @@ public class MapboxApplication extends Application {
     super.onCreate();
     setUpPicasso();
     Mapbox.getInstance(this, getString(R.string.access_token));
+    Mapbox.getTelemetry().setDebugLoggingEnabled(true);
+    setUpTileLoadingMeasurement();
   }
 
   private void setUpPicasso() {
@@ -21,5 +27,12 @@ public class MapboxApplication extends Application {
     Picasso built = builder.build();
     built.setLoggingEnabled(true);
     Picasso.setSingletonInstance(built);
+  }
+
+  private void setUpTileLoadingMeasurement() {
+    OkHttpClient okHttpClient = new OkHttpClient.Builder()
+            .addNetworkInterceptor(new TileLoadingInterceptor())
+            .build();
+    HttpRequestUtil.setOkHttpClient(okHttpClient);
   }
 }

--- a/MapboxAndroidDemo/src/global/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/global/AndroidManifest.xml
@@ -3,7 +3,8 @@
           package="com.mapbox.mapboxandroiddemo">
 
 
-    <application>
+    <application
+        android:name=".MapboxApplication">
 
         <activity
             android:name=".account.LandingActivity"

--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
@@ -4,9 +4,13 @@ import android.support.multidex.MultiDexApplication;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import com.mapbox.mapboxandroiddemo.utils.TileLoadingInterceptor;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.module.http.HttpRequestUtil;
 import com.squareup.picasso.OkHttpDownloader;
 import com.squareup.picasso.Picasso;
+
+import okhttp3.OkHttpClient;
 
 public class MapboxApplication extends MultiDexApplication {
 
@@ -16,6 +20,9 @@ public class MapboxApplication extends MultiDexApplication {
     initializeFirebaseApp();
     setUpPicasso();
     Mapbox.getInstance(this, getString(R.string.access_token));
+    Mapbox.getTelemetry().setDebugLoggingEnabled(true);
+    setUpTileLoadingMeasurement();
+
   }
 
   private void initializeFirebaseApp() {
@@ -32,5 +39,12 @@ public class MapboxApplication extends MultiDexApplication {
     Picasso built = builder.build();
     built.setLoggingEnabled(true);
     Picasso.setSingletonInstance(built);
+  }
+
+  private void setUpTileLoadingMeasurement() {
+    OkHttpClient okHttpClient = new OkHttpClient.Builder()
+      .addNetworkInterceptor(new TileLoadingInterceptor())
+      .build();
+    HttpRequestUtil.setOkHttpClient(okHttpClient);
   }
 }

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:required="false" />
 
     <application
+        android:name=".MapboxApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/utils/TileLoadingInterceptor.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/utils/TileLoadingInterceptor.java
@@ -1,0 +1,180 @@
+package com.mapbox.mapboxandroiddemo.utils;
+
+import android.app.ActivityManager;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkCapabilities;
+import android.net.NetworkInfo;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.StringDef;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.mapbox.mapboxandroiddemo.BuildConfig;
+import com.mapbox.mapboxsdk.Mapbox;
+
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import timber.log.Timber;
+
+/**
+ * This Interceptor allows to measure time spent getting a response object over network.
+ * The following data will be collected:
+ *  responseCode, elapsedMS
+ *  requestUrl (request string till the question mark),
+ *  and device metadata.
+ */
+public class TileLoadingInterceptor implements Interceptor {
+
+  private static String metadata = null;
+
+  @StringDef( {CONNECTION_NONE, CONNECTION_CELLULAR, CONNECTION_WIFI})
+  @Retention(RetentionPolicy.SOURCE)
+  @interface ConnectionState {
+  }
+  private static final String CONNECTION_NONE = "none";
+  private static final String CONNECTION_CELLULAR = "cellular";
+  private static final String CONNECTION_WIFI = "wifi";
+
+  @Override
+  public Response intercept(Chain chain) throws IOException {
+    Request request = chain.request();
+    long elapsed = System.nanoTime();
+
+    Response response = chain.proceed(request);
+    elapsed = System.nanoTime() - elapsed;
+
+    triggerPerformanceEvent(response, elapsed / 1000000);
+
+    return response;
+  }
+
+  private void triggerPerformanceEvent(Response response, long elapsedMs) {
+
+    String connectionState = getWifiState();
+    List<Attribute<String>> attributes = new ArrayList<>();
+    String request = getUrl(response.request());
+    attributes.add(
+            new Attribute<>("requestUrl", request));
+    attributes.add(
+            new Attribute<>("responseCode", String.valueOf(response.code())));
+    attributes.add(
+            new Attribute<>("connectionState", connectionState));
+
+    List<Attribute<Long>> counters = new ArrayList();
+    counters.add(new Attribute<>("elapsedMS", elapsedMs));
+
+    Bundle bundle = new Bundle();
+    Gson gson = new Gson();
+    bundle.putString("attributes", gson.toJson(attributes));
+    bundle.putString("counters", gson.toJson(counters));
+    bundle.putString("metadata", getMetadata());
+
+    Mapbox.getTelemetry().onPerformanceEvent(bundle);
+
+    Mapbox.getTelemetry().setUserTelemetryRequestState(true);
+
+    Timber.d(">>> PERF Event CODE=" + response.code()
+            + " elapsed=" + elapsedMs
+            + " connectionState=" + connectionState
+            + " url=" + request);
+  }
+
+  private static String getUrl(Request request) {
+    String url = request.url().toString();
+    return url.substring(0, url.indexOf('?'));
+  }
+
+  private static String getMetadata() {
+    if (metadata == null) {
+      JsonObject metaData = new JsonObject();
+      metaData.addProperty("os", "android");
+      metaData.addProperty("manufacturer", Build.MANUFACTURER);
+      metaData.addProperty("brand", Build.BRAND);
+      metaData.addProperty("device", Build.MODEL);
+      metaData.addProperty("version", Build.VERSION.RELEASE);
+      metaData.addProperty("abi", Build.CPU_ABI);
+      metaData.addProperty("country", Locale.getDefault().getISO3Country());
+      metaData.addProperty("ram", getRam());
+      metaData.addProperty("screenSize", getWindowSize());
+      metaData.addProperty("buildFlavor", BuildConfig.FLAVOR);
+      metadata = metaData.toString();
+    }
+    return metadata;
+  }
+
+  private static String getRam() {
+    ActivityManager actManager =
+            (ActivityManager) Mapbox.getApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
+    ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
+    actManager.getMemoryInfo(memInfo);
+    return String.valueOf(memInfo.totalMem);
+  }
+
+  private static String getWindowSize() {
+    WindowManager windowManager =
+            (WindowManager) Mapbox.getApplicationContext().getSystemService(Context.WINDOW_SERVICE);
+    Display display = windowManager.getDefaultDisplay();
+    DisplayMetrics metrics = new DisplayMetrics();
+    display.getMetrics(metrics);
+    int width = metrics.widthPixels;
+    int height = metrics.heightPixels;
+
+    return "{" + width + "," + height + "}";
+  }
+
+  @ConnectionState
+  private static String getWifiState() {
+    Context appContext = Mapbox.getApplicationContext();
+    ConnectivityManager connectivityManager =
+            (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (connectivityManager != null) {
+        NetworkCapabilities capabilities =
+                connectivityManager.getNetworkCapabilities(connectivityManager.getActiveNetwork());
+        if (capabilities != null) {
+          if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+            return CONNECTION_WIFI;
+          } else if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+            return CONNECTION_CELLULAR;
+          }
+        }
+      }
+    } else {
+      if (connectivityManager != null) {
+        NetworkInfo activeNetwork = connectivityManager.getActiveNetworkInfo();
+        if (activeNetwork != null) {
+          if (activeNetwork.getType() == ConnectivityManager.TYPE_WIFI) {
+            return CONNECTION_WIFI;
+          } else if (activeNetwork.getType() == ConnectivityManager.TYPE_MOBILE) {
+            return CONNECTION_CELLULAR;
+          }
+        }
+      }
+    }
+    return CONNECTION_NONE;
+  }
+
+  private static class Attribute<T> {
+    private String name;
+    private T value;
+
+    Attribute(String name, T value) {
+      this.name = name;
+      this.value = value;
+    }
+  }
+}

--- a/MapboxAndroidWearDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidWearDemo/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-feature android:name="android.hardware.type.watch"/>
 
     <application
+        android:name=".MapboxApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
This PR is based on [OkHttp Network Interceptor](https://github.com/square/okhttp/wiki/Interceptors) and the available support in Android Maps SDK for Performance measurement [TelementryDefinition](https://github.com/mapbox/mapbox-gl-native/blob/ce37879231514cfc60e66454ca493c2d76765318/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/maps/TelemetryDefinition.java#L58), [PerformanceEvent](https://github.com/mapbox/mapbox-gl-native/blob/b6910407e8849a5b243bc21617ee15d6b702d803/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/module/telemetry/PerformanceEvent.java)

The following measurements are collected:
attributes:
- requestUrl (without token)
- responseCode
- connectionState (none, cellular,   wifi)

counters:
- elapsedMS  (number in ms)

device metadata:
- os : android
- manufacturer
- brand
- version : (as reported by Build.VERSION.RELEASE)
- abi
- country : (ISO3 country format)
- ram
- screenSize :  {width, height}