### PR TITLE
Added geometry check to building outline example

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/BuildingOutlineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/BuildingOutlineActivity.java
@@ -128,13 +128,15 @@ public class BuildingOutlineActivity extends AppCompatActivity implements
       if (features.size() > 0) {
         Feature buildingFeature = features.get(0);
         // Build a list of Point objects from the building Feature's coordinates
-        for (int i = 0; i < ((Polygon) buildingFeature.geometry()).coordinates().size(); i++) {
-          for (int j = 0;
-               j < ((Polygon) buildingFeature.geometry()).coordinates().get(i).size(); j++) {
-            pointList.add(Point.fromLngLat(
-              ((Polygon) buildingFeature.geometry()).coordinates().get(i).get(j).longitude(),
-              ((Polygon) buildingFeature.geometry()).coordinates().get(i).get(j).latitude()
-            ));
+        if (buildingFeature.geometry() instanceof Polygon) {
+          for (int i = 0; i < ((Polygon) buildingFeature.geometry()).coordinates().size(); i++) {
+            for (int j = 0;
+                 j < ((Polygon) buildingFeature.geometry()).coordinates().get(i).size(); j++) {
+              pointList.add(Point.fromLngLat(
+                ((Polygon) buildingFeature.geometry()).coordinates().get(i).get(j).longitude(),
+                ((Polygon) buildingFeature.geometry()).coordinates().get(i).get(j).latitude()
+              ));
+            }
           }
         }
         // Create a LineString from the list of Point objects


### PR DESCRIPTION
Resolves the 💥 that can happen in `BuildingOutlineActivity.java`. A 🐛 found by @zqlq4ever and reported in https://github.com/mapbox/mapbox-android-demo/issues/1083

Added a `if (buildingFeature.geometry() instanceof Polygon) {` check so that the example doesn't try to cast a `MultiPolygon` to a `Polygon`.