### PR TITLE
Adding multiple color formatting to TextFieldMultipleFormatsActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/TextFieldMultipleFormatsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/TextFieldMultipleFormatsActivity.java
@@ -1,5 +1,6 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
@@ -14,6 +15,7 @@ import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.Layer;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatFontScale;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatTextColor;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.FormatOption.formatTextFont;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.format;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.formatEntry;
@@ -22,8 +24,8 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
 
 
 /**
- * Use runtime styling to create labels with a SymbolLayer that include multiple
- * text fonts and sizes.
+ * Use runtime styling to create labels with a SymbolLayer that include multiple text
+ * languages, fonts, sizes, and colors.
  */
 public class TextFieldMultipleFormatsActivity extends AppCompatActivity {
 
@@ -53,16 +55,19 @@ public class TextFieldMultipleFormatsActivity extends AppCompatActivity {
             Expression.FormatEntry bigLabel = formatEntry(
               get("name_en"),
               formatFontScale(1.5),
+              formatTextColor(Color.BLUE),
               formatTextFont(new String[] {"Ubuntu Medium", "Arial Unicode MS Regular"})
             );
 
             Expression.FormatEntry newLine = formatEntry(
+              // Add "\n" in order to break the line and have the second label underneath
               "\n",
               formatFontScale(0.5)
             );
 
             Expression.FormatEntry smallLabel = formatEntry(
               get("name"),
+              formatTextColor(Color.parseColor("#d6550a")),
               formatTextFont(new String[] {"Caveat Regular", "Arial Unicode MS Regular"})
             );
 

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -30,7 +30,7 @@
     <string name="activity_style_image_source_description">Use an image source to easily display images on the map.</string>
     <string name="activity_style_hillshade_description">Use elevation data to show and customize hills and mountains.</string>
     <string name="activity_styles_fade_switch_description">Fade map styles in and out based on zoom level.</string>
-    <string name="activity_styles_text_field_multiple_formats_description">Use a format expression to style labels in multiple ways.</string>
+    <string name="activity_styles_text_field_multiple_formats_description">Use a format expression to style labels with multiple languages, fonts, sizes, and colors.</string>
     <string name="activity_styles_transparent_background_description">Create a transparent background and fill it with something such as moving water.</string>
     <string name="activity_styles_click_to_add_image_description">Select a photo on the device and add it on the map tap location.</string>
     <string name="activity_styles_rotating_anchor_text_description">Adjust the anchor position of SymbolLayer text fields.</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -29,7 +29,7 @@
     <string name="activity_style_image_source_url" translatable="false">https://i.imgur.com/I6B6cCE.png</string>
     <string name="activity_style_hillshade_url" translatable="false">https://i.imgur.com/U2OKixV.png</string>
     <string name="activity_styles_fade_switch_url" translatable="false">https://i.imgur.com/1sPnDx5.png</string>
-    <string name="activity_styles_text_field_multiple_formats_url" translatable="false">https://i.imgur.com/OIbBFI5.png</string>
+    <string name="activity_styles_text_field_multiple_formats_url" translatable="false">https://i.imgur.com/dpiGiTg.png</string>
     <string name="activity_styles_transparent_background_url" translatable="false">https://i.imgur.com/5bYnlp5.png</string>
     <string name="activity_styles_click_to_add_image_url" translatable="false">https://i.imgur.com/uPIH5Ck.png</string>
     <string name="activity_styles_rotating_anchor_text_url" translatable="false">https://i.imgur.com/w8cP6Wn.png</string>


### PR DESCRIPTION
This pr adds multiple color formatting to @riastrad 's existing example of multiple font/size text (https://github.com/mapbox/mapbox-android-demo/pull/988). `TextFieldMultipleFormatsActivity` already showed how to use different text sizes and fonts. This pr adds usage of `formatTextColor(int)` to the `textField` formatting.

cc @chloekraw 

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/57412560-df375a00-71a5-11e9-9479-160de5b712f2.gif)
