### PR TITLE
Variable label placement example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -138,6 +138,7 @@ import com.mapbox.mapboxandroiddemo.examples.styles.StyleFadeSwitchActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.TextFieldFormattingActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.TextFieldMultipleFormatsActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.TransparentBackgroundActivity;
+import com.mapbox.mapboxandroiddemo.examples.styles.VariableLabelPlacementActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.VectorSourceActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.ZoomDependentFillColorActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.HomeScreenWidgetActivity;
@@ -650,12 +651,20 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       R.string.activity_styles_text_field_formatting_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
-            R.id.nav_styles,
-            R.string.activity_styles_missing_icon_title,
-            R.string.activity_styles_missing_icon_description,
-            new Intent(MainActivity.this, MissingIconActivity.class),
+      R.id.nav_styles,
+      R.string.activity_styles_missing_icon_title,
+      R.string.activity_styles_missing_icon_description,
+      new Intent(MainActivity.this, MissingIconActivity.class),
+      null,
+      R.string.activity_styles_missing_icon_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_styles,
+      R.string.activity_styles_variable_label_placement_title,
+      R.string.activity_styles_variable_label_placement_description,
+      new Intent(MainActivity.this, VariableLabelPlacementActivity.class),
             null,
-            R.string.activity_styles_missing_icon_url, true, BuildConfig.MIN_SDK_VERSION));
+       R.string.activity_styles_variable_label_placement_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_extrusions,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -526,6 +526,14 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.styles.VariableLabelPlacementActivity"
+            android:label="@string/activity_styles_variable_label_placement_title"
+            android:screenOrientation="portrait">]
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.PulsingLayerOpacityColorActivity"
             android:label="@string/activity_lab_pulsing_layer_opacity_color_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/assets/poi_places.geojson
+++ b/MapboxAndroidDemo/src/main/assets/poi_places.geojson
@@ -1,0 +1,74 @@
+{
+    "type": "FeatureCollection",
+    "features": [{
+        "type": "Feature",
+        "properties": {
+            "description": "Ford's\nTheater",
+            "icon": "theatre"
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-77.038659, 38.931567]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "description": "The\nGaslight",
+            "icon": "theatre"
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-77.003168, 38.894651]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "description": "Horrible\nHarry's",
+            "icon": "bar"
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-77.090372, 38.881189]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "description": "Bike\nParty",
+            "icon": "bicycle"
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-77.052477, 38.943951]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "description": "Rockabilly\nRockstars",
+            "icon": "music"
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-77.031706, 38.914581]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "description": "District\nDrum Tribe",
+            "icon": "music"
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-77.020945, 38.878241]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "description": "Motown\nMemories",
+            "icon": "music"
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-77.007481, 38.876516]
+        }
+    }]
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/VariableLabelPlacementActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/VariableLabelPlacementActivity.java
@@ -1,0 +1,129 @@
+package com.mapbox.mapboxandroiddemo.examples.styles;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.widget.Toast;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_BOTTOM;
+import static com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_LEFT;
+import static com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_RIGHT;
+import static com.mapbox.mapboxsdk.style.layers.Property.TEXT_ANCHOR_TOP;
+import static com.mapbox.mapboxsdk.style.layers.Property.TEXT_JUSTIFY_AUTO;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textJustify;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textRadialOffset;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textVariableAnchor;
+
+
+/**
+ * To increase the chance of high-priority labels staying visible, provide the map
+ * renderer a list of preferred text anchor positions via
+ * {@link com.mapbox.mapboxsdk.style.layers.PropertyFactory#textVariableAnchor(String[])}.
+ */
+public class VariableLabelPlacementActivity extends AppCompatActivity {
+
+  private static final String GEOJSON_SRC_ID = "poi_source_id";
+  private static final String POI_LABELS_LAYER_ID = "poi_labels_layer_id";
+  private MapView mapView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_style_variable_text_placement);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+
+        GeoJsonSource source = new GeoJsonSource(GEOJSON_SRC_ID);
+        source.setUrl("asset://poi_places.geojson");
+
+        mapboxMap.setStyle(new Style.Builder().fromUrl(Style.LIGHT)
+            .withSource(source)
+            // Adds a SymbolLayer to display POI labels
+            .withLayer(new SymbolLayer(POI_LABELS_LAYER_ID, GEOJSON_SRC_ID)
+              .withProperties(
+                textField(get("description")),
+                textSize(17f),
+                textColor(Color.RED),
+                textVariableAnchor(
+                  new String[]{TEXT_ANCHOR_TOP, TEXT_ANCHOR_BOTTOM, TEXT_ANCHOR_LEFT, TEXT_ANCHOR_RIGHT}),
+                textJustify(TEXT_JUSTIFY_AUTO),
+                textRadialOffset(0.5f))),
+          new Style.OnStyleLoaded() {
+            @Override
+            public void onStyleLoaded(@NonNull final Style style) {
+              Toast.makeText(VariableLabelPlacementActivity.this,
+                getString(R.string.zoom_map_in_and_out_variable_label_instruction),
+                Toast.LENGTH_SHORT).show();
+            }
+          });
+      }
+    });
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_style_variable_text_placement.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_style_variable_text_placement.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="38.907"
+        mapbox:mapbox_cameraTargetLng="-77.04"
+        mapbox:mapbox_cameraZoom="11.15"/>
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -348,4 +348,7 @@
     <string name="icon_overlap_explanation">iconAllowOverlap: the icon will be visible even if it collides with other previously drawn symbols</string>
     <string name="icon_placement_explanation">iconIgnorePlacement: other symbols can be visible even if \n they collide with the icon</string>
 
