### PR TITLE
Adding Scale Bar Plugin example

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -134,6 +134,7 @@ dependencies {
     implementation dependenciesList.mapboxPluginTraffic
     implementation dependenciesList.mapboxPluginMarkerView
     implementation dependenciesList.mapboxPluginAnnotation
+    implementation dependenciesList.mapboxPluginScalebar
 
     // Firebase
     globalImplementation dependenciesList.firebaseCrash

--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -106,6 +106,7 @@ import com.mapbox.mapboxandroiddemo.examples.plugins.LocalizationPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.MarkerViewPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.PlaceSelectionPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.PlacesPluginActivity;
+import com.mapbox.mapboxandroiddemo.examples.plugins.ScalebarPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.SymbolListenerActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.TrafficPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.query.BuildingOutlineActivity;
@@ -763,6 +764,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, MarkerViewPluginActivity.class),
       null,
       R.string.activity_plugins_markerview_plugin_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_plugins,
+      R.string.activity_plugins_scalebar_plugin_title,
+      R.string.activity_plugins_scalebar_plugin_description,
+      new Intent(MainActivity.this, ScalebarPluginActivity.class),
+      null,
+      R.string.activity_plugins_scalebar_plugin_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_dds,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -718,6 +718,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.plugins.ScalebarPluginActivity"
+            android:label="@string/activity_plugins_scalebar_plugin_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.plugins.SymbolListenerActivity"
             android:label="Listen for Symbol interaction">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/ScalebarPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/ScalebarPluginActivity.java
