### PR TITLE
Get only fully loaded style when returning from async tasks

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ChoroplethJsonVectorMixActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ChoroplethJsonVectorMixActivity.java
@@ -95,10 +95,7 @@ public class ChoroplethJsonVectorMixActivity extends AppCompatActivity implement
 
     // Add layer to map below the "waterway-label" layer
     if (mapboxMap != null) {
-      Style style = mapboxMap.getStyle();
-      if (style != null) {
-        style.addLayerAbove(statesJoinLayer, "waterway-label");
-      }
+      mapboxMap.getStyle(style -> style.addLayerAbove(statesJoinLayer, "waterway-label"));
     }
   }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/DrawGeojsonLineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/DrawGeojsonLineActivity.java
@@ -62,8 +62,7 @@ public class DrawGeojsonLineActivity extends AppCompatActivity implements OnMapR
 
   private void drawLines(@NonNull FeatureCollection featureCollection) {
     if (mapboxMap != null) {
-      Style style = mapboxMap.getStyle();
-      if (style != null) {
+      mapboxMap.getStyle(style -> {
         if (featureCollection.features().size() > 0) {
           style.addSource(new GeoJsonSource("line-source", featureCollection));
 
@@ -76,7 +75,7 @@ public class DrawGeojsonLineActivity extends AppCompatActivity implements OnMapR
               PropertyFactory.lineWidth(7f),
               PropertyFactory.lineColor(Color.parseColor("#3bb2d0"))));
         }
-      }
+      });
     }
   }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ExpressionIntegrationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ExpressionIntegrationActivity.java
@@ -140,8 +140,7 @@ public class ExpressionIntegrationActivity
     // Retrieves GeoJSON from local file and adds it to the map
     GeoJsonSource geoJsonSource = new GeoJsonSource(GEOJSON_SRC_ID, featureCollection);
     if (mapboxMap != null) {
-      final Style style = mapboxMap.getStyle();
-      if (style != null) {
+      mapboxMap.getStyle(style -> {
         style.addSource(geoJsonSource);
         initTemperatureLayers(style);
         populateMenu();
@@ -159,7 +158,7 @@ public class ExpressionIntegrationActivity
             }
           }
         });
-      }
+      });
     }
   }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/InfoWindowSymbolLayerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/InfoWindowSymbolLayerActivity.java
@@ -103,13 +103,12 @@ public class InfoWindowSymbolLayerActivity extends AppCompatActivity implements
   public void setUpData(final FeatureCollection collection) {
     featureCollection = collection;
     if (mapboxMap != null) {
-      Style style = mapboxMap.getStyle();
-      if (style != null) {
+      mapboxMap.getStyle(style -> {
         setupSource(style);
         setUpImage(style);
         setUpMarkerLayer(style);
         setUpInfoWindowLayer(style);
-      }
+      });
     }
   }
 
@@ -242,11 +241,10 @@ public class InfoWindowSymbolLayerActivity extends AppCompatActivity implements
    */
   public void setImageGenResults(HashMap<String, Bitmap> imageMap) {
     if (mapboxMap != null) {
-      Style style = mapboxMap.getStyle();
-      if (style != null) {
+      mapboxMap.getStyle(style -> {
         // calling addImages is faster as separate addImage calls for each bitmap.
         style.addImages(imageMap);
-      }
+      });
     }
   }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/PolygonSelectToggleActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/PolygonSelectToggleActivity.kt
@@ -84,37 +84,39 @@ class PolygonSelectToggleActivity : AppCompatActivity(), MapboxMap.OnMapClickLis
         // Create a GeoJsonSource and add it to the map.
         geoJsonSource = GeoJsonSource(NEIGHBORHOOD_POLYGON_SOURCE_ID, featureCollection)
 