+    <!-- Variable label placement-->
+    <string name="zoom_map_in_and_out_variable_label_instruction">Zoom in and out to see red labels try to avoid collisions</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -36,6 +36,7 @@
     <string name="activity_styles_click_to_add_image_description">Select a photo on the device and add it on the map tap location.</string>
     <string name="activity_styles_rotating_anchor_text_description">Adjust the anchor position of SymbolLayer text fields.</string>
     <string name="activity_styles_missing_icon_description">Provide an icon when a Style failed to load one.</string>
+    <string name="activity_styles_variable_label_placement_description">To increase the chance of high-priority labels staying visible, provide the map renderer a list of preferred text anchor positions.</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_description">Use data-driven styling and GeoJSON data to set extrusions\' heights.</string>
     <string name="activity_extrusions_population_density_extrusions_description">Use extrusions to display 3D building height based on imported vector data.</string>
     <string name="activity_extrusions_adjust_extrusions_description">Change the location and color of the light shined on extrusions.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -33,6 +33,7 @@
     <string name="activity_styles_click_to_add_image_title">Click to add photo</string>
     <string name="activity_styles_rotating_anchor_text_title">Text anchor position</string>
     <string name="activity_styles_missing_icon_title">Style with missing icon</string>
+    <string name="activity_styles_variable_label_placement_title">Variable label placement</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_title">Use GeoJSON data to set extrusion height</string>
     <string name="activity_extrusions_population_density_extrusions_title">Display 3D building height based on vector data</string>
     <string name="activity_extrusions_adjust_extrusions_title">Adjust light location and color</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -35,6 +35,7 @@
     <string name="activity_styles_click_to_add_image_url" translatable="false">https://i.imgur.com/uPIH5Ck.png</string>
     <string name="activity_styles_rotating_anchor_text_url" translatable="false">https://i.imgur.com/w8cP6Wn.png</string>
     <string name="activity_styles_missing_icon_url" translatable="false">https://i.imgur.com/lSk2tDB.png</string>
+    <string name="activity_styles_variable_label_placement_url" translatable="false">https://i.imgur.com/vLgFvlZ.jpg</string>
     <string name="activity_extrusions_population_density_extrusions_url" translatable="false">http://i.imgur.com/se1z8Wb.png</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_url" translatable="false">http://i.imgur.com/6j848JL.jpg</string>
     <string name="activity_extrusions_adjust_extrusions_url" translatable="false">http://i.imgur.com/XNTyIO5.png</string>


### PR DESCRIPTION
This PR adds an example of variable label placement using [PropertyFactory.textVariableAnchor().](https://github.com/mapbox/mapbox-gl-native/blob/20a807fdf36e2609973451ef8d0e49472a59db91/platform/android/MapboxGLAndroidSDK/src/main/java/com/mapbox/mapboxsdk/style/layers/PropertyFactory.java#L2324)

The renderer attempts placing the label at the positions in this list in the provided order of the array at collision detection time. If the symbol was successfully placed in a previous round, the renderer attempts that anchor position first before moving on to the rest of the list.

In this example the following values were used:
```
textVariableAnchor: ["top", "bottom", "left", "right"],
textRadialOffse: 0.5
textJustify: auto
```

![ezgif com-optimize](https://user-images.githubusercontent.com/4394910/58127938-61267a80-7bcb-11e9-89a4-5dcf5712968a.gif)

