### PR TITLE
Refactoring fromUrl() to fromUri()

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolCollisionDetectionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolCollisionDetectionActivity.java
@@ -66,7 +66,7 @@ public class SymbolCollisionDetectionActivity extends AppCompatActivity implemen
   public void onMapReady(final MapboxMap mapboxMap) {
     initIconCoordinates();
 
-    mapboxMap.setStyle(new Style.Builder().fromUrl(Style.MAPBOX_STREETS)
+    mapboxMap.setStyle(new Style.Builder().fromUri(Style.MAPBOX_STREETS)
 
       // Add the SymbolLayer icon image to the map style
       .withImage(ICON_ID, BitmapFactory.decodeResource(

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolSwitchOnZoomActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/SymbolSwitchOnZoomActivity.java
@@ -56,61 +56,61 @@ public class SymbolSwitchOnZoomActivity extends AppCompatActivity implements OnM
   @Override
   public void onMapReady(final MapboxMap mapboxMap) {
 
-    mapboxMap.setStyle(new Style.Builder().fromUrl(Style.OUTDOORS)
+    mapboxMap.setStyle(new Style.Builder().fromUri(Style.OUTDOORS)
 
-        // Add images to the map so that the SymbolLayers can reference the images.
-        .withImage(BLUE_PERSON_ICON_ID, BitmapUtils.getBitmapFromDrawable(
-          getResources().getDrawable(R.drawable.ic_person)))
-        .withImage(BLUE_PIN_ICON_ID, BitmapUtils.getBitmapFromDrawable(
-          getResources().getDrawable(R.drawable.blue_marker)))
+            // Add images to the map so that the SymbolLayers can reference the images.
+            .withImage(BLUE_PERSON_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+                getResources().getDrawable(R.drawable.ic_person)))
+            .withImage(BLUE_PIN_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+                getResources().getDrawable(R.drawable.blue_marker)))
 
-        // Add random data to the GeoJsonSource and then add the GeoJsonSource to the map
-        .withSource(new GeoJsonSource("source-id",
-          FeatureCollection.fromFeatures(new Feature[] {
-            Feature.fromGeometry(Point.fromLngLat(
-              9.205394983291626,
-              45.47661043757903)),
-            Feature.fromGeometry(Point.fromLngLat(
-              9.223880767822266,
-              45.47623240235297)),
-            Feature.fromGeometry(Point.fromLngLat(
-              9.15530204772949,
-              45.4706650227671)),
-            Feature.fromGeometry(Point.fromLngLat(
-              9.153714179992676,
-              45.48625229963004)),
-            Feature.fromGeometry(Point.fromLngLat(
-              9.158306121826172,
-              45.482731998239636)),
-            Feature.fromGeometry(Point.fromLngLat(
-              9.188523888587952,
-              45.4923746929562)),
-            Feature.fromGeometry(Point.fromLngLat(
-              9.20929491519928,
-              45.45314676076135)),
-            Feature.fromGeometry(Point.fromLngLat(
-              9.177778959274292,
-              45.45569808340158))
-          })
-        )), new Style.OnStyleLoaded() {
-          @Override
-          public void onStyleLoaded(@NonNull Style style) {
+            // Add random data to the GeoJsonSource and then add the GeoJsonSource to the map
+            .withSource(new GeoJsonSource("source-id",
+                FeatureCollection.fromFeatures(new Feature[]{
+                    Feature.fromGeometry(Point.fromLngLat(
+                        9.205394983291626,
+                        45.47661043757903)),
+                    Feature.fromGeometry(Point.fromLngLat(
+                        9.223880767822266,
+                        45.47623240235297)),
+                    Feature.fromGeometry(Point.fromLngLat(
+                        9.15530204772949,
+                        45.4706650227671)),
+                    Feature.fromGeometry(Point.fromLngLat(
+                        9.153714179992676,
+                        45.48625229963004)),
+                    Feature.fromGeometry(Point.fromLngLat(
+                        9.158306121826172,
+                        45.482731998239636)),
+                    Feature.fromGeometry(Point.fromLngLat(
+                        9.188523888587952,
+                        45.4923746929562)),
+                    Feature.fromGeometry(Point.fromLngLat(
+                        9.20929491519928,
+                        45.45314676076135)),
+                    Feature.fromGeometry(Point.fromLngLat(
+                        9.177778959274292,
+                        45.45569808340158))
+                })
+            )), new Style.OnStyleLoaded() {
+              @Override
+              public void onStyleLoaded(@NonNull Style style) {
 
-            // Create a SymbolLayer and use the {@link com.mapbox.mapboxsdk.style.expressions.Expression.step()}
-            // to adjust the SymbolLayer icon based on the zoom level. The blue person icon is set as the default
-            // icon and then a step is used to switch to the blue person icon at a certain map camera zoom level.
-            SymbolLayer singleLayer = new SymbolLayer("symbol-layer-id", "source-id");
-            singleLayer.setProperties(
-              iconImage(step(zoom(), literal(BLUE_PERSON_ICON_ID),
-                stop(ZOOM_LEVEL_FOR_SWITCH, BLUE_PIN_ICON_ID))),
-              iconIgnorePlacement(true),
-              iconAllowOverlap(true));
-            style.addLayer(singleLayer);
+                // Create a SymbolLayer and use the {@link com.mapbox.mapboxsdk.style.expressions.Expression.step()}
+                // to adjust the SymbolLayer icon based on the zoom level. The blue person icon is set as the default
+                // icon and then a step is used to switch to the blue person icon at a certain map camera zoom level.
+                SymbolLayer singleLayer = new SymbolLayer("symbol-layer-id", "source-id");
+                singleLayer.setProperties(
+                    iconImage(step(zoom(), literal(BLUE_PERSON_ICON_ID),
+                        stop(ZOOM_LEVEL_FOR_SWITCH, BLUE_PIN_ICON_ID))),
+                    iconIgnorePlacement(true),
+                    iconAllowOverlap(true));
+                style.addLayer(singleLayer);
 
-            Toast.makeText(SymbolSwitchOnZoomActivity.this,
-              R.string.zoom_map_in_and_out_icon_switch_instruction, Toast.LENGTH_SHORT).show();
-          }
-        }
+                Toast.makeText(SymbolSwitchOnZoomActivity.this,
+                    R.string.zoom_map_in_and_out_icon_switch_instruction, Toast.LENGTH_SHORT).show();
+                }
+            }
     );
   }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/IsochroneActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/IsochroneActivity.java
@@ -102,7 +102,7 @@ public class IsochroneActivity extends AppCompatActivity implements MapboxMap.On
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
       public void onMapReady(@NonNull MapboxMap mapboxMap) {
-        mapboxMap.setStyle(new Style.Builder().fromUrl(Style.DARK)
+        mapboxMap.setStyle(new Style.Builder().fromUri(Style.DARK)
 
             //Add a SymbolLayer to the map so that the map click point has a visual marker. This is where the
             // Isochrone API information radiates from.

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MatrixApiActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MatrixApiActivity.java
@@ -82,7 +82,7 @@ public class MatrixApiActivity extends AppCompatActivity {
       public void onMapReady(@NonNull final MapboxMap mapboxMap) {
         MatrixApiActivity.this.mapboxMap = mapboxMap;
 
-        mapboxMap.setStyle(new Style.Builder().fromUrl("mapbox://styles/mapbox/cj8gg22et19ot2rnz65958fkn"),
+        mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/mapbox/cj8gg22et19ot2rnz65958fkn"),
           new Style.OnStyleLoaded() {
             @Override
             public void onStyleLoaded(@NonNull Style style) {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TurfRingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TurfRingActivity.java
@@ -59,7 +59,7 @@ public class TurfRingActivity extends AppCompatActivity implements MapboxMap.OnM
       public void onMapReady(@NonNull MapboxMap mapboxMap) {
         TurfRingActivity.this.mapboxMap = mapboxMap;
         mapboxMap.setStyle(new Style.Builder()
-            .fromUrl(Style.LIGHT)
+            .fromUri(Style.LIGHT)
             .withSource(new GeoJsonSource(OUTER_CIRCLE_GEOJSON_SOURCE_ID))
             .withSource(new GeoJsonSource(INNER_CIRCLE_GEOJSON_SOURCE_ID))
             .withLayer(new FillLayer(OUTER_CIRCLE_LAYER_ID, OUTER_CIRCLE_GEOJSON_SOURCE_ID).withProperties(

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/InsetMapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/InsetMapActivity.java
@@ -77,7 +77,7 @@ public class InsetMapActivity extends AppCompatActivity {
     @Override
     public void onMapReady(@NonNull MapboxMap mapboxMap) {
       InsetMapActivity.this.mainMapboxMap = mapboxMap;
-      mapboxMap.setStyle(new Style.Builder().fromUrl(STYLE_URL), new Style.OnStyleLoaded() {
+      mapboxMap.setStyle(new Style.Builder().fromUri(STYLE_URL), new Style.OnStyleLoaded() {
         @Override
         public void onStyleLoaded(@NonNull Style style) {
           mainMapboxMap.addOnCameraMoveListener(mainCameraMoveListener);
@@ -90,7 +90,7 @@ public class InsetMapActivity extends AppCompatActivity {
     @Override
     public void onMapReady(@NonNull MapboxMap mapboxMap) {
       insetMapboxMap = mapboxMap;
-      mapboxMap.setStyle(new Style.Builder().fromUrl(STYLE_URL));
+      mapboxMap.setStyle(new Style.Builder().fromUri(STYLE_URL));
     }
   };
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SnakingDirectionsRouteActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SnakingDirectionsRouteActivity.java
@@ -92,7 +92,7 @@ public class SnakingDirectionsRouteActivity extends AppCompatActivity
   public void onMapReady(@NonNull final MapboxMap mapboxMap) {
     this.mapboxMap = mapboxMap;
 
-    this.mapboxMap.setStyle(new Style.Builder().fromUrl(Style.LIGHT)
+    this.mapboxMap.setStyle(new Style.Builder().fromUri(Style.LIGHT)
 
       // Add origin and destination SymbolLayer marker icons to the map
       .withImage("icon-id", BitmapFactory.decodeResource(

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/ValueAnimatorIconAnimationActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/ValueAnimatorIconAnimationActivity.java
@@ -74,7 +74,7 @@ public class ValueAnimatorIconAnimationActivity extends AppCompatActivity implem
 
   @Override
   public void onMapReady(@NonNull final MapboxMap mapboxMap) {
-    mapboxMap.setStyle(new Style.Builder().fromUrl(Style.LIGHT)
+    mapboxMap.setStyle(new Style.Builder().fromUri(Style.LIGHT)
         // Add GeoJsonSource with random Features to the map.
         .withSource(new GeoJsonSource("source-id",
           FeatureCollection.fromFeatures(new Feature[] {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/KotlinLocationComponentActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/KotlinLocationComponentActivity.kt
@@ -43,7 +43,7 @@ class KotlinLocationComponentActivity : AppCompatActivity(), OnMapReadyCallback,
 
   override fun onMapReady(mapboxMap: MapboxMap) {
     this.mapboxMap = mapboxMap
-    mapboxMap.setStyle(Style.Builder().fromUrl(
+    mapboxMap.setStyle(Style.Builder().fromUri(
             "mapbox://styles/mapbox/cjerxnqt3cgvp2rmyuxbeqme7")) {
 
       // Map is set up and the style has loaded. Now you can add data or make other map adjustments

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentActivity.java
@@ -50,7 +50,7 @@ public class LocationComponentActivity extends AppCompatActivity implements
   public void onMapReady(@NonNull final MapboxMap mapboxMap) {
     LocationComponentActivity.this.mapboxMap = mapboxMap;
 
-    mapboxMap.setStyle(new Style.Builder().fromUrl("mapbox://styles/mapbox/cjerxnqt3cgvp2rmyuxbeqme7"),
+    mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/mapbox/cjerxnqt3cgvp2rmyuxbeqme7"),
       new Style.OnStyleLoaded() {
         @Override
         public void onStyleLoaded(@NonNull Style style) {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/BasicSymbolLayerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/BasicSymbolLayerActivity.java
@@ -62,7 +62,7 @@ public class BasicSymbolLayerActivity extends AppCompatActivity implements
     symbolLayerIconFeatureList.add(Feature.fromGeometry(
       Point.fromLngLat(-56.990533, -30.583266)));
 
-    mapboxMap.setStyle(new Style.Builder().fromUrl("mapbox://styles/mapbox/cjf4m44iw0uza2spb3q0a7s41")
+    mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/mapbox/cjf4m44iw0uza2spb3q0a7s41")
 
       // Add the SymbolLayer icon image to the map style
       .withImage(ICON_ID, BitmapFactory.decodeResource(

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LocalStyleSourceActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LocalStyleSourceActivity.java
@@ -42,7 +42,7 @@ public class LocalStyleSourceActivity extends AppCompatActivity {
           @Override
           public void onClick(View view) {
             // Reference the custom raster file URL and pass through as the string parameter
-            mapboxMap.setStyle(new Style.Builder().fromUrl("https://www.mapbox.com/android-docs/files/mapbox-raster-v8.json"));
+            mapboxMap.setStyle(new Style.Builder().fromUri("https://www.mapbox.com/android-docs/files/mapbox-raster-v8.json"));
           }
         });
 
@@ -50,7 +50,7 @@ public class LocalStyleSourceActivity extends AppCompatActivity {
           @Override
           public void onClick(View view) {
             // Reference the local JSON style file in the assets folder and pass through as the string parameter
-            mapboxMap.setStyle(new Style.Builder().fromUrl("asset://local_style_file.json"));
+            mapboxMap.setStyle(new Style.Builder().fromUri("asset://local_style_file.json"));
           }
         });
       }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/MapboxStudioStyleActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/MapboxStudioStyleActivity.java
@@ -34,7 +34,7 @@ public class MapboxStudioStyleActivity extends AppCompatActivity {
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
       public void onMapReady(@NonNull MapboxMap mapboxMap) {
-        mapboxMap.setStyle(new Style.Builder().fromUrl("mapbox://styles/mapbox/cj3kbeqzo00022smj7akz3o1e"));
+        mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/mapbox/cj3kbeqzo00022smj7akz3o1e"));
       }
     });
   }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/MissingIconActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/MissingIconActivity.java
@@ -80,7 +80,7 @@ public class MissingIconActivity extends AppCompatActivity {
 
         // Use a URL to build and add a Style object to the map. Then add a source to the Style.
         mapboxMap.setStyle(
-          new Style.Builder().fromUrl(Style.LIGHT)
+          new Style.Builder().fromUri(Style.LIGHT)
             .withSource(new GeoJsonSource(ICON_SOURCE_ID,
               FeatureCollection.fromFeatures(new Feature[] {
                 carlosFeature,

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/VariableLabelPlacementActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/VariableLabelPlacementActivity.java
@@ -60,7 +60,7 @@ public class VariableLabelPlacementActivity extends AppCompatActivity {
         GeoJsonSource source = new GeoJsonSource(GEOJSON_SRC_ID);
         source.setUrl("asset://poi_places.geojson");
 
-        mapboxMap.setStyle(new Style.Builder().fromUrl(Style.LIGHT)
+        mapboxMap.setStyle(new Style.Builder().fromUri(Style.LIGHT)
             .withSource(source)
             // Adds a SymbolLayer to display POI labels
             .withLayer(new SymbolLayer(POI_LABELS_LAYER_ID, GEOJSON_SRC_ID)


### PR DESCRIPTION
`fromUrl()` was recently deprecated, so this pr refactors usage of `Style.Builder().fromUrl()` to `Style.Builder().fromUri()`

