### PR TITLE
Adding example of textField label multiple colors 

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -131,6 +131,7 @@ import com.mapbox.mapboxandroiddemo.examples.styles.RotatingTextAnchorPositionAc
 import com.mapbox.mapboxandroiddemo.examples.styles.ShowHideLayersActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.StyleFadeSwitchActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.TextFieldFormattingActivity;
+import com.mapbox.mapboxandroiddemo.examples.styles.TextFieldMultipleColorActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.TextFieldMultipleFormatsActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.TransparentBackgroundActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.VectorSourceActivity;
@@ -627,6 +628,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, TextFieldFormattingActivity.class),
       null,
       R.string.activity_styles_text_field_formatting_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_styles,
+      R.string.activity_styles_text_field_multiple_colors_title,
+      R.string.activity_styles_text_field_multiple_colors_description,
+      new Intent(MainActivity.this, TextFieldMultipleColorActivity.class),
+      null,
+      R.string.activity_styles_text_field_multiple_colors_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_extrusions,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -99,6 +99,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.styles.TextFieldMultipleColorActivity"
+            android:label="@string/activity_styles_text_field_multiple_colors_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.offline.SimpleOfflineMapActivity"
             android:label="@string/activity_offline_simple_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/TextFieldMultipleColorActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/TextFieldMultipleColorActivity.java
@@ -1,0 +1,126 @@
+package com.mapbox.mapboxandroiddemo.examples.styles;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatFontScale;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatTextColor;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.format;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.formatEntry;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
+
+
+/**
+ * Use runtime styling to create SymbolLayer text labels that have different colors.
+ */
+public class TextFieldMultipleColorActivity extends AppCompatActivity {
+
+  private MapView mapView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_style_text_field_multiple_colors);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+        mapboxMap.setStyle(Style.DARK, new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull final Style style) {
+
+            // Set up label formatting expression
+            Expression.FormatEntry firstLabel = formatEntry(
+              get("name_en"),
+              formatTextColor(Color.YELLOW)
+            );
+
+            Expression.FormatEntry newLine = formatEntry(
+              // Add "\n" in order to break the line and have the second label underneath
+              "\n",
+              formatFontScale(0.5)
+            );
+
+            Expression.FormatEntry secondLabel = formatEntry(
+              get("name"),
+              formatTextColor(Color.RED)
+            );
+
+            Expression format = format(firstLabel, newLine, secondLabel);
+
+            // Retrieve the country label layers from the style and update them with the formatting expression
+            for (Layer mapLabelLayer : style.getLayers()) {
+              if (mapLabelLayer.getId().contains("country-label")) {
+                // Apply formatting expression
+                mapLabelLayer.setProperties(textField(format));
+              }
+            }
+          }
+        });
+      }
+    });
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_style_text_field_multiple_colors.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_style_text_field_multiple_colors.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.styles.TextFieldMultipleColorActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="48.4"
+        mapbox:mapbox_cameraTargetLng="18.49"
+        mapbox:mapbox_cameraZoom="4.5" />
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -19,6 +19,7 @@
     <string name="activity_styles_vector_source_description">Add a vector source to a map and display it as a layer.</string>
     <string name="activity_styles_add_wms_source_description">Adding an external Web Map Service layer to the map.</string>
     <string name="activity_styles_zoom_dependent_fill_color_description">Make a property depend on the map zoom level, in this case, the water layers fill color.</string>
+    <string name="activity_styles_text_field_multiple_colors_description">Use runtime styling to create SymbolLayer text labels that have different colors.</string>
     <string name="activity_dds_create_hotspots_points_description">Use the Mapbox Maps SDK to visualize point data as hotspots.</string>
     <string name="activity_styles_dds_geojson_circle_layer_clusters_description">Use GeoJSON and circle layers to visualize point data in clusters.</string>
     <string name="activity_dds_image_clustering_description">Use GeoJSON and SymbolLayer icons to view clustered images.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -28,6 +28,7 @@
     <string name="activity_styles_hillshade_title">Hillshading</string>
     <string name="activity_styles_fade_switch_title">Switch map styles with fade</string>
     <string name="activity_styles_text_field_multiple_formats_title">Multiple text formats</string>
+    <string name="activity_styles_text_field_multiple_colors_title">Multiple text colors</string>
     <string name="activity_styles_transparent_background_title">Transparent render surface</string>
     <string name="activity_styles_click_to_add_image_title">Click to add photo</string>
     <string name="activity_styles_rotating_anchor_text_title">Text anchor position</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -33,6 +33,8 @@
     <string name="activity_styles_transparent_background_url" translatable="false">https://i.imgur.com/5bYnlp5.png</string>
     <string name="activity_styles_click_to_add_image_url" translatable="false">https://i.imgur.com/uPIH5Ck.png</string>
     <string name="activity_styles_rotating_anchor_text_url" translatable="false">https://i.imgur.com/w8cP6Wn.png</string>
+    <string name="activity_styles_text_field_multiple_colors_url" translatable="false">https://i.imgur.com/sqj7TxX.png</string>
+
     <string name="activity_extrusions_population_density_extrusions_url" translatable="false">http://i.imgur.com/se1z8Wb.png</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_url" translatable="false">http://i.imgur.com/6j848JL.jpg</string>
     <string name="activity_extrusions_adjust_extrusions_url" translatable="false">http://i.imgur.com/XNTyIO5.png</string>


### PR DESCRIPTION
This pr adds a simple example of using `Expression.FormatEntry` to set multiple colors for `SymbolLayer` text fields. 

cc @chloekraw 


![ezgif com-resize (11)](https://user-images.githubusercontent.com/4394910/57340851-8eaff600-70ec-11e9-9918-b472d32a97b1.gif)

