### PR TITLE
Adding LocationComponent camera mode example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -97,6 +97,7 @@ import com.mapbox.mapboxandroiddemo.examples.labs.SymbolLayerMapillaryActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.ValueAnimatorIconAnimationActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.KotlinLocationComponentActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.LocationComponentActivity;
+import com.mapbox.mapboxandroiddemo.examples.location.LocationComponentCameraOptionsActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.LocationComponentFragmentActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.LocationComponentOptionsActivity;
 import com.mapbox.mapboxandroiddemo.examples.offline.OfflineManagerActivity;
@@ -805,6 +806,15 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, LocationComponentOptionsActivity.class),
       null,
       R.string.activity_location_location_component_options_url, false, BuildConfig.MIN_SDK_VERSION)
+    );
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_location,
+      R.string.activity_location_location_component_camera_options_title,
+      R.string.activity_location_location_component_camera_options_description,
+      new Intent(MainActivity.this, LocationComponentCameraOptionsActivity.class),
+      null,
+      R.string.activity_location_location_component_camera_options_url, false, BuildConfig.MIN_SDK_VERSION)
     );
 
     exampleItemModels.add(new ExampleItemModel(

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -184,6 +184,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.location.LocationComponentCameraOptionsActivity"
+            android:label="@string/activity_location_location_component_camera_options_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.location.LocationComponentOptionsActivity"
             android:label="@string/activity_location_location_component_options_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentCameraOptionsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentCameraOptionsActivity.java
@@ -1,0 +1,363 @@
+package com.mapbox.mapboxandroiddemo.examples.location;
+
+import android.annotation.SuppressLint;
+import android.location.Location;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.ListPopupWindow;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.Toast;
+
+import com.mapbox.android.core.location.LocationEngineRequest;
+import com.mapbox.android.core.permissions.PermissionsListener;
+import com.mapbox.android.core.permissions.PermissionsManager;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
+import com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener;
+import com.mapbox.mapboxsdk.location.OnLocationCameraTransitionListener;
+import com.mapbox.mapboxsdk.location.OnLocationClickListener;
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Use LocationComponent camera options to customize the map camera's behavior. More information
+ * can be found at https://docs.mapbox.com/android/maps/overview/location-component and in
+ * {@link CameraMode}.
+ */
+public class LocationComponentCameraOptionsActivity extends AppCompatActivity implements OnMapReadyCallback,
+  OnLocationClickListener, OnCameraTrackingChangedListener {
+
+  private static final String SAVED_STATE_CAMERA = "saved_state_camera";
+  private static final String SAVED_STATE_RENDER = "saved_state_render";
+  private static final String SAVED_STATE_LOCATION = "saved_state_location";
+  private MapView mapView;
+  private Button locationModeBtn;
+  private Button locationTrackingBtn;
+  private PermissionsManager permissionsManager;
+  private LocationComponent locationComponent;
+  private MapboxMap mapboxMap;
+  private Location lastLocation;
+
+  @CameraMode.Mode
+  private int cameraMode = CameraMode.TRACKING;
+
+  @RenderMode.Mode
+  private int renderMode = RenderMode.NORMAL;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_location_component_camera_options);
+
+    mapView = findViewById(R.id.mapView);
+
+    // Check and use saved instance state in case of device rotation
+    if (savedInstanceState != null) {
+      cameraMode = savedInstanceState.getInt(SAVED_STATE_CAMERA);
+      renderMode = savedInstanceState.getInt(SAVED_STATE_RENDER);
+      lastLocation = savedInstanceState.getParcelable(SAVED_STATE_LOCATION);
+    }
+
+    mapView.onCreate(savedInstanceState);
+
+    // Check for (and request) the device location permission
+    if (PermissionsManager.areLocationPermissionsGranted(this)) {
+      mapView.getMapAsync(this);
+    } else {
+      permissionsManager = new PermissionsManager(new PermissionsListener() {
+        @Override
+        public void onExplanationNeeded(List<String> permissionsToExplain) {
+          Toast.makeText(LocationComponentCameraOptionsActivity.this,
+            R.string.user_location_permission_explanation, Toast.LENGTH_LONG).show();
+        }
+
+        @Override
+        public void onPermissionResult(boolean granted) {
+          if (granted) {
+            mapView.getMapAsync(LocationComponentCameraOptionsActivity.this);
+          } else {
+            finish();
+          }
+        }
+      });
+      permissionsManager.requestLocationPermissions(this);
+    }
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
+  }
+
+  @SuppressLint("MissingPermission")
+  @Override
+  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+    mapboxMap.setStyle(Style.MAPBOX_STREETS, style -> {
+
+      setModeButtonListeners();
+
+      // Retrieve and customize the Maps SDK's LocationComponent
+      locationComponent = mapboxMap.getLocationComponent();
+      locationComponent.activateLocationComponent(
+        LocationComponentActivationOptions
+          .builder(this, style)
+          .useDefaultLocationEngine(true)
+          .locationEngineRequest(new LocationEngineRequest.Builder(750)
+            .setFastestInterval(750)
+            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+            .build())
+          .build());
+
+      locationComponent.setLocationComponentEnabled(true);
+      locationComponent.addOnLocationClickListener(this);
+      locationComponent.addOnCameraTrackingChangedListener(this);
+      locationComponent.setCameraMode(cameraMode);
+      setRendererMode(renderMode);
+      locationComponent.forceLocationUpdate(lastLocation);
+    });
+  }
+
+  @SuppressLint("MissingPermission")
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+
+    // Save LocationComponent-related settings to use once device rotation is finished
+    outState.putInt(SAVED_STATE_CAMERA, cameraMode);
+    outState.putInt(SAVED_STATE_RENDER, renderMode);
+    if (locationComponent != null) {
+      outState.putParcelable(SAVED_STATE_LOCATION, locationComponent.getLastKnownLocation());
+    }
+  }
+
+  /**
+   * Listen to and use a tap on the LocationComponent
+   */
+  @Override
+  public void onLocationComponentClick() {
+    Toast.makeText(this, getString(R.string.clicked_on_location_component), Toast.LENGTH_LONG).show();
+  }
+
+  /**
+   * Adjust the LocationComponent's image to one of the preset options.
+   *
+   * @param mode desired normal (small blue circle laid on top of larger white dot),
+   *             compass (arrow point representing the phone's bearing), or
+   *             GPS (blue arrow within a white circle).
+   */
+  private void setRendererMode(@RenderMode.Mode int mode) {
+    renderMode = mode;
+    locationComponent.setRenderMode(mode);
+    if (mode == RenderMode.NORMAL) {
+      locationModeBtn.setText(getString(R.string.normal));
+    } else if (mode == RenderMode.COMPASS) {
+      locationModeBtn.setText(getString(R.string.compass));
+    } else if (mode == RenderMode.GPS) {
+      locationModeBtn.setText(getString(R.string.gps));
+    }
+  }
+
+  private void showModeListDialog() {
+    List<String> modes = new ArrayList<>();
+    modes.add(getString(R.string.normal));
+    modes.add(getString(R.string.compass));
+    modes.add(getString(R.string.gps));
+    ArrayAdapter<String> profileAdapter = new ArrayAdapter<>(this,
+      android.R.layout.simple_list_item_1, modes);
+    ListPopupWindow listPopup = new ListPopupWindow(this);
+    listPopup.setAdapter(profileAdapter);
+    listPopup.setAnchorView(locationModeBtn);
+    listPopup.setOnItemClickListener((parent, itemView, position, id) -> {
+      String selectedMode = modes.get(position);
+      locationModeBtn.setText(selectedMode);
+      if (selectedMode.contentEquals(getString(R.string.normal))) {
+        setRendererMode(RenderMode.NORMAL);
+      } else if (selectedMode.contentEquals(getString(R.string.compass))) {
+        setRendererMode(RenderMode.COMPASS);
+      } else if (selectedMode.contentEquals(getString(R.string.gps))) {
+        setRendererMode(RenderMode.GPS);
+      }
+      listPopup.dismiss();
+    });
+    listPopup.show();
+  }
+
+  /**
+   * Instruct the map camera to disregard the LocationComponent or to
+   * follow the device location in a certain way.
+   * <p>
+   * NONE = No camera tracking.
+   * NONE_COMPASS = Camera does not track location, but does track compass bearing.
+   * NONE_GPS = Camera does not track location, but does track GPS {@link Location} bearing.
+   * TRACKING = Camera tracks the user location.
+   * TRACKING_COMPASS = Camera tracks the user location, with bearing provided by a compass.
+   * TRACKING_GPS = Camera tracks the user location, with bearing provided by a
+   * normalized {@link Location#getBearing()}.
+   * TRACKING_GPS_NORTH = Camera tracks the user location, with bearing always set to north (0).
+   */
+  private void showTrackingListDialog() {
+    List<String> trackingTypes = new ArrayList<>();
+    trackingTypes.add(getString(R.string.none));
+    trackingTypes.add(getString(R.string.none_compass));
+    trackingTypes.add(getString(R.string.none_gps));
+    trackingTypes.add(getString(R.string.tracking));
+    trackingTypes.add(getString(R.string.tracking_compass));
+    trackingTypes.add(getString(R.string.tracking_gps));
+    trackingTypes.add(getString(R.string.tracking_gps_north));
+    ArrayAdapter<String> profileAdapter = new ArrayAdapter<>(this,
+      android.R.layout.simple_list_item_1, trackingTypes);
+    ListPopupWindow listPopup = new ListPopupWindow(this);
+    listPopup.setAdapter(profileAdapter);
+    listPopup.setAnchorView(locationTrackingBtn);
+    listPopup.setOnItemClickListener((parent, itemView, position, id) -> {
+      String selectedTrackingType = trackingTypes.get(position);
+      locationTrackingBtn.setText(selectedTrackingType);
+      if (selectedTrackingType.contentEquals(getString(R.string.none))) {
+        setCameraTrackingMode(CameraMode.NONE);
+      } else if (selectedTrackingType.contentEquals(getString(R.string.none_compass))) {
+        setCameraTrackingMode(CameraMode.NONE_COMPASS);
+      } else if (selectedTrackingType.contentEquals(getString(R.string.none_gps))) {
+        setCameraTrackingMode(CameraMode.NONE_GPS);
+      } else if (selectedTrackingType.contentEquals(getString(R.string.tracking))) {
+        setCameraTrackingMode(CameraMode.TRACKING);
+      } else if (selectedTrackingType.contentEquals(getString(R.string.tracking_compass))) {
+        setCameraTrackingMode(CameraMode.TRACKING_COMPASS);
+      } else if (selectedTrackingType.contentEquals(getString(R.string.tracking_gps))) {
+        setCameraTrackingMode(CameraMode.TRACKING_GPS);
+      } else if (selectedTrackingType.contentEquals(getString(R.string.tracking_gps_north))) {
+        setCameraTrackingMode(CameraMode.TRACKING_GPS_NORTH);
+      }
+      listPopup.dismiss();
+    });
+    listPopup.show();
+  }
+
+  private void setCameraTrackingMode(@CameraMode.Mode int mode) {
+    locationComponent.setCameraMode(mode, new OnLocationCameraTransitionListener() {
+      @Override
+      public void onLocationCameraTransitionFinished(@CameraMode.Mode int cameraMode) {
+        if (mode != CameraMode.NONE) {
+          locationComponent.zoomWhileTracking(15, 750, new MapboxMap.CancelableCallback() {
+            @Override
+            public void onCancel() {
+              // No impl
+            }
+
+            @Override
+            public void onFinish() {
+              locationComponent.tiltWhileTracking(45);
+            }
+          });
+        } else {
+          mapboxMap.easeCamera(CameraUpdateFactory.tiltTo(0));
+        }
+      }
+
+      @Override
+      public void onLocationCameraTransitionCanceled(@CameraMode.Mode int cameraMode) {
+        // No impl
+      }
+    });
+  }
+
+  @Override
+  public void onCameraTrackingDismissed() {
+    locationTrackingBtn.setText(getString(R.string.none));
+  }
+
+  @Override
+  public void onCameraTrackingChanged(int currentMode) {
+    this.cameraMode = currentMode;
+    if (currentMode == CameraMode.NONE) {
+      locationTrackingBtn.setText(getString(R.string.none));
+    } else if (currentMode == CameraMode.NONE_COMPASS) {
+      locationTrackingBtn.setText(getString(R.string.none_compass));
+    } else if (currentMode == CameraMode.NONE_GPS) {
+      locationTrackingBtn.setText(getString(R.string.none_gps));
+    } else if (currentMode == CameraMode.TRACKING) {
+      locationTrackingBtn.setText(getString(R.string.tracking));
+    } else if (currentMode == CameraMode.TRACKING_COMPASS) {
+      locationTrackingBtn.setText(getString(R.string.tracking_compass));
+    } else if (currentMode == CameraMode.TRACKING_GPS) {
+      locationTrackingBtn.setText(getString(R.string.tracking_gps));
+    } else if (currentMode == CameraMode.TRACKING_GPS_NORTH) {
+      locationTrackingBtn.setText(getString(R.string.tracking_gps_north));
+    }
+  }
+
+  private void setModeButtonListeners() {
+    locationModeBtn = findViewById(R.id.button_location_mode);
+    locationModeBtn.setOnClickListener(v -> {
+      if (locationComponent == null) {
+        return;
+      }
+      showModeListDialog();
+    });
+
+    locationTrackingBtn = findViewById(R.id.button_location_tracking);
+    locationTrackingBtn.setOnClickListener(v -> {
+      if (locationComponent == null) {
+        return;
+      }
+      showTrackingListDialog();
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/drawable-anydpi/ic_keyboard_arrow_up.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable-anydpi/ic_keyboard_arrow_up.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M7.41,15.41L12,10.83l4.59,4.58L18,14l-6,-6 -6,6z"/>
+</vector>

--- a/MapboxAndroidDemo/src/main/res/drawable-anydpi/ic_signal_wifi_4_bar.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable-anydpi/ic_signal_wifi_4_bar.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12.01,21.49L23.64,7c-0.45,-0.34 -4.93,-4 -11.64,-4C5.28,3 0.81,6.66 0.36,7l11.63,14.49 0.01,0.01 0.01,-0.01z"/>
+</vector>

--- a/MapboxAndroidDemo/src/main/res/drawable-xxhdpi/custom_user_icon.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable-xxhdpi/custom_user_icon.xml
@@ -1,0 +1,10 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportHeight="14.0"
+    android:viewportWidth="14.0">
+    <path
+        android:fillColor="#fff"
+        android:pathData="M7,7m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"/>
+</vector>

--- a/MapboxAndroidDemo/src/main/res/drawable-xxxhdpi/custom_user_arrow.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable-xxxhdpi/custom_user_arrow.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="36dp"
+        android:height="36dp"
+        android:viewportHeight="36.0"
+        android:viewportWidth="36.0">
+    <path
+        android:fillColor="#FF82C6"
+        android:pathData="M18,0L23,7L13,7L18,0ZM22.8,7C21.33,6.36 19.71,6 18,6C16.29,6 14.67,6.36 13.2,7L22.8,7Z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1"/>
+</vector>

--- a/MapboxAndroidDemo/src/main/res/drawable/custom_user_puck_icon.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable/custom_user_puck_icon.xml
@@ -1,0 +1,23 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="75dp"
+    android:height="75dp"
+    android:viewportHeight="75.0"
+    android:viewportWidth="75.0">
+    <path
+        android:fillAlpha="0.16"
+        android:fillColor="#FF3D57"
+        android:pathData="M37.5,37.5m-37.5,0a37.5,37.5 0,1 1,75 0a37.5,37.5 0,1 1,-75 0"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1"/>
+    <path
+        android:fillColor="#000000"
+        android:pathData="M37.5,37.5m-28.5,0a28.5,28.5 0,1 1,57 0a28.5,28.5 0,1 1,-57 0"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1"/>
+    <path
+        android:fillColor="#FF82C6"
+        android:pathData="M39.2,28.46C39.01,27.99 38.54,27.68 38.02,27.69C37.5,27.7 37.02,28.01 36.81,28.49L27.05,45.83C26.83,46.32 26.92,46.89 27.28,47.26C27.65,47.64 28.21,47.75 28.71,47.54L37.07,44.03C37.39,43.89 37.75,43.89 38.06,44.02L46.27,47.34C46.75,47.54 47.33,47.42 47.71,47.03C48.09,46.64 48.21,46.07 48,45.59L39.2,28.46Z"
+        android:strokeColor="#00000000"
+        android:strokeWidth="1"/>
+</vector>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_location_component_camera_options.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_location_component_camera_options.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="0dp"
+        mapbox:mapbox_cameraZoom="10"
+        app:layout_constraintBottom_toTopOf="@+id/linearLayout"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        style="?android:attr/buttonBarStyle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/colorPrimaryDark"
+        android:orientation="horizontal"
+        android:weightSum="4"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        tools:layout_constraintBottom_creator="1"
+        tools:layout_constraintLeft_creator="1"
+        tools:layout_constraintRight_creator="1">
+
+        <TextView
+            android:id="@+id/tv_mode"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight=".75"
+            android:gravity="center"
+            android:text="Mode:"
+            android:textColor="@color/mapboxWhite"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/button_location_mode"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.25"
+            android:gravity="center"
+            android:text="Normal"
+            android:textColor="@android:color/white" />
+
+        <TextView
+            android:id="@+id/tv_tracking"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight=".85"
+            android:gravity="center"
+            android:text="Tracking:"
+            android:textColor="@color/mapboxWhite"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/button_location_tracking"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.15"
+            android:gravity="center"
+            android:text="None"
+            android:textColor="@android:color/white" />
+
+    </LinearLayout>
+
+</android.support.constraint.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -367,5 +367,17 @@
     <!-- Scale bar plugin-->
     <string name="zoom_map_fab_instruction">Zoom the map in and out. Click the button to change the scale bar styling.</string>
 
+    <!-- LocationComponent camera options -->
+    <string name="normal">Normal</string>
+    <string name="compass">Compass</string>
+    <string name="gps">GPS</string>
+    <string name="none">None</string>
+    <string name="none_compass">None Compass</string>
+    <string name="none_gps">None GPS</string>
+    <string name="tracking">Tracking</string>
+    <string name="tracking_compass">Tracking Compass</string>
+    <string name="tracking_gps">Tracking GPS</string>
+    <string name="tracking_gps_north">Tracking GPS North</string>
+    <string name="clicked_on_location_component">Clicked on LocationComponent</string>
 
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -96,9 +96,10 @@
     <string name="activity_plugins_place_picker_plugin_description">Use the place picker function of the Places Plugin to choose a specific location in the world.</string>
     <string name="activity_plugins_markerview_plugin_description">Create a marker with an Android-system View.</string>
     <string name="activity_plugins_scalebar_plugin_description">Add a scale bar to determine distance based on zoom level.</string>
-    <string name="activity_location_location_component_description">Use the location component to easily show a user\'s location on the map</string>
-    <string name="activity_location_user_location_map_frag_plugin_description">Use the location component to display a user\'s location on a map fragment.</string>
-    <string name="activity_location_location_component_options_description">Use location component options to customize the user location information.</string>
+    <string name="activity_location_location_component_description">Use the LocationComponent to easily show a user\'s location on the map</string>
+    <string name="activity_location_user_location_map_frag_plugin_description">Use the LocationComponent to display a user\'s location on a map fragment.</string>
+    <string name="activity_location_location_component_options_description">Use LocationComponent options to customize the user location information.</string>
+    <string name="activity_location_location_component_camera_options_description">Use LocationComponent camera options to customize map camera behavior.</string>
     <string name="activity_java_services_simplify_polyline_description">Using the polylines utility, simplify a polyline which reduces the amount of coordinates making up the polyline depending on tolerance.</string>
     <string name="activity_java_services_map_matching_description">Match raw GPS points to the map so they aligns with the roads/pathways.</string>
     <string name="activity_image_generator_snapshot_share_description">Send and share a map snapshot image.</string>

--- a/MapboxAndroidDemo/src/main/res/values/styles.xml
+++ b/MapboxAndroidDemo/src/main/res/values/styles.xml
@@ -22,4 +22,22 @@
         <item name="android:textColor">@color/mapboxWhite</item>
     </style>
 
+    <style name="custom_locationComponent" parent="mapbox_LocationComponent">
+        <item name="mapbox_foregroundDrawable">@drawable/custom_user_icon</item>
+
+        <item name="mapbox_bearingDrawable">@drawable/custom_user_arrow</item>
+        <item name="mapbox_gpsDrawable">@drawable/custom_user_puck_icon</item>
+
+        <item name="mapbox_accuracyAlpha">0.15</item>
+        <item name="mapbox_accuracyColor">#FF82C6</item>
+
+        <item name="mapbox_elevation">0dp</item>
+        <item name="mapbox_compassAnimationEnabled">false</item>
+        <item name="mapbox_accuracyAnimationEnabled">false</item>
+
+        <item name="mapbox_layer_above">road-label</item>
+    </style>
+
+
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -96,6 +96,7 @@
     <string name="activity_plugins_scalebar_plugin_title">Scale bar</string>
     <string name="activity_location_user_location_map_frag_title">Show a user\'s location on a map fragment</string>
     <string name="activity_location_location_component_title">Show a user\'s location</string>
+    <string name="activity_location_location_component_camera_options_title">Location camera options</string>
     <string name="activity_location_location_component_options_title">Customized location icon</string>
     <string name="activity_java_services_simplify_polyline_title">Simplify a polyline</string>
     <string name="activity_java_services_map_matching_title">Map Matching</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -98,6 +98,7 @@
     <string name="activity_location_location_component_url" translatable="false">https://i.imgur.com/77PVsni.png</string>
     <string name="activity_location_user_location_fragment_plugin_url" translatable="false">https://i.imgur.com/1jG8WQG.png</string>
     <string name="activity_location_location_component_options_url" translatable="false">https://i.imgur.com/4HiEJC1.png</string>
+    <string name="activity_location_location_component_camera_options_url" translatable="false">https://i.imgur.com/Q2cB3NY.png</string>
     <string name="activity_java_services_simplify_polyline_url" translatable="false">http://i.imgur.com/uATgul1.png</string>
     <string name="activity_java_services_map_matching_url" translatable="false">https://i.imgur.com/ig8gGnY.png</string>
     <string name="activity_image_generator_snapshot_notification_url" translatable="false">https://i.imgur.com/OiveDFG.png</string>


### PR DESCRIPTION
This pr resolves https://github.com/mapbox/mapbox-android-demo/issues/969 by adding an example that show the `LocationComponent`'s various camera mode options.  The example is a close copy of [the Maps SDK test app's `LocationComponent` camera options example](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/android/MapboxGLAndroidSDKTestApp/src/main/java/com/mapbox/mapboxsdk/testapp/activity/location/LocationModesActivity.java): 

Related: https://github.com/mapbox/android-docs/issues/854

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/59537829-8d70a680-8eac-11e9-8b36-10a5872a8e13.gif)

