### PR TITLE
Camera adjustment to GeojsonLayerInStackActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/res/layout/activity_style_geojson_layer_in_stack.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_style_geojson_layer_in_stack.xml
@@ -11,8 +11,8 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        mapbox:mapbox_cameraTargetLat="35.137451890638886"
-        mapbox:mapbox_cameraTargetLng="-88.13734351262877"
-        mapbox:mapbox_cameraZoom="4"/>
+        mapbox:mapbox_cameraTargetLat="33.749909"
+        mapbox:mapbox_cameraTargetLng="-84.381546"
+        mapbox:mapbox_cameraZoom="8.471903"/>
 
 </RelativeLayout>


### PR DESCRIPTION
This pr adjusts the starting camera position for `GeojsonLayerInStackActivity`, to quickly show how the pink layer is under other layers.

![ezgif com-resize (1)](https://user-images.githubusercontent.com/4394910/57805944-ec5ac880-7712-11e9-8d17-479f89352f86.gif)
