### PR TITLE
Adding example of ignorePlacement/allowOverlap for text and icons

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -59,6 +59,7 @@ import com.mapbox.mapboxandroiddemo.examples.dds.PolygonSelectToggleActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.SatelliteLandSelectActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.StyleCirclesCategoricallyActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.StyleLineIdentityPropertyActivity;
+import com.mapbox.mapboxandroiddemo.examples.dds.SymbolCollisionDetectionActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.SymbolSwitchOnZoomActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.AdjustExtrusionLightActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.Indoor3DMapActivity;
@@ -1289,6 +1290,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       null,
       new Intent(MainActivity.this, PolygonSelectToggleActivity.class),
       R.string.activity_dds_polygon_select_toggle_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_dds,
+      R.string.activity_dds_symbol_collision_detection_title,
+      R.string.activity_dds_symbol_collision_detection_description,
+      new Intent(MainActivity.this, SymbolCollisionDetectionActivity.class),
+      null,
+      R.string.activity_dds_symbol_collision_detection_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_basics,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -743,6 +743,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.dds.SymbolCollisionDetectionActivity"
+            android:label="@string/activity_dds_symbol_collision_detection_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.snapshot.SnapshotShareActivity"
             android:label="@string/activity_image_generator_snapshot_share_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolCollisionDetectionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolCollisionDetectionActivity.java