@@ -1,0 +1,169 @@
+package com.mapbox.mapboxandroiddemo.examples.plugins;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Toast;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.pluginscalebar.ScaleBarOptions;
+import com.mapbox.pluginscalebar.ScaleBarPlugin;
+
+/**
+ * Use the Scale Bar Plugin to provide a visual indication of how far various map features are from
+ * one another at a certain zoom level. The scalebar can be customized with options such as the
+ * text color/size, referesh interval, margins, and border width.
+ */
+public class ScalebarPluginActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private MapView mapView;
+  private ScaleBarPlugin scaleBarPlugin;
+  private ScaleBarOptions[] listOfScalebarStyleVariations;
+  private String[] listOfStyles = new String[] {Style.LIGHT, Style.DARK, Style.SATELLITE_STREETS, Style.OUTDOORS};
+  private int index = 0;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+    setContentView(R.layout.activity_scalebar_plugin);
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+    mapboxMap.setStyle(listOfStyles[index], new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull final Style style) {
+
+        initStyling();
+
+        // Create a new ScaleBarPlugin object
+        scaleBarPlugin = new ScaleBarPlugin(mapView, mapboxMap);
+
+        scaleBarPlugin.create(listOfScalebarStyleVariations[index]);
+
+        findViewById(R.id.switch_scalebar_style_fab).setOnClickListener(new View.OnClickListener() {
+          @Override
+          public void onClick(View view) {
+
+            if (index == listOfScalebarStyleVariations.length - 1) {
+              index = 0;
+            }
+
+            mapboxMap.setStyle(listOfStyles[index], new Style.OnStyleLoaded() {
+              @Override
+              public void onStyleLoaded(@NonNull Style style) {
+
+                scaleBarPlugin.create(listOfScalebarStyleVariations[index]);
+
+              }
+            });
+
+            index++;
+
+          }
+        });
+
+        Toast.makeText(ScalebarPluginActivity.this, getString(R.string.zoom_map_fab_instruction),
+          Toast.LENGTH_LONG).show();
+      }
+    });
+  }
+
+  private void initStyling() {
+    listOfScalebarStyleVariations = new ScaleBarOptions[] {
+
+      // Using the plugin's default styling to start
+      new ScaleBarOptions(this),
+
+      // Random styling option #2
+      new ScaleBarOptions(this)
+        .setTextColor(R.color.mapboxRed)
+        .setTextSize(40f)
+        .setBarHeight(15f)
+        .setBorderWidth(5f)
+        .setMetricUnit(true)
+        .setRefreshInterval(15)
+        .setMarginTop(30f)
+        .setMarginLeft(16f)
+        .setTextBarMargin(15f),
+
+      // Random styling option #3
+      new ScaleBarOptions(this)
+        .setTextColor(R.color.mapbox_blue)
+        .setTextSize(60f)
+        .setBarHeight(15f)
+        .setBorderWidth(5f)
+        .setMetricUnit(true)
+        .setRefreshInterval(15)
+        .setMarginTop(30f)
+        .setMarginLeft(30f)
+        .setTextBarMargin(25f),
+
+      // Random styling option #4
+      new ScaleBarOptions(this)
+        .setTextColor(R.color.mapboxYellow)
+        .setTextSize(30f)
+        .setBarHeight(15f)
+        .setBorderWidth(5f)
+        .setMetricUnit(false)
+        .setRefreshInterval(15)
+        .setMarginTop(30f)
+        .setMarginLeft(30f)
+        .setTextBarMargin(25f),
+    };
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_scalebar_plugin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_scalebar_plugin.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="23.585781"
+        mapbox:mapbox_cameraTargetLng="58.545909"
+        mapbox:mapbox_cameraZoom="13.674097" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/switch_scalebar_style_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_swap_horiz_white_24dp"
+        mapbox:fabSize="normal" />
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -364,4 +364,8 @@
     <string name="single_line">single line</string>
     <string name="polygon">polygon</string>
 
+    <!-- Scale bar plugin-->
+    <string name="zoom_map_fab_instruction">Zoom the map in and out. Click the button to change the scale bar styling.</string>
+
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -95,6 +95,7 @@
     <string name="activity_plugins_localization_plugin_description">Use the plugin to automatically change map label text to the language set on the device.</string>
     <string name="activity_plugins_place_picker_plugin_description">Use the place picker function of the Places Plugin to choose a specific location in the world.</string>
     <string name="activity_plugins_markerview_plugin_description">Create a marker with an Android-system View.</string>
+    <string name="activity_plugins_scalebar_plugin_description">Add a scale bar to determine distance based on zoom level.</string>
     <string name="activity_location_location_component_description">Use the location component to easily show a user\'s location on the map</string>
     <string name="activity_location_user_location_map_frag_plugin_description">Use the location component to display a user\'s location on a map fragment.</string>
     <string name="activity_location_location_component_options_description">Use location component options to customize the user location information.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -90,9 +90,10 @@
     <string name="activity_plugins_localization_plugin_title">Change map text to device language</string>
     <string name="activity_plugins_geojson_plugin_title">Load GeoJSON data</string>
     <string name="activity_plugins_places_plugin_title">Location search</string>
-    <string name="activity_plugins_symbol_listener_title">Symbol listener</string>
+    <string name="activity_plugins_symbol_listener_title">Symbol annotation listener</string>
     <string name="activity_plugins_place_picker_plugin_title">Place picker</string>
     <string name="activity_plugins_markerview_plugin_title">MarkerView</string>
+    <string name="activity_plugins_scalebar_plugin_title">Scale bar</string>
     <string name="activity_location_user_location_map_frag_title">Show a user\'s location on a map fragment</string>
     <string name="activity_location_location_component_title">Show a user\'s location</string>
     <string name="activity_location_location_component_options_title">Customized location icon</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -94,6 +94,7 @@
     <string name="activity_plugins_localization_plugin_url" translatable="false">https://i.imgur.com/tsOM1am.png</string>
     <string name="activity_plugins_place_picker_plugin_url" translatable="false">https://i.imgur.com/fPZQg7z.png</string>
     <string name="activity_plugins_markerview_plugin_url" translatable="false">https://i.imgur.com/DyDVUJr.png</string>
+    <string name="activity_plugins_scalebar_plugin_url" translatable="false">https://i.imgur.com/YIGSu0C.png</string>
     <string name="activity_location_location_component_url" translatable="false">https://i.imgur.com/77PVsni.png</string>
     <string name="activity_location_user_location_fragment_plugin_url" translatable="false">https://i.imgur.com/1jG8WQG.png</string>
     <string name="activity_location_location_component_options_url" translatable="false">https://i.imgur.com/4HiEJC1.png</string>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,6 +21,7 @@ ext {
             mapboxChinaPlugin        : '2.2.0',
             mapboxPluginMarkerView   : '0.3.0',
             mapboxPluginAnnotation   : '0.7.0',
+            mapboxPluginScalebar     : '0.1.0',
 
             // Support
             supportLib               : '28.0.0',
@@ -78,6 +79,7 @@ ext {
             mapboxChinaPlugin        : "com.mapbox.mapboxsdk:mapbox-android-plugin-china:${version.mapboxChinaPlugin}",
             mapboxPluginMarkerView   : "com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-${version.mapboxMapPrefix}:${version.mapboxPluginMarkerView}",
             mapboxPluginAnnotation   : "com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-${version.mapboxMapPrefix}:${version.mapboxPluginAnnotation}",
+            mapboxPluginScalebar     : "com.mapbox.mapboxsdk:mapbox-android-plugin-scalebar-${version.mapboxMapPrefix}:${version.mapboxPluginScalebar}",
 
             // Support
             supportV4                : "com.android.support:support-v4:${version.supportLib}",


### PR DESCRIPTION
This pr shows how to use [the Scale Bar Plugin for Android](https://github.com/mapbox/mapbox-plugins-android/blob/83fdc9765e37c940d0cc07740b9bd94227248398/plugin-scalebar/README.md) to display and style the map scale bar. The plugin was released in https://github.com/mapbox/mapbox-plugins-android/issues/987.

Related: 

- https://github.com/mapbox/mapbox-android-demo/pull/1102
- https://github.com/mapbox/mapbox-plugins-android/issues/987


![ezgif com-resize](https://user-images.githubusercontent.com/4394910/59314037-472b0580-8c68-11e9-84f4-1db46012bd5a.gif)
