### PR TITLE
Switching to greater than or equals for circle clustering example

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleLayerClusteringActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleLayerClusteringActivity.java
@@ -31,7 +31,6 @@ import static com.mapbox.mapboxsdk.style.expressions.Expression.all;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.division;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.exponential;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
-import static com.mapbox.mapboxsdk.style.expressions.Expression.gt;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.gte;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.has;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.interpolate;
@@ -208,7 +207,7 @@ public class CircleLayerClusteringActivity extends AppCompatActivity {
           ? all(has("point_count"),
           gte(pointCount, literal(layers[i][0]))
         ) : all(has("point_count"),
-          gt(pointCount, literal(layers[i][0])),
+          gte(pointCount, literal(layers[i][0])),
           lt(pointCount, literal(layers[i - 1][0]))
         )
       );


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1048 by switching to greater than or equal (`gte`) for some runtime styling in the circle cluster example.

cc @martinKindall 