@@ -1,0 +1,197 @@
+package com.mapbox.mapboxandroiddemo.examples.dds;
+
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.CompoundButton;
+import android.widget.Switch;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textIgnorePlacement;
+
+/**
+ * Use {@link com.mapbox.mapboxsdk.style.layers.PropertyFactory#iconIgnorePlacement(Boolean)},
+ * {@link com.mapbox.mapboxsdk.style.layers.PropertyFactory#iconAllowOverlap(Boolean)},
+ * {@link com.mapbox.mapboxsdk.style.layers.PropertyFactory#textIgnorePlacement(Boolean)},
+ * and {@link com.mapbox.mapboxsdk.style.layers.PropertyFactory#iconAllowOverlap(Boolean)},
+ * to handle icon and text collisions.
+ */
+public class SymbolCollisionDetectionActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private static final String ICON_SOURCE_ID = "ICON_SOURCE_ID";
+  private static final String ICON_ID = "ICON_ID";
+  private static final String ICON_LAYER_ID = "ICON_LAYER_ID";
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private List<Feature> symbolLayerIconFeatureList;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_dds_symbol_collision);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(final MapboxMap mapboxMap) {
+    initIconCoordinates();
+
+    mapboxMap.setStyle(new Style.Builder().fromUrl(Style.MAPBOX_STREETS)
+
+      // Add the SymbolLayer icon image to the map style
+      .withImage(ICON_ID, BitmapFactory.decodeResource(
+        SymbolCollisionDetectionActivity.this.getResources(), R.drawable.red_marker))
+
+      // Adding a GeoJson source for the SymbolLayer icons.
+      .withSource(new GeoJsonSource(ICON_SOURCE_ID,
+        FeatureCollection.fromFeatures(symbolLayerIconFeatureList)))
+
+      // Adding the actual SymbolLayer to the map style. An offset is added that the bottom of the red
+      // marker icon gets fixed to the coordinate, rather than the middle of the icon being fixed to
+      // the coordinate point. This is offset is not always needed and is dependent on the image
+      // that you use for the SymbolLayer icon.
+      .withLayer(new SymbolLayer(ICON_LAYER_ID, ICON_SOURCE_ID)
+        .withProperties(PropertyFactory.iconImage(ICON_ID),
+          iconOffset(new Float[] {0f, -9f}))
+      ), new Style.OnStyleLoaded() {
+        @Override
+        public void onStyleLoaded(@NonNull Style style) {
+
+          SymbolCollisionDetectionActivity.this.mapboxMap = mapboxMap;
+          setUpCheckListener(R.id.toggle_text_ignore_placement_switch, true, false);
+          setUpCheckListener(R.id.toggle_text_ignore_overlap_switch, false, false);
+          setUpCheckListener(R.id.toggle_icon_ignore_placement_switch, false, true);
+          setUpCheckListener(R.id.toggle_icon_ignore_overlap_switch, false, false);
+        }
+      });
+  }
+
+  /**
+   * Add a {@link android.widget.CompoundButton.OnCheckedChangeListener} to a switch button and then
+   * use the Maps SDK's runtime-styling to adjust overlap and placement logic.
+   *
+   * @param checkboxId the id of the switch button to add a listener to
+   * @param adjustTextIgnorePlacement whether or not text placement should be ignored
+   * @param adjustIconIgnorePlacement whether or not icon placement should be ignored
+   */
+  private void setUpCheckListener(int checkboxId, boolean adjustTextIgnorePlacement,
+                                  boolean adjustIconIgnorePlacement) {
+    Switch switchUi = findViewById(checkboxId);
+    switchUi.setText(getString(R.string.collision_disabled));
+    switchUi.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+      @Override
+      public void onCheckedChanged(CompoundButton compoundButton, boolean checked) {
+        switchUi.setText(checked ? getString(R.string.collision_enabled) : getString(R.string.collision_disabled));
+        Layer singleLayer = mapboxMap.getStyle().getLayer(adjustIconIgnorePlacement ? ICON_LAYER_ID : "country-label");
+        singleLayer.setProperties(
+          adjustTextIgnorePlacement ? textIgnorePlacement(checked) : textAllowOverlap(checked),
+          adjustIconIgnorePlacement ? iconIgnorePlacement(checked) : iconAllowOverlap(checked)
+        );
+      }
+    });
+  }
+
+  /**
+   * Initialize a list of Features to use to show SymbolLayer icons.
+   */
+  private void initIconCoordinates() {
+    symbolLayerIconFeatureList = new ArrayList<>();
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(10.338784, 49.481615)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(15.081775, 49.957444)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(11.810747, 50.53269)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(16.308411, 51.35705)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(19.661215, 49.161803)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(16.799065, 46.864746)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(13.364485, 52.764672)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(8.457943, 51.203595)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(12.873831, 51.459068)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(14.836448, 52.814126)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(9.193924, 52.516561)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(12.219625, 47.143578)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(14.182242, 48.893705)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(16.717289, 50.324313)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(22.686916, 45.905823)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(7.967289, 49.904804)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(6.98598, 47.916571)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(18.925233, 44.231107)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(18.843458, 49.957444)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(-17.999544, 62.216028)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(20.151869, 46.415586)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(9.193924, 51.864868)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(16.144859, 48.732152)));
+    symbolLayerIconFeatureList.add(Feature.fromGeometry(Point.fromLngLat(5.105139, 50.324313)));
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_dds_symbol_collision.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_dds_symbol_collision.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="36.132522"
+        mapbox:mapbox_cameraTargetLng="16.156205"
+        mapbox:mapbox_cameraZoom="2.494647" />
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/cardView4"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="16dp"
+        mapbox:layout_constraintBottom_toTopOf="@+id/cardView5"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/textView3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/placement_explanation"
+                mapbox:layout_constraintStart_toStartOf="parent"
+                mapbox:layout_constraintTop_toTopOf="parent"
+
+                />
+
+            <Switch
+                android:id="@+id/toggle_text_ignore_placement_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|bottom"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                mapbox:layout_constraintBottom_toBottomOf="parent"
+                mapbox:layout_constraintStart_toStartOf="@+id/textView3"
+                mapbox:layout_constraintTop_toBottomOf="@+id/textView3" />
+
+        </android.support.constraint.ConstraintLayout>
+
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/cardView5"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="48dp"
+        mapbox:layout_constraintBottom_toBottomOf="@+id/mapView"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/textView4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/overlap_explanation"
+                mapbox:layout_constraintStart_toStartOf="parent"
+                mapbox:layout_constraintTop_toTopOf="parent" />
+
+            <Switch
+                android:id="@+id/toggle_text_ignore_overlap_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|bottom"
+                android:layout_marginTop="8dp"
+                mapbox:layout_constraintStart_toStartOf="@+id/textView4"
+                mapbox:layout_constraintTop_toBottomOf="@+id/textView4" />
+
+        </android.support.constraint.ConstraintLayout>
+
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/cardView6"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="24dp"
+        mapbox:layout_constraintBottom_toTopOf="@+id/cardView4"
+        mapbox:layout_constraintEnd_toEndOf="@+id/mapView"
+        mapbox:layout_constraintStart_toStartOf="@+id/mapView">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/textView5"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/icon_overlap_explanation"
+                mapbox:layout_constraintStart_toStartOf="parent"
+                mapbox:layout_constraintTop_toTopOf="parent"
+
+
+                />
+
+            <Switch
+                android:id="@+id/toggle_icon_ignore_overlap_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|bottom"
+                android:layout_marginTop="8dp"
+                mapbox:layout_constraintStart_toStartOf="@+id/textView5"
+                mapbox:layout_constraintTop_toBottomOf="@+id/textView5" />
+
+        </android.support.constraint.ConstraintLayout>
+
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView
+        android:layout_width="395dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginBottom="16dp"
+        mapbox:layout_constraintBottom_toTopOf="@+id/cardView6"
+        mapbox:layout_constraintEnd_toEndOf="@+id/mapView"
+        mapbox:layout_constraintStart_toStartOf="@+id/mapView">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <TextView
+                android:id="@+id/textView6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/icon_placement_explanation"
+                mapbox:layout_constraintStart_toStartOf="parent"
+                mapbox:layout_constraintTop_toTopOf="parent" />
+
+            <Switch
+                android:id="@+id/toggle_icon_ignore_placement_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end|bottom"
+                android:layout_marginTop="8dp"
+                mapbox:layout_constraintStart_toStartOf="@+id/textView6"
+                mapbox:layout_constraintTop_toBottomOf="@+id/textView6" />
+
+        </android.support.constraint.ConstraintLayout>
+
+    </android.support.v7.widget.CardView>
+
+
+</android.support.constraint.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -336,4 +336,13 @@
 
     <!-- Turf circle ring-->
     <string name="tap_on_map">Tap on the map to move the ring</string>
