### PR TITLE
Adding coordinate check in IsochroneActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/IsochroneActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/IsochroneActivity.java
@@ -107,7 +107,9 @@ public class IsochroneActivity extends AppCompatActivity implements MapboxMap.On
                 @Override
                 public void onClick(View view) {
                   usePolygon = !usePolygon;
-                  makeIsochroneApiCall(style, lastSelectedLatLng);
+                  if (lastSelectedLatLng != null) {
+                    makeIsochroneApiCall(style, lastSelectedLatLng);
+                  }
                 }
               });
 


### PR DESCRIPTION
`IsochroneActivity` needed a coordinate null check in the floating action button click listener. The example would crash if the fab was clicked before the map was clicked on.