### PR TITLE
bump china plugin to 2.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
             mapboxPluginPlaces       : '0.8.0',
             mapboxPluginLocalization : '0.9.0',
             mapboxPluginTraffic      : '0.8.0',
-            mapboxChinaPlugin        : '2.1.0',
+            mapboxChinaPlugin        : '2.1.1',
             mapboxPluginMarkerView   : '0.2.0',
             mapboxPluginAnnotation   : '0.6.0',
 


### PR DESCRIPTION
China plugin 2.1.1 add the function that auto mapping styles to china style, so after update to 2.1.1, we will not need to change current codes.