### PR TITLE
Moving Firebase crash configuration to CI

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -46,8 +46,8 @@ android {
     productFlavors {
         global {
             isGlobal = true
-            resValue "string", "firebase_app_id", "1:557332920931:android:bdf11618ae45dd61"
-            resValue "string", "firebase_api_key", "AIzaSyCGCYLyLoi31Hv-pkBO0D51zCyxjngJbz8"
+            resValue "string", "firebase_app_id", System.getenv('FIREBASE_APP_ID') ? System.getenv('FIREBASE_APP_ID') : "blank_place_holder_string"
+            resValue "string", "firebase_api_key", System.getenv('FIREBASE_API_KEY') ? System.getenv('FIREBASE_API_KEY') : "blank_place_holder_string"
         }
 
         china {

--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
@@ -22,7 +22,6 @@ public class MapboxApplication extends MultiDexApplication {
     Mapbox.getInstance(this, getString(R.string.access_token));
     Mapbox.getTelemetry().setDebugLoggingEnabled(true);
     setUpTileLoadingMeasurement();
-
   }
 
   private void initializeFirebaseApp() {


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/926 by removing hardcoded values and using BuildConfig instead. The values are now set via CircleCI environment variables.

Using `blank_place_holder_string` means that `FIREBASE_APP_ID` and `FIREBASE_API_KEY` don't _have_ to be set locally to compile the app on a local computer. I'd still advise Mapboxers and others who interact with this app on a frequent basis, to add the following to the Gradle user home folder's `gradle.properties` file (similar to https://docs.mapbox.com/help/troubleshooting/private-access-token-android-and-ios/#non-git-option) .

```
FIREBASE_APP_ID="ID_HERE"
FIREBASE_API_KEY="KEY_HERE"
```

cc @zmully @Guardiola31337 