### PR TITLE
Refactoring Isochrone example to add time label toggle

### DIFF
--- a/MapboxAndroidDemo/src/main/res/drawable/ic_text_icon_24dp.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable/ic_text_icon_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M9.93,13.5h4.14L12,7.98zM20,2L4,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,4c0,-1.1 -0.9,-2 -2,-2zM15.95,18.5l-1.14,-3L9.17,15.5l-1.12,3L5.96,18.5l5.11,-13h1.86l5.11,13h-2.09z"/>
+</vector>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_isochrone.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_isochrone.xml
@@ -15,6 +15,20 @@
         mapbox:mapbox_cameraTargetLng="12.48278"
         mapbox:mapbox_cameraZoom="11" />
 
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/toggle_isochrone_time_label_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginBottom="74dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_text_icon_24dp"
+        mapbox:fabSize="normal" />
+
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/switch_isochrone_style_fab"
         android:layout_width="wrap_content"

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -289,6 +289,7 @@
 
     <!-- Isochrone change -->
     <string name="click_on_map_instruction">Tap on the map</string>
+    <string name="showing_time_labels_on_line_toast">Now showing minute labels on lines</string>
 
     <!--Custom location layer plugin icon-->
     <string name="tap_the_icon">Tap the location icon</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -84,7 +84,7 @@
     <string name="activity_java_services_optimization_url" translatable="false">http://i.imgur.com/guEQtlP.jpg</string>
     <string name="activity_java_services_matrix_url" translatable="false">https://i.imgur.com/65RlfRZ.png</string>
     <string name="activity_java_services_geocoding_url" translatable="false">https://i.imgur.com/9xl3EF8.png</string>
-    <string name="activity_java_services_isochrone_url" translatable="false">https://i.imgur.com/5tQPmDs.png</string>
+    <string name="activity_java_services_isochrone_url" translatable="false">https://i.imgur.com/eUByGvt.png</string>
     <string name="activity_java_services_tilequery_url" translatable="false">http://i.imgur.com/VkOCYwq.jpg</string>
     <string name="activity_plugins_traffic_plugin_url" translatable="false">http://i.imgur.com/HRriOVR.png</string>
     <string name="activity_plugins_building_plugin_url" translatable="false">http://i.imgur.com/Vcu67UR.png</string>


### PR DESCRIPTION
Born out of https://github.com/mapbox/mapbox-gl-native/issues/14843, this pr adds the option to show `SymbolLayer` text time labels on the isochrone area lines. Each `Feature` in the Isochrone API response includes a `contour` item, so `textField(concat(get("contour"), literal(" MIN"))),` is the key part to showing the label


![ezgif com-resize (2)](https://user-images.githubusercontent.com/4394910/58906261-62be6b00-86c0-11e9-9bb5-c663e51b70b5.gif)
