### PR TITLE
Using dependencies.gradle file for Gradle plugin script version setup

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -58,7 +58,9 @@ ext {
             firebase           : '1.1.1',
             gradle             : '3.2.1',
             gradlePlayPublisher: '1.2.2',
-            kotlin             : '1.2.71'
+            kotlin             : '1.2.71',
+            dependencyGraph    : '0.3.0',
+            grgit              : '2.3.0'
     ]
 
     dependenciesList = [
@@ -120,11 +122,13 @@ ext {
     ]
 
     pluginDependencies = [
-            gradle       : "com.android.tools.build:gradle:${pluginVersion.gradle}",
-            checkstyle   : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
-            firebase     : "com.google.firebase:firebase-plugins:${pluginVersion.firebase}",
-            playPublisher: "com.github.triplet.gradle:play-publisher:${pluginVersion.gradlePlayPublisher}",
-            kotlin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}"
+            gradle          : "com.android.tools.build:gradle:${pluginVersion.gradle}",
+            checkstyle      : "com.puppycrawl.tools:checkstyle:${pluginVersion.checkstyle}",
+            firebase        : "com.google.firebase:firebase-plugins:${pluginVersion.firebase}",
+            playPublisher   : "com.github.triplet.gradle:play-publisher:${pluginVersion.gradlePlayPublisher}",
+            kotlin          : "org.jetbrains.kotlin:kotlin-gradle-plugin:${pluginVersion.kotlin}",
+            dependencyGraph : "com.vanniktech:gradle-dependency-graph-generator-plugin:${pluginVersion.dependencyGraph}",
+            grgit           : "org.ajoberstar:grgit:${pluginVersion.grgit}"
     ]
 
     wearDependencies = [

--- a/gradle/gradle-dependencies-graph.gradle
+++ b/gradle/gradle-dependencies-graph.gradle
@@ -1,10 +1,12 @@
+apply from: "${rootDir}/gradle/dependencies.gradle"
+
 buildscript {
     repositories {
         mavenCentral()
     }
 
     dependencies {
-        classpath "com.vanniktech:gradle-dependency-graph-generator-plugin:0.3.0"
+        classpath pluginDependencies.dependencyGraph
     }
 }
 

--- a/gradle/script-git-version.gradle
+++ b/gradle/script-git-version.gradle
@@ -1,11 +1,13 @@
 // https://hackernoon.com/configuring-android-project-version-name-code-b168952f3323#.fcoiok3lv
 
+apply from: "${rootDir}/gradle/dependencies.gradle"
+
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'org.ajoberstar:grgit:2.3.0'
+        classpath pluginDependencies.grgit
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/676 by using the `dependencies.gradle` file for the two other Gradle plugin script files which mention specific plugin version numbers (`gradle-dependencies-graph.gradle` and `script-git-version.gradle`).

Gradle builds fine for me on this pr and app can be installed just fine.