+
+    <!-- Collision toggle -->
+    <string name="collision_enabled">true</string>
+    <string name="collision_disabled">false</string>
+    <string name="placement_explanation">textIgnorePlacement: other symbols can be visible even if \n they collide with the text</string>
+    <string name="overlap_explanation">textAllowOverlap: if true, the text will be visible even if it collides with other previously drawn symbols</string>
+    <string name="icon_overlap_explanation">iconAllowOverlap: the icon will be visible even if it collides with other previously drawn symbols</string>
+    <string name="icon_placement_explanation">iconIgnorePlacement: other symbols can be visible even if \n they collide with the icon</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -58,6 +58,9 @@
     <string name="activity_dds_geojson_line_description">Draw a polyline by parsing a GeoJSON file with the Mapbox Maps SDK.</string>
     <string name="activity_dds_polygon_description">Draw a vector polygon on a map with the Mapbox Maps SDK.</string>
     <string name="activity_dds_polygon_holes_description">Draw a vector polygon with holes on a map using the Mapbox Maps SDK.</string>
+    <string name="activity_dds_symbol_collision_detection_description">Draw a vector polygon with holes on a map using the Mapbox Maps SDK.</string>
+
+
     <string name="activity_styles_text_field_formatting_description">Adjust the color, size, and fonts of SymbolLayer text fields.</string>
     <string name="activity_annotation_marker_view_description">Attach a view to a given position on the map.</string>
     <string name="activity_annotation_custom_info_window_description">Use an info window adapter to customize the info window.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -58,6 +58,7 @@
     <string name="activity_dds_geojson_line_title">Draw a GeoJSON line</string>
     <string name="activity_dds_polygon_title">Draw a polygon</string>
     <string name="activity_dds_polygon_holes_title">Draw a polygon with holes</string>
+    <string name="activity_dds_symbol_collision_detection_title">Toggle collision detection</string>
     <string name="activity_styles_text_field_formatting_title">Adjust text labels</string>
     <string name="activity_annotation_marker_view_title">Draw a marker view</string>
     <string name="activity_annotation_custom_info_window_title">Custom info window</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -57,6 +57,7 @@
     <string name="activity_dds_geojson_line_url" translatable="false">https://i.imgur.com/Bs0X98z.png</string>
     <string name="activity_dds_polygon_url" translatable="false">http://i.imgur.com/v9X28id.png</string>
     <string name="activity_dds_polygon_holes_url" translatable="false">https://i.imgur.com/6hcqbNw.png</string>
+    <string name="activity_dds_symbol_collision_detection_url" translatable="false">https://i.imgur.com/nV1YnIv.png</string>
     <string name="activity_styles_text_field_formatting_url" translatable="false">https://i.imgur.com/MSoIYmU.png</string>
     <string name="activity_annotation_basic_marker_view_url" translatable="false">http://i.imgur.com/vbWTLIE.png</string>
     <string name="activity_annotation_custom_info_window_url" translatable="false">http://i.imgur.com/mCWbosy.png</string>


### PR DESCRIPTION
This pr adds an example of using `textIgnorePlacement`, `textAllowOverlap`, `iconIgnorePlacement`, and `iconAllowOverlap`. These are options within runtime styling and this example helps to visualize these booleans' effects.

cc @chloekraw 

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/57735129-72fe9f80-7658-11e9-8675-50049481a438.gif)
