### PR TITLE
Tweaks to SymbolLayer iconOffset spacing in InfoWindowSymbolLayerActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/InfoWindowSymbolLayerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/InfoWindowSymbolLayerActivity.java
@@ -145,7 +145,8 @@ public class InfoWindowSymbolLayerActivity extends AppCompatActivity implements
     loadedStyle.addLayer(new SymbolLayer(MARKER_LAYER_ID, GEOJSON_SOURCE_ID)
       .withProperties(
         iconImage(MARKER_IMAGE_ID),
-        iconAllowOverlap(true)
+        iconAllowOverlap(true),
+        iconOffset(new Float[] {0f, -8f})
       ));
   }
 
@@ -168,7 +169,7 @@ public class InfoWindowSymbolLayerActivity extends AppCompatActivity implements
         iconAllowOverlap(true),
 
         /* offset the info window to be above the marker */
-        iconOffset(new Float[] {-2f, -25f})
+        iconOffset(new Float[] {-2f, -28f})
       )
       /* add a filter to show only when selected feature property is true */
       .withFilter(eq((get(PROPERTY_SELECTED)), literal(true))));


### PR DESCRIPTION
This pr makes some tweaks to `iconOffset` spacing for the red markers in the `InfoWindowSymbolLayerActivity` example. Without the `iconOffset`, their bottoms would end up in the ocean and other inaccurate areas as the map was zoomed in/out on.

Not applying this offset to account for the icon height, is a very common problem that I see on apps/sites that use Mapbox.