-        mapboxMap.style?.addSource(geoJsonSource!!)
+        mapboxMap.getStyle {style ->
+            style.addSource(geoJsonSource!!)
 
-        // Create a FillLayer which will show a background of all neighborhoods on the map.
-        val neighborhoodPolygonBaseFillLayer = FillLayer(BASE_NEIGHBORHOOD_FILL_LAYER_ID,
-                NEIGHBORHOOD_POLYGON_SOURCE_ID)
-        neighborhoodPolygonBaseFillLayer.withProperties(
-                fillOpacity(.2f))
+            // Create a FillLayer which will show a background of all neighborhoods on the map.
+            val neighborhoodPolygonBaseFillLayer = FillLayer(BASE_NEIGHBORHOOD_FILL_LAYER_ID,
+              NEIGHBORHOOD_POLYGON_SOURCE_ID)
+            neighborhoodPolygonBaseFillLayer.withProperties(
+              fillOpacity(.2f))
 
-        // Add neighborhood layer below the city label layer
-        mapboxMap.style?.addLayerBelow(neighborhoodPolygonBaseFillLayer, "settlement-label")
+            // Add neighborhood layer below the city label layer
+            style.addLayerBelow(neighborhoodPolygonBaseFillLayer, "settlement-label")
 
-        // Add a FillLayer which will only show "selected" features/polygons/neighborhoods.
-        val neighborhoodPolygonColoredFillLayer = FillLayer(COLORED_FILL_LAYER_ID,
-                NEIGHBORHOOD_POLYGON_SOURCE_ID)
-        neighborhoodPolygonColoredFillLayer.withProperties(
+            // Add a FillLayer which will only show "selected" features/polygons/neighborhoods.
+            val neighborhoodPolygonColoredFillLayer = FillLayer(COLORED_FILL_LAYER_ID,
+              NEIGHBORHOOD_POLYGON_SOURCE_ID)
+            neighborhoodPolygonColoredFillLayer.withProperties(
 
-                // Use data-driven styling to use each Feature's color property, which was set in
-                // `onPostExecute()` of the data loading AsyncTask.
-                fillColor(toColor(get(PROPERTY_FILL_COLOR))),
-                fillOpacity(.45f))
+              // Use data-driven styling to use each Feature's color property, which was set in
+              // `onPostExecute()` of the data loading AsyncTask.
+              fillColor(toColor(get(PROPERTY_FILL_COLOR))),
+              fillOpacity(.45f))
 
-        // Add a filter to ensure that only "selected" features/polygons/neighborhoods are displayed.
-        neighborhoodPolygonColoredFillLayer.withFilter(eq((get(PROPERTY_SELECTED)), literal(true)))
-        mapboxMap.style?.addLayerBelow(neighborhoodPolygonColoredFillLayer, "settlement-label")
+            // Add a filter to ensure that only "selected" features/polygons/neighborhoods are displayed.
+            neighborhoodPolygonColoredFillLayer.withFilter(eq((get(PROPERTY_SELECTED)), literal(true)))
+            style.addLayerBelow(neighborhoodPolygonColoredFillLayer, "settlement-label")
 
-        // Add LineLayer to outline the various neighborhoods' areas
-        val neighborhoodOutlineLineLayer = LineLayer(LINE_LAYER_ID, NEIGHBORHOOD_POLYGON_SOURCE_ID)
-        neighborhoodOutlineLineLayer.withProperties(
-                lineColor(Color.GRAY),
-                lineWidth(2.2f))
-        mapboxMap.style?.addLayerBelow(neighborhoodOutlineLineLayer, "settlement-label")
+            // Add LineLayer to outline the various neighborhoods' areas
+            val neighborhoodOutlineLineLayer = LineLayer(LINE_LAYER_ID, NEIGHBORHOOD_POLYGON_SOURCE_ID)
+            neighborhoodOutlineLineLayer.withProperties(
+              lineColor(Color.GRAY),
+              lineWidth(2.2f))
+            style.addLayerBelow(neighborhoodOutlineLineLayer, "settlement-label")
+        }
     }
 
     /**

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MapMatchingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MapMatchingActivity.java
@@ -168,17 +168,14 @@ public class MapMatchingActivity extends AppCompatActivity {
   }
 
   private void drawBeforeMapMatching(Feature feature) {
-    Style style = map.getStyle();
-    if (style != null) {
+    map.getStyle(style -> {
       style.addSource(new GeoJsonSource("pre-matched-source-id", feature));
       style.addLayer(new LineLayer("pre-matched-layer-id", "pre-matched-source-id").withProperties(
         lineColor(ColorUtils.colorToRgbaString(Color.parseColor("#3bb2d0"))),
         lineWidth(6f),
         lineOpacity(1f)
       ));
-    } else {
-      throw new IllegalStateException("Style isn't ready yet.");
-    }
+    });
   }
 
   private void requestMapMatched(Feature feature) {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/SimplifyPolylineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/SimplifyPolylineActivity.java
@@ -170,15 +170,12 @@ public class SimplifyPolylineActivity extends AppCompatActivity {
   }
 
   private void addLine(String layerId, Feature feature, String lineColorHex) {
-    Style style = map.getStyle();
-    if (style != null) {
+    map.getStyle(style -> {
       style.addSource(new GeoJsonSource(layerId, feature));
       style.addLayer(new LineLayer(layerId, layerId).withProperties(
         lineColor(ColorUtils.colorToRgbaString(Color.parseColor(lineColorHex))),
         lineWidth(4f)
       ));
-    } else {
-      throw new IllegalStateException("Style hasn't been fully initialised");
-    }
+    });
   }
 }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MarkerFollowingRouteActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MarkerFollowingRouteActivity.java
@@ -96,13 +96,12 @@ public class MarkerFollowingRouteActivity extends AppCompatActivity {
     LineString lineString = (LineString) featureCollection.features().get(0).geometry();
     routeCoordinateList = lineString.coordinates();
     if (mapboxMap != null) {
-      Style style = mapboxMap.getStyle();
-      if (style != null) {
+      mapboxMap.getStyle(style -> {
         initSources(style, featureCollection);
         initSymbolLayer(style);
         initDotLinePath(style);
         initRunnable();
-      }
+      });
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-android-demo/issues/1068.

The intermittent failures in https://github.com/mapbox/mapbox-android-demo/issues/1068 popped up as part of the https://github.com/mapbox/mapbox-android-demo/pull/1019, because in `v7.4.0` we started marking style as "not-fully-loaded" when the map is destroyed. In consequence, activities like `SimplifyPolylineActivity` which were using a `Style` when returning from an `AsyncTask` started crashing, as the returned `Style` was `null`. Those async tasks were relying on a `WeakReference` to an activity, however, the GC might not have cleaned up the activity yet, and because we marked the style as not fully loaded when the activity has been destroyed, `MapboxMap#getStyle` was returning `null`.