### PR TITLE
RecyclerView + Directions route example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -93,6 +93,7 @@ import com.mapbox.mapboxandroiddemo.examples.labs.MarkerFollowingRouteActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.MovingIconWithTrailingLineActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.PictureInPictureActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.PulsingLayerOpacityColorActivity;
+import com.mapbox.mapboxandroiddemo.examples.labs.RecyclerViewDirectionsActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.RecyclerViewOnMapActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SnakingDirectionsRouteActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SpaceStationLocationActivity;
@@ -1013,11 +1014,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_java_services,
-      R.string.activity_java_turf_ring_title,
-      R.string.activity_java_turf_ring_description,
+      R.string.activity_java_services_turf_ring_title,
+      R.string.activity_java_services_turf_ring_description,
       new Intent(MainActivity.this, TurfRingActivity.class),
       null,
-      R.string.activity_java_turf_ring_url, false, BuildConfig.MIN_SDK_VERSION
+      R.string.activity_java_services_turf_ring_url, false, BuildConfig.MIN_SDK_VERSION
     ));
 
     exampleItemModels.add(new ExampleItemModel(
@@ -1193,6 +1194,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, MovingIconWithTrailingLineActivity.class),
       null,
       R.string.activity_lab_moving_icon_with_trailing_line_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+        R.id.nav_lab,
+        R.string.activity_lab_rv_directions_title,
+        R.string.activity_lab_rv_directions_description,
+        new Intent(MainActivity.this, RecyclerViewDirectionsActivity.class),
+        null,
+        R.string.activity_lab_rv_directions_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_dds,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -248,6 +248,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.labs.RecyclerViewDirectionsActivity"
+            android:label="@string/activity_lab_rv_directions_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.AnimatedImageGifActivity"
             android:label="@string/activity_labs_gif_on_map_title">
             <meta-data
@@ -848,7 +855,7 @@
         </activity>
         <activity
             android:name=".examples.javaservices.TurfRingActivity"
-            android:label="@string/activity_java_turf_ring_title"
+            android:label="@string/activity_java_services_turf_ring_title"
             android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/RecyclerViewDirectionsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/RecyclerViewDirectionsActivity.java
@@ -1,0 +1,420 @@
+package com.mapbox.mapboxandroiddemo.examples.labs;
+
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.CardView;
+import android.support.v7.widget.DefaultItemAnimator;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.LinearSnapHelper;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.MapboxDirections;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+import static com.mapbox.core.constants.Constants.PRECISION_6;
+import static com.mapbox.mapboxsdk.style.layers.Property.LINE_JOIN_ROUND;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconSize;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+
+/**
+ * When a RecyclerView item is tapped on, display the Mapbox Directions API route
+ * associated with the item.
+ */
+public class RecyclerViewDirectionsActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private static final String TAG = "RVDirectionsActivity";
+  private static final String SYMBOL_ICON_ID = "SYMBOL_ICON_ID";
+  private static final String PERSON_ICON_ID = "PERSON_ICON_ID";
+  private static final String MARKER_SOURCE_ID = "MARKER_SOURCE_ID";
+  private static final String PERSON_SOURCE_ID = "PERSON_SOURCE_ID";
+  private static final String DASHED_DIRECTIONS_LINE_LAYER_SOURCE_ID = "DASHED_DIRECTIONS_LINE_LAYER_SOURCE_ID";
+  private static final String LAYER_ID = "LAYER_ID";
+  private static final String PERSON_LAYER_ID = "PERSON_LAYER_ID";
+  private static final String DASHED_DIRECTIONS_LINE_LAYER_ID = "DASHED_DIRECTIONS_LINE_LAYER_ID";
+  private static final Point directionsOriginPoint = Point.fromLngLat(100.48730850219725,
+      13.737217333153827);
+  private static final  LatLng[] possibleDestinations = new LatLng[]{
+    new LatLng(13.773399508046145, 100.51116943359375),
+    new LatLng(13.743387039520751, 100.45074462890625),
+    new LatLng(13.732715012486663, 100.5523681640625),
+    new LatLng(13.665336643848484, 100.45486450195312),
+    new LatLng(13.7153719325982, 100.49263000488281),
+    new LatLng(13.742053062720384, 100.51288604736328),
+    new LatLng(13.77773432408578, 100.4806137084961),
+    new LatLng(13.784736549340208, 100.55580139160156),
+    new LatLng(13.71670606117596, 100.45520782470703)
+  };
+  private final List<DirectionsRoute> directionsRouteList = new ArrayList<>();
+  private MapboxMap mapboxMap;
+  private MapView mapView;
+  private FeatureCollection dashedLineDirectionsFeatureCollection;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_lab_recycler_view_directions);
+
+    // Initialize the map view
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+    RecyclerViewDirectionsActivity.this.mapboxMap = mapboxMap;
+    mapboxMap.setStyle(new Style.Builder().fromUri(Style.LIGHT)
+
+        // Set up the image, source, and layer for the person icon,
+        // which is where all of the routes will start from
+        .withImage(PERSON_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+            getResources().getDrawable(R.drawable.ic_person)))
+        .withSource(new GeoJsonSource(PERSON_SOURCE_ID,
+            Feature.fromGeometry(directionsOriginPoint)))
+        .withLayer(new SymbolLayer(PERSON_LAYER_ID, PERSON_SOURCE_ID).withProperties(
+            iconImage(PERSON_ICON_ID),
+            iconSize(2f),
+            iconAllowOverlap(true),
+            iconIgnorePlacement(true)
+        ))
+
+        // Set up the image, source, and layer for the potential destination markers
+        .withImage(SYMBOL_ICON_ID, BitmapFactory.decodeResource(
+            this.getResources(), R.drawable.red_marker))
+        .withSource(new GeoJsonSource(MARKER_SOURCE_ID, initDestinationFeatureCollection()))
+        .withLayer(new SymbolLayer(LAYER_ID, MARKER_SOURCE_ID).withProperties(
+            iconImage(SYMBOL_ICON_ID),
+            iconAllowOverlap(true),
+            iconIgnorePlacement(true),
+            iconOffset(new Float[]{0f, -4f})
+        ))
+
+        // Set up the source and layer for the direction route LineLayer
+        .withSource(new GeoJsonSource(DASHED_DIRECTIONS_LINE_LAYER_SOURCE_ID))
+        .withLayerBelow(
+            new LineLayer(DASHED_DIRECTIONS_LINE_LAYER_ID, DASHED_DIRECTIONS_LINE_LAYER_SOURCE_ID)
+                .withProperties(
+                    lineWidth(7f),
+                    lineJoin(LINE_JOIN_ROUND),
+                    lineColor(Color.parseColor("#2096F3"))
+                ), PERSON_LAYER_ID), new Style.OnStyleLoaded() {
+                  @Override
+                  public void onStyleLoaded(@NonNull Style style) {
+                    getRoutesToAllPoints();
+                    initRecyclerView();
+                    Toast.makeText(RecyclerViewDirectionsActivity.this,
+                        R.string.toast_instruction, Toast.LENGTH_SHORT).show();
+                  }
+                });
+  }
+
+  /**
+   * Loop through the possible destination list of LatLng locations and get
+   * the route for each destination.
+   */
+  private void getRoutesToAllPoints() {
+    for (LatLng singleLatLng : possibleDestinations) {
+      getRoute(Point.fromLngLat(singleLatLng.getLongitude(), singleLatLng.getLatitude()));
+    }
+  }
+
+  /**
+   * Make a call to the Mapbox Directions API to get the route from the person location icon
+   * to the marker's location and then add the route to the route list.
+   *
+   * @param destination the marker associated with the recyclerview card that was tapped on.
+   */
+  @SuppressWarnings({"MissingPermission"})
+  private void getRoute(Point destination) {
+    MapboxDirections client = MapboxDirections.builder()
+        .origin(directionsOriginPoint)
+        .destination(destination)
+        .overview(DirectionsCriteria.OVERVIEW_FULL)
+        .profile(DirectionsCriteria.PROFILE_DRIVING)
+        .accessToken(getString(R.string.access_token))
+        .build();
+    client.enqueueCall(new Callback<DirectionsResponse>() {
+      @Override
+      public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
+        if (response.body() == null) {
+          Log.d(TAG, "No routes found, make sure you set the right user and access token.");
+          return;
+        } else if (response.body().routes().size() < 1) {
+          Log.d(TAG, "No routes found");
+          return;
+        }
+        // Add the route to the list.
+        directionsRouteList.add(response.body().routes().get(0));
+      }
+
+      @Override
+      public void onFailure(Call<DirectionsResponse> call, Throwable throwable) {
+        Log.d(TAG, "Error: " + throwable.getMessage());
+        if (!throwable.getMessage().equals("Coordinate is invalid: 0,0")) {
+          Toast.makeText(RecyclerViewDirectionsActivity.this,
+              "Error: " + throwable.getMessage(), Toast.LENGTH_SHORT).show();
+        }
+      }
+    });
+  }
+
+  /**
+   * Update the GeoJSON data for the direction route LineLayer.
+   *
+   * @param route The route to be drawn in the map's LineLayer that was set up above.
+   */
+  private void drawNavigationPolylineRoute(final DirectionsRoute route) {
+    if (mapboxMap != null) {
+      mapboxMap.getStyle(new Style.OnStyleLoaded() {
+        @Override
+        public void onStyleLoaded(@NonNull Style style) {
+          List<Feature> directionsRouteFeatureList = new ArrayList<>();
+          LineString lineString = LineString.fromPolyline(route.geometry(), PRECISION_6);
+          List<Point> lineStringCoordinates = lineString.coordinates();
+          for (int i = 0; i < lineStringCoordinates.size(); i++) {
+            directionsRouteFeatureList.add(Feature.fromGeometry(
+                LineString.fromLngLats(lineStringCoordinates)));
+          }
+          dashedLineDirectionsFeatureCollection =
+              FeatureCollection.fromFeatures(directionsRouteFeatureList);
+          GeoJsonSource source = style.getSourceAs(DASHED_DIRECTIONS_LINE_LAYER_SOURCE_ID);
+          if (source != null) {
+            source.setGeoJson(dashedLineDirectionsFeatureCollection);
+          }
+        }
+      });
+    }
+  }
+
+  /**
+   * Create a FeatureCollection to display the possible destination markers.
+   *
+   * @return a {@link FeatureCollection}, which represents the possible destinations.
+   */
+  private FeatureCollection initDestinationFeatureCollection() {
+    List<Feature> featureList = new ArrayList<>();
+    for (LatLng latLng : possibleDestinations) {
+      featureList.add(Feature.fromGeometry(
+          Point.fromLngLat(latLng.getLongitude(), latLng.getLatitude())));
+    }
+    return FeatureCollection.fromFeatures(featureList);
+  }
+
+  /**
+   * Set up the RecyclerView.
+   */
+  private void initRecyclerView() {
+    RecyclerView recyclerView = findViewById(R.id.rv_on_top_of_map);
+    recyclerView.setLayoutManager(new LinearLayoutManager(getApplicationContext(),
+        LinearLayoutManager.HORIZONTAL, true));
+    recyclerView.setItemAnimator(new DefaultItemAnimator());
+    recyclerView.setAdapter(new LocationRecyclerViewAdapter(this,
+        createRecyclerViewLocations(), mapboxMap));
+    new LinearSnapHelper().attachToRecyclerView(recyclerView);
+  }
+
+  /**
+   * Create data fro the RecyclerView.
+   *
+   * @return a list of {@link SingleRecyclerViewLocation} objects for the RecyclerView.
+   */
+  private List<SingleRecyclerViewLocation> createRecyclerViewLocations() {
+    ArrayList<SingleRecyclerViewLocation> locationList = new ArrayList<>();
+    for (int x = 0; x < possibleDestinations.length; x++) {
+      SingleRecyclerViewLocation singleLocation = new SingleRecyclerViewLocation();
+      singleLocation.setName(String.format(getString(R.string.rv_directions_route_card_name), x));
+      singleLocation.setAvailableTables(String.format(getString(
+          R.string.rv_directions_route_available_table_info),
+          new Random().nextInt(possibleDestinations.length)));
+      locationList.add(singleLocation);
+    }
+    return locationList;
+  }
+
+  /**
+   * POJO model class for a single location in the RecyclerView.
+   */
+  class SingleRecyclerViewLocation {
+
+    private String name;
+    private String availableTables;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getAvailableTables() {
+      return availableTables;
+    }
+
+    public void setAvailableTables(String availableTables) {
+      this.availableTables = availableTables;
+    }
+
+  }
+
+  static class LocationRecyclerViewAdapter extends
+      RecyclerView.Adapter<LocationRecyclerViewAdapter.MyViewHolder> {
+
+    private List<SingleRecyclerViewLocation> locationList;
+    private MapboxMap map;
+    private WeakReference<RecyclerViewDirectionsActivity> weakReference;
+
+
+    public LocationRecyclerViewAdapter(RecyclerViewDirectionsActivity activity,
+                                       List<SingleRecyclerViewLocation> locationList,
+                                       MapboxMap mapBoxMap) {
+      this.locationList = locationList;
+      this.map = mapBoxMap;
+      this.weakReference = new WeakReference<>(activity);
+    }
+
+    @Override
+    public MyViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+      View itemView = LayoutInflater.from(parent.getContext())
+          .inflate(R.layout.rv_directions_card, parent, false);
+      return new MyViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(MyViewHolder holder, int position) {
+      SingleRecyclerViewLocation singleRecyclerViewLocation = locationList.get(position);
+      holder.name.setText(singleRecyclerViewLocation.getName());
+      holder.numOfAvailableTables.setText(singleRecyclerViewLocation.getAvailableTables());
+      holder.setClickListener(new ItemClickListener() {
+        @Override
+        public void onClick(View view, int position) {
+          weakReference.get()
+              .drawNavigationPolylineRoute(weakReference.get().directionsRouteList.get(position));
+        }
+      });
+    }
+
+    @Override
+    public int getItemCount() {
+      return locationList.size();
+    }
+
+    static class MyViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+      TextView name;
+      TextView numOfAvailableTables;
+      CardView singleCard;
+      ItemClickListener clickListener;
+
+      MyViewHolder(View view) {
+        super(view);
+        name = view.findViewById(R.id.location_title_tv);
+        numOfAvailableTables = view.findViewById(R.id.location_num_of_beds_tv);
+        singleCard = view.findViewById(R.id.single_location_cardview);
+        singleCard.setOnClickListener(this);
+      }
+
+      public void setClickListener(ItemClickListener itemClickListener) {
+        this.clickListener = itemClickListener;
+      }
+
+      @Override
+      public void onClick(View view) {
+        clickListener.onClick(view, getLayoutPosition());
+      }
+    }
+  }
+
+  public interface ItemClickListener {
+    void onClick(View view, int position);
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_lab_recycler_view_directions.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_lab_recycler_view_directions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="13.730219"
+        mapbox:mapbox_cameraTargetLng="100.501723"
+        mapbox:mapbox_cameraZoom="10.58" />
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/rv_on_top_of_map"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginBottom="32dp" />
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/layout/rv_directions_card.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/rv_directions_card.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="300dp"
+    android:layout_height="wrap_content"
+    android:id="@+id/single_location_cardview"
+    android:layout_marginEnd="8dp"
+    android:layout_marginLeft="8dp"
+    android:layout_marginRight="8dp"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="#2096F3"
+        android:gravity="center_horizontal"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/location_title_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:textColor="@color/mapboxWhite"
+            android:textSize="20sp"/>
+
+        <TextView
+            android:id="@+id/location_num_of_beds_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:textColor="@color/mapboxWhite"
+            android:textSize="14sp"/>
+
+    </LinearLayout>
+
+
+</android.support.v7.widget.CardView>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -192,7 +192,12 @@
     <!-- Recyclerview on map -->
     <string name="rv_card_name">Location #%1$d</string>
     <string name="rv_card_bed_info">This location has %1$d beds</string>
-    <string name="toast_instruction">Click on cards below</string>
+    <string name="toast_instruction">Tap on cards below</string>
+
+    <!-- Recyclerview Directions on map -->
+    <string name="rv_directions_route_card_name">Restaurant #%1$d</string>
+    <string name="rv_directions_route_available_table_info">%1$d tables available</string>
+    <string name="rv_directions_route_toast_instruction">Tap on cards below</string>
 
     <!-- Optimization API activity -->
     <string name="origin">Origin</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -88,6 +88,9 @@
     <string name="activity_java_services_isochrone_description">Use the Isochrone API to receive information about how far you can travel within a given time.</string>
     <string name="activity_java_services_isochrone_with_seekbar_description">Use an Android seekbar slider to retrieve info from the the Isochrone API. Display the data and adjust the camera accordingly.</string>
     <string name="activity_java_services_tilequery_description">Use the Tilequery API to search for features in a tileset. This example queries for up to 10 buildings which are within 50 meters of the single map click location.</string>
+    <string name="activity_java_services_simplify_polyline_description">Using the polylines utility, simplify a polyline which reduces the amount of coordinates making up the polyline depending on tolerance.</string>
+    <string name="activity_java_services_map_matching_description">Match raw GPS points to the map so they aligns with the roads/pathways.</string>
+    <string name="activity_java_services_turf_ring_description">Use Turf to calculate coordinates to eventually draw a ring around a center coordinate.</string>
     <string name="activity_plugins_traffic_plugin_description">Use the traffic plugin to display live car congestion data on top of a map.</string>
     <string name="activity_plugins_building_plugin_description">Use the building plugin to easily display 3D building height</string>
     <string name="activity_plugins_geojson_plugin_description">Easily retrieve GeoJSON data from a url, asset, or path</string>
@@ -101,8 +104,6 @@
     <string name="activity_location_user_location_map_frag_plugin_description">Use the LocationComponent to display a user\'s location on a map fragment.</string>
     <string name="activity_location_location_component_options_description">Use LocationComponent options to customize the user location information.</string>
     <string name="activity_location_location_component_camera_options_description">Use LocationComponent camera options to customize map camera behavior.</string>
-    <string name="activity_java_services_simplify_polyline_description">Using the polylines utility, simplify a polyline which reduces the amount of coordinates making up the polyline depending on tolerance.</string>
-    <string name="activity_java_services_map_matching_description">Match raw GPS points to the map so they aligns with the roads/pathways.</string>
     <string name="activity_image_generator_snapshot_share_description">Send and share a map snapshot image.</string>
     <string name="activity_image_generator_snapshot_notification_description">Show a snapshotted image in a notification.</string>
     <string name="activity_lab_animated_marker_description">Animate the marker to a new position on the map.</string>
@@ -125,7 +126,8 @@
     <string name="activity_lab_fog_background_description">Add a gradient on top of a MapView to show a background fog effect.</string>
     <string name="activity_lab_animated_interpolator_icon_drop_description">Use Android system interpolators to animate SymbolLayer icons movement.</string>
     <string name="activity_lab_drag_draw_description">Drag a finger on the map to draw a search area.</string>
-    <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
     <string name="activity_lab_home_screen_widget_description">Show the device\'s current location or other information in a homescreen widget.</string>
-    <string name="activity_java_turf_ring_description">Use Turf to calculate coordinates to eventually draw a ring around a center coordinate.</string>
+    <string name="activity_lab_rv_directions_description">Quickly show the directions route associated with a RecyclerView item.</string>
+    <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -86,6 +86,9 @@
     <string name="activity_java_services_isochrone_title">Make a isochrone request</string>
     <string name="activity_java_services_isochrone_with_seekbar_title">Ischrone time slider</string>
     <string name="activity_java_services_tilequery_title">Make a tilequery request</string>
+    <string name="activity_java_services_simplify_polyline_title">Simplify a polyline</string>
+    <string name="activity_java_services_map_matching_title">Map Matching</string>
+    <string name="activity_java_services_turf_ring_title">Hollow circle</string>
     <string name="activity_plugins_traffic_plugin_title">Display real-time traffic</string>
     <string name="activity_plugins_building_plugin_title">Display buildings in 3D</string>
     <string name="activity_plugins_localization_plugin_title">Change map text to device language</string>
@@ -99,8 +102,6 @@
     <string name="activity_location_location_component_title">Show a user\'s location</string>
     <string name="activity_location_location_component_camera_options_title">Location camera options</string>
     <string name="activity_location_location_component_options_title">Customized location icon</string>
-    <string name="activity_java_services_simplify_polyline_title">Simplify a polyline</string>
-    <string name="activity_java_services_map_matching_title">Map Matching</string>
     <string name="activity_image_generator_snapshot_notification_title">Snapshot Notification</string>
     <string name="activity_image_generator_snapshot_share_title">Share snapshot image</string>
     <string name="activity_lab_animated_marker_title">Animate marker position</string>
@@ -125,5 +126,5 @@
     <string name="activity_lab_drag_draw_title">Drawing search area</string>
     <string name="activity_china_simple_china_mapview_title">China map view</string>
     <string name="activity_lab_home_screen_widget_title">Homescreen geocoding widget</string>
-    <string name="activity_java_turf_ring_title">Hollow circle</string>
+    <string name="activity_lab_rv_directions_title">RecyclerView Directions</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -87,6 +87,9 @@
     <string name="activity_java_services_isochrone_url" translatable="false">https://i.imgur.com/eUByGvt.png</string>
     <string name="activity_java_services_isochrone_with_seekbar_url" translatable="false">https://i.imgur.com/hCVswtE.png</string>
     <string name="activity_java_services_tilequery_url" translatable="false">http://i.imgur.com/VkOCYwq.jpg</string>
+    <string name="activity_java_services_simplify_polyline_url" translatable="false">http://i.imgur.com/uATgul1.png</string>
+    <string name="activity_java_services_map_matching_url" translatable="false">https://i.imgur.com/ig8gGnY.png</string>
+    <string name="activity_java_services_turf_ring_url" translatable="false">https://i.imgur.com/nG8xeXH.png</string>
     <string name="activity_plugins_traffic_plugin_url" translatable="false">http://i.imgur.com/HRriOVR.png</string>
     <string name="activity_plugins_building_plugin_url" translatable="false">http://i.imgur.com/Vcu67UR.png</string>
     <string name="activity_plugins_places_plugin_url" translatable="false">https://i.imgur.com/oKHx3bv.png</string>
@@ -100,8 +103,6 @@
     <string name="activity_location_user_location_fragment_plugin_url" translatable="false">https://i.imgur.com/1jG8WQG.png</string>
     <string name="activity_location_location_component_options_url" translatable="false">https://i.imgur.com/4HiEJC1.png</string>
     <string name="activity_location_location_component_camera_options_url" translatable="false">https://i.imgur.com/Q2cB3NY.png</string>
-    <string name="activity_java_services_simplify_polyline_url" translatable="false">http://i.imgur.com/uATgul1.png</string>
-    <string name="activity_java_services_map_matching_url" translatable="false">https://i.imgur.com/ig8gGnY.png</string>
     <string name="activity_image_generator_snapshot_notification_url" translatable="false">https://i.imgur.com/OiveDFG.png</string>
     <string name="activity_image_generator_snapshot_share_url" translatable="false">https://i.imgur.com/KgfsY3s.png</string>
     <string name="activity_lab_animated_marker_url" translatable="false">http://i.imgur.com/XegvIKr.png</string>
@@ -126,6 +127,6 @@
     <string name="activity_lab_animated_interpolator_icon_drop_url">https://i.imgur.com/JfLf69C.png</string>
     <string name="activity_lab_drag_draw_url" translatable="false">https://i.imgur.com/vf5uZyS.png</string>
     <string name="activity_lab_home_screen_widget_url" translatable="false">https://i.imgur.com/H5N9jDn.png</string>
-    <string name="activity_java_turf_ring_url" translatable="false">https://i.imgur.com/nG8xeXH.png</string>
+    <string name="activity_lab_rv_directions_url" translatable="false">https://i.imgur.com/LurOuXQ.png</string>
     <string name="activity_china_simple_china_mapview_url" translatable="false">https://i.imgur.com/KwoEynZ.png</string>
 </resources>


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1118 by adding an example of RecyclerView interaction with the Mapbox Directions API. Various routes are loaded in the background when the example opens. Because they're pre-loaded, they appear quickly when the corresponding RecyclerView item is selected.

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/60399860-6bb82600-9b20-11e9-9a74-5cc521613251.gif)
