### PR TITLE
China plugin bump to 2.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,7 @@ ext {
             mapboxPluginPlaces       : '0.8.0',
             mapboxPluginLocalization : '0.9.0',
             mapboxPluginTraffic      : '0.8.0',
-            mapboxChinaPlugin        : '2.1.1',
+            mapboxChinaPlugin        : '2.2.0',
             mapboxPluginMarkerView   : '0.2.0',
             mapboxPluginAnnotation   : '0.6.0',
 


### PR DESCRIPTION
Bumping the China plugin dependency to `2.2.0` as part of the 2.2.0 release of the Mapbox China Plugin for Android, which is a part of the `8.0.0` release of the Mapbox Maps SDK for Android.


cc @Chaoba 