### PR TITLE
Revert committing template configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ local.properties
 build
 .DS_Store
 .gradle/
-/MapboxAndroidDemo/src/main/res/values/developer-config.xml
-/MapboxAndroidWearDemo/src/main/res/values/developer-config.xml
 gradlew.bat
 *.properties
 src/main/res/

--- a/MapboxAndroidDemo/src/main/res/values/developer-config.xml
+++ b/MapboxAndroidDemo/src/main/res/values/developer-config.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="access_token">@null</string>
-</resources>


### PR DESCRIPTION
Not sure why the gradle task configuration wasn't working for me. This PR reverts #1011 and updates the .gitignore to reflect that developer config is placed in SharedCode module.

cc @langsmith @osana 
