### PR TITLE
Removed duplicate ClickToAddImageActivity example entry in MainActivity

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -564,14 +564,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       R.string.activity_style_image_source_url, false, BuildConfig.MIN_SDK_VERSION
     ));
     exampleItemModels.add(new ExampleItemModel(
-        R.id.nav_styles,
-        R.string.activity_styles_click_to_add_image_title,
-        R.string.activity_styles_click_to_add_image_description,
-        new Intent(MainActivity.this, ClickToAddImageActivity.class),
-        null,
-        R.string.activity_styles_click_to_add_image_url, false, BuildConfig.MIN_SDK_VERSION
-    ));
-    exampleItemModels.add(new ExampleItemModel(
       R.id.nav_styles,
       R.string.activity_style_image_source_time_lapse_title,
       R.string.activity_style_image_source_time_lapse_description,


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1021 by removing a duplicate `ClickToAddImageActivity` entry in `MainActivity`