### PR TITLE
Making needed iconTranslate -> iconOffset refactoring changes

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ImageClusteringActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ImageClusteringActivity.java
@@ -34,11 +34,11 @@ import static com.mapbox.mapboxsdk.style.expressions.Expression.lt;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.toNumber;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconSize;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconTranslate;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textAllowOverlap;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textOffset;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
 
 /**
@@ -119,8 +119,7 @@ public class ImageClusteringActivity extends AppCompatActivity implements OnMapR
       SymbolLayer symbolLayer = new SymbolLayer("cluster-" + i, "earthquakes");
 
       symbolLayer.setProperties(
-        iconImage("quake-triangle-icon-id"),
-        iconTranslate(new Float[] {0f, -9f})
+        iconImage("quake-triangle-icon-id")
       );
       Expression pointCount = toNumber(get("point_count"));
 
@@ -143,6 +142,9 @@ public class ImageClusteringActivity extends AppCompatActivity implements OnMapR
       textSize(12f),
       textColor(Color.BLACK),
       textIgnorePlacement(true),
+      // The .5f offset moves the data numbers down a little bit so that they're
+      // in the middle of the triangle cluster image
+      textOffset(new Float[] {0f, .5f}),
       textAllowOverlap(true)
     ));
   }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/ValueAnimatorIconAnimationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/ValueAnimatorIconAnimationActivity.java
@@ -29,7 +29,6 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconTranslate;
 
 /**
  * Combine SymbolLayer icons with the Android system's ValueAnimator and interpolator
@@ -140,7 +139,7 @@ public class ValueAnimatorIconAnimationActivity extends AppCompatActivity implem
     if (animator != null) {
       animator.cancel();
     }
-    animator = ValueAnimator.ofFloat(STARTING_DROP_HEIGHT, 0);
+    animator = ValueAnimator.ofFloat(STARTING_DROP_HEIGHT, -17);
     animator.setDuration(DROP_SPEED_MILLISECONDS);
     animator.setInterpolator(desiredTimeInterpolator);
     animator.setStartDelay(1000);
@@ -152,7 +151,7 @@ public class ValueAnimatorIconAnimationActivity extends AppCompatActivity implem
           initSymbolLayer();
           animationHasStarted = true;
         }
-        pinSymbolLayer.setProperties(iconTranslate(new Float[] {0f, (Float) valueAnimator.getAnimatedValue()}));
+        pinSymbolLayer.setProperties(iconOffset(new Float[] {0f, (Float) valueAnimator.getAnimatedValue()}));
       }
     });
   }


### PR DESCRIPTION
In working with @yuletide, I discovered that one example was still using `iconTranslate` when it should actually be `iconOffset`. This pr makes `iconOffset`-related adjustments to two examples.