### PR TITLE
Updated Mapbox SF office coordinates for PlacesPluginActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlacesPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlacesPluginActivity.java
@@ -105,8 +105,8 @@ public class PlacesPluginActivity extends AppCompatActivity implements OnMapRead
 
   private void addUserLocations() {
     home = CarmenFeature.builder().text("Mapbox SF Office")
-      .geometry(Point.fromLngLat(-122.399854, 37.7884400))
-      .placeName("50 Beale st, San Francisco, CA")
+      .geometry(Point.fromLngLat(-122.3964485, 37.7912561))
+      .placeName("50 Beale St, San Francisco, CA")
       .id("mapbox-sf")
       .properties(new JsonObject())
       .build();


### PR DESCRIPTION
Address for Mapbox SF office was correct, but coordinates were incorrect and leftover from previous Mapbox office. This pr updates the coordinates so that the pin is dropped in the correct location.