### PR TITLE
Adding SKU generation

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -816,6 +816,11 @@
             android:name="android.appwidget.provider"
             android:resource="@xml/demo_app_home_screen_widget_info" />
     </receiver>
+
+        <!-- Set value to true to have SKU token generation on -->
+        <meta-data
+            android:name="com.mapbox.EnableSkuToken"
+            android:value="true" />
     </application>
 
 </manifest>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     version = [
 
             // Mapbox
-            mapboxMapSdk             : '7.3.2',
+            mapboxMapSdk             : '7.4.0-beta.2',
             mapboxTurf               : '4.6.0',
             mapboxServices           : '4.6.0',
             mapboxPluginBuilding     : '0.5.0',


### PR DESCRIPTION
This pr bumps the Maps SDK dependency to `7.4.0-beta.2` and adds a manifest tag. Both are needed to enabled SKU token generation.

https://github.com/mapbox/mapbox-android-demo/pull/1019 is related