### PR TITLE
Add tutorial demos

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -44,6 +44,7 @@ import com.mapbox.mapboxandroiddemo.examples.dds.BathymetryActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.ChoroplethJsonVectorMixActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.ChoroplethZoomChangeActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.CircleLayerClusteringActivity;
+import com.mapbox.mapboxandroiddemo.examples.dds.CircleRadiusActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.CreateHotspotsActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.DrawGeojsonLineActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.DrawPolygonActivity;
@@ -100,6 +101,7 @@ import com.mapbox.mapboxandroiddemo.examples.labs.SpaceStationLocationActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SymbolLayerMapillaryActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.ValueAnimatorIconAnimationActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.KotlinLocationComponentActivity;
+import com.mapbox.mapboxandroiddemo.examples.location.LocationChangeListeningActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.LocationComponentActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.LocationComponentCameraOptionsActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.LocationComponentFragmentActivity;
@@ -141,6 +143,7 @@ import com.mapbox.mapboxandroiddemo.examples.styles.LocalStyleSourceActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.MapboxStudioStyleActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.MissingIconActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.RotatingTextAnchorPositionActivity;
+import com.mapbox.mapboxandroiddemo.examples.styles.RuntimeStylingActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.SatelliteOpacityOnZoomActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.ShowHideLayersActivity;
 import com.mapbox.mapboxandroiddemo.examples.styles.TextFieldFormattingActivity;
@@ -1392,13 +1395,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_basics,
-      R.string.activity_map_and_marker_title,
-      R.string.activity_basic_simple_mapview_description,
-      new Intent(MainActivity.this, MapAndMarkerActivity.class),
-      R.string.activity_basic_simple_mapview_url, false, BuildConfig.MIN_SDK_VERSION));
-
-    exampleItemModels.add(new ExampleItemModel(
-      R.id.nav_basics,
       R.string.activity_basic_simple_mapview_title,
       R.string.activity_basic_simple_mapview_description,
       new Intent(MainActivity.this, SimpleMapViewActivity.class),
@@ -1420,5 +1416,29 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, MapboxMapOptionActivity.class),
       null,
       R.string.activity_basic_mapbox_options_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_dds,
+      R.string.activity_dds_circle_radius_title,
+      R.string.activity_dds_circle_radius_description,
+      new Intent(MainActivity.this, CircleRadiusActivity.class),
+      null,
+      R.string.activity_dds_circle_radius_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_location,
+      R.string.activity_location_location_change_listening_title,
+      R.string.activity_location_location_change_listening_description,
+      new Intent(MainActivity.this, LocationChangeListeningActivity.class),
+      null,
+      R.string.activity_location_location_change_listening_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_styles,
+      R.string.activity_styles_runtime_styling_title,
+      R.string.activity_styles_runtime_styling_description,
+      new Intent(MainActivity.this, RuntimeStylingActivity.class),
+      null,
+      R.string.activity_styles_runtime_styling_url, false, BuildConfig.MIN_SDK_VERSION));
   }
 }

--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -1392,6 +1392,13 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_basics,
+      R.string.activity_map_and_marker_title,
+      R.string.activity_basic_simple_mapview_description,
+      new Intent(MainActivity.this, MapAndMarkerActivity.class),
+      R.string.activity_basic_simple_mapview_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_basics,
       R.string.activity_basic_simple_mapview_title,
       R.string.activity_basic_simple_mapview_description,
       new Intent(MainActivity.this, SimpleMapViewActivity.class),

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -234,6 +234,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.dds.CircleRadiusActivity"
+            android:label="@string/activity_dds_circle_radius_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.LocationPickerActivity"
             android:label="@string/activity_lab_location_picker_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -219,6 +219,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.location.LocationChangeListeningActivity"
+            android:label="@string/activity_location_location_change_listening_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.camera.BoundingBoxCameraActivity"
             android:label="@string/activity_camera_bounding_box_title">
             <meta-data
@@ -449,6 +456,13 @@
         <activity
             android:name=".examples.styles.MissingIconActivity"
             android:label="@string/activity_styles_missing_icon_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
+            android:name=".examples.styles.RuntimeStylingActivity"
+            android:label="@string/activity_styles_runtime_styling_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleRadiusActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleRadiusActivity.java
@@ -4,25 +4,27 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
-import com.mapbox.mapboxandroiddemo.R;
 
+import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
-
 import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.sources.VectorSource;
 
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
-import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleOpacity;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.exponential;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.interpolate;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.stop;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleOpacity;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
 
+/**
+ * Set the radii of a CircleLayer's circles based on a data property.
+ */
 public class CircleRadiusActivity extends AppCompatActivity {
 
   private MapView mapView;
@@ -37,13 +39,13 @@ public class CircleRadiusActivity extends AppCompatActivity {
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
       public void onMapReady(@NonNull final MapboxMap mapboxMap) {
-
         mapboxMap.setStyle(Style.DARK, new Style.OnStyleLoaded() {
           @Override
           public void onStyleLoaded(@NonNull Style style) {
             // replace examples.8mj5l1r9 with the map ID for the tileset
             // you created by uploading data to your Mapbox account
             style.addSource(new VectorSource("trees-source", "mapbox://examples.8mj5l1r9"));
+
             CircleLayer circleLayer = new CircleLayer("trees-style", "trees-source");
             // replace street-trees-DC-9gvg5l with the name of your source layer
             circleLayer.setSourceLayer("street-trees-DC-9gvg5l");
@@ -64,7 +66,6 @@ public class CircleRadiusActivity extends AppCompatActivity {
       }
     });
   }
-
 
   // Add the mapView's own lifecycle methods to the activity's lifecycle methods
   @Override

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleRadiusActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleRadiusActivity.java
@@ -1,0 +1,111 @@
+package com.mapbox.mapboxandroiddemo.examples.dds;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
+import com.mapbox.mapboxandroiddemo.R;
+
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import com.mapbox.mapboxsdk.style.layers.CircleLayer;
+import com.mapbox.mapboxsdk.style.sources.VectorSource;
+
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleOpacity;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.exponential;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.interpolate;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.stop;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
+
+public class CircleRadiusActivity extends AppCompatActivity {
+
+  private MapView mapView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    Mapbox.getInstance(this, getString(R.string.access_token));
+    setContentView(R.layout.activity_circle_radius_activity);
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+
+        mapboxMap.setStyle(Style.DARK, new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style style) {
+            // replace examples.8mj5l1r9 with the map ID for the tileset
+            // you created by uploading data to your Mapbox account
+            style.addSource(new VectorSource("trees-source", "mapbox://examples.8mj5l1r9"));
+            CircleLayer circleLayer = new CircleLayer("trees-style", "trees-source");
+            // replace street-trees-DC-9gvg5l with the name of your source layer
+            circleLayer.setSourceLayer("street-trees-DC-9gvg5l");
+            circleLayer.withProperties(
+                    circleOpacity(0.6f),
+                    circleColor(Color.parseColor("#ffffff")),
+                    circleRadius(
+                            interpolate(exponential(1.0f), get("DBH"),
+                                    stop(0, 0f),
+                                    stop(1, 1f),
+                                    stop(110, 11f)
+                            )
+                    )
+            );
+            style.addLayer(circleLayer);
+          }
+        });
+      }
+    });
+  }
+
+
+  // Add the mapView's own lifecycle methods to the activity's lifecycle methods
+  @Override
+  public void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationChangeListeningActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationChangeListeningActivity.java
@@ -1,52 +1,49 @@
 package com.mapbox.mapboxandroiddemo.examples.location;
 
-import com.mapbox.mapboxandroiddemo.R;
 import android.annotation.SuppressLint;
 import android.location.Location;
-import android.util.Log;
-import android.widget.Toast;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-// Classes needed to initialize the map
-import com.mapbox.mapboxsdk.Mapbox;
-import com.mapbox.mapboxsdk.maps.MapView;
-import com.mapbox.mapboxsdk.maps.MapboxMap;
-import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
-import com.mapbox.mapboxsdk.maps.Style;
-// Classes needed to handle location permissions
-import com.mapbox.android.core.permissions.PermissionsListener;
-import com.mapbox.android.core.permissions.PermissionsManager;
-import java.util.List;
-// Classes needed to add the location engine
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.widget.Toast;
+
 import com.mapbox.android.core.location.LocationEngine;
 import com.mapbox.android.core.location.LocationEngineCallback;
 import com.mapbox.android.core.location.LocationEngineProvider;
 import com.mapbox.android.core.location.LocationEngineRequest;
 import com.mapbox.android.core.location.LocationEngineResult;
-import java.lang.ref.WeakReference;
-// Classes needed to add the location component
+import com.mapbox.android.core.permissions.PermissionsListener;
+import com.mapbox.android.core.permissions.PermissionsManager;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.location.LocationComponent;
 import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import java.lang.ref.WeakReference;
+import java.util.List;
+
 
 /**
- * Use the Mapbox Core Library to listen to device location updates
+ * Use the Mapbox Core Library to receive updates when the device changes location.
  */
 public class LocationChangeListeningActivity extends AppCompatActivity implements
         OnMapReadyCallback, PermissionsListener {
-  // Variables needed to initialize a map
+
+  private static final long DEFAULT_INTERVAL_IN_MILLISECONDS = 1000L;
+  private static final long DEFAULT_MAX_WAIT_TIME = DEFAULT_INTERVAL_IN_MILLISECONDS * 5;
   private MapboxMap mapboxMap;
   private MapView mapView;
-  // Variables needed to handle location permissions
   private PermissionsManager permissionsManager;
-  // Variables needed to add the location engine
   private LocationEngine locationEngine;
-  private long DEFAULT_INTERVAL_IN_MILLISECONDS = 1000L;
-  private long DEFAULT_MAX_WAIT_TIME = DEFAULT_INTERVAL_IN_MILLISECONDS * 5;
-  // Variables needed to listen to location updates
-  private LocationChangeListeningActivityLocationCallback callback = new LocationChangeListeningActivityLocationCallback(this);
+  private LocationChangeListeningActivityLocationCallback callback =
+    new LocationChangeListeningActivityLocationCallback(this);
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -69,12 +66,11 @@ public class LocationChangeListeningActivity extends AppCompatActivity implement
     this.mapboxMap = mapboxMap;
 
     mapboxMap.setStyle(Style.TRAFFIC_NIGHT,
-            new Style.OnStyleLoaded() {
-              @Override
-              public void onStyleLoaded(@NonNull Style style) {
-                enableLocationComponent(style);
-              }
-            });
+      new Style.OnStyleLoaded() {
+        @Override public void onStyleLoaded(@NonNull Style style) {
+          enableLocationComponent(style);
+        }
+      });
   }
 
   /**
@@ -129,13 +125,15 @@ public class LocationChangeListeningActivity extends AppCompatActivity implement
   }
 
   @Override
-  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                         @NonNull int[] grantResults) {
     permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 
   @Override
   public void onExplanationNeeded(List<String> permissionsToExplain) {
-    Toast.makeText(this, R.string.user_location_permission_explanation, Toast.LENGTH_LONG).show();
+    Toast.makeText(this, R.string.user_location_permission_explanation,
+      Toast.LENGTH_LONG).show();
   }
 
   @Override
@@ -177,7 +175,8 @@ public class LocationChangeListeningActivity extends AppCompatActivity implement
 
         // Create a Toast which displays the new location's coordinates
         Toast.makeText(activity, String.format(activity.getString(R.string.new_location),
-                String.valueOf(result.getLastLocation().getLatitude()), String.valueOf(result.getLastLocation().getLongitude())),
+                String.valueOf(result.getLastLocation().getLatitude()),
+          String.valueOf(result.getLastLocation().getLongitude())),
                 Toast.LENGTH_SHORT).show();
 
         // Pass the new location to the Maps SDK's LocationComponent
@@ -188,7 +187,7 @@ public class LocationChangeListeningActivity extends AppCompatActivity implement
     }
 
     /**
-     * The LocationEngineCallback interface's method which fires when the device's location can not be captured
+     * The LocationEngineCallback interface's method which fires when the device's location can't be captured
      *
      * @param exception the exception message
      */

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationChangeListeningActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationChangeListeningActivity.java
@@ -1,0 +1,251 @@
+package com.mapbox.mapboxandroiddemo.examples.location;
+
+import com.mapbox.mapboxandroiddemo.R;
+import android.annotation.SuppressLint;
+import android.location.Location;
+import android.util.Log;
+import android.widget.Toast;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+// Classes needed to initialize the map
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+// Classes needed to handle location permissions
+import com.mapbox.android.core.permissions.PermissionsListener;
+import com.mapbox.android.core.permissions.PermissionsManager;
+import java.util.List;
+// Classes needed to add the location engine
+import com.mapbox.android.core.location.LocationEngine;
+import com.mapbox.android.core.location.LocationEngineCallback;
+import com.mapbox.android.core.location.LocationEngineProvider;
+import com.mapbox.android.core.location.LocationEngineRequest;
+import com.mapbox.android.core.location.LocationEngineResult;
+import java.lang.ref.WeakReference;
+// Classes needed to add the location component
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
+
+/**
+ * Use the Mapbox Core Library to listen to device location updates
+ */
+public class LocationChangeListeningActivity extends AppCompatActivity implements
+        OnMapReadyCallback, PermissionsListener {
+  // Variables needed to initialize a map
+  private MapboxMap mapboxMap;
+  private MapView mapView;
+  // Variables needed to handle location permissions
+  private PermissionsManager permissionsManager;
+  // Variables needed to add the location engine
+  private LocationEngine locationEngine;
+  private long DEFAULT_INTERVAL_IN_MILLISECONDS = 1000L;
+  private long DEFAULT_MAX_WAIT_TIME = DEFAULT_INTERVAL_IN_MILLISECONDS * 5;
+  // Variables needed to listen to location updates
+  private LocationChangeListeningActivityLocationCallback callback = new LocationChangeListeningActivityLocationCallback(this);
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_location_change_listening);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+    this.mapboxMap = mapboxMap;
+
+    mapboxMap.setStyle(Style.TRAFFIC_NIGHT,
+            new Style.OnStyleLoaded() {
+              @Override
+              public void onStyleLoaded(@NonNull Style style) {
+                enableLocationComponent(style);
+              }
+            });
+  }
+
+  /**
+   * Initialize the Maps SDK's LocationComponent
+   */
+  @SuppressWarnings( {"MissingPermission"})
+  private void enableLocationComponent(@NonNull Style loadedMapStyle) {
+    // Check if permissions are enabled and if not request
+    if (PermissionsManager.areLocationPermissionsGranted(this)) {
+
+      // Get an instance of the component
+      LocationComponent locationComponent = mapboxMap.getLocationComponent();
+
+      // Set the LocationComponent activation options
+      LocationComponentActivationOptions locationComponentActivationOptions =
+              LocationComponentActivationOptions.builder(this, loadedMapStyle)
+                      .useDefaultLocationEngine(false)
+                      .build();
+
+      // Activate with the LocationComponentActivationOptions object
+      locationComponent.activateLocationComponent(locationComponentActivationOptions);
+
+      // Enable to make component visible
+      locationComponent.setLocationComponentEnabled(true);
+
+      // Set the component's camera mode
+      locationComponent.setCameraMode(CameraMode.TRACKING);
+
+      // Set the component's render mode
+      locationComponent.setRenderMode(RenderMode.COMPASS);
+
+      initLocationEngine();
+    } else {
+      permissionsManager = new PermissionsManager(this);
+      permissionsManager.requestLocationPermissions(this);
+    }
+  }
+
+  /**
+   * Set up the LocationEngine and the parameters for querying the device's location
+   */
+  @SuppressLint("MissingPermission")
+  private void initLocationEngine() {
+    locationEngine = LocationEngineProvider.getBestLocationEngine(this);
+
+    LocationEngineRequest request = new LocationEngineRequest.Builder(DEFAULT_INTERVAL_IN_MILLISECONDS)
+            .setPriority(LocationEngineRequest.PRIORITY_HIGH_ACCURACY)
+            .setMaxWaitTime(DEFAULT_MAX_WAIT_TIME).build();
+
+    locationEngine.requestLocationUpdates(request, callback, getMainLooper());
+    locationEngine.getLastLocation(callback);
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
+  }
+
+  @Override
+  public void onExplanationNeeded(List<String> permissionsToExplain) {
+    Toast.makeText(this, R.string.user_location_permission_explanation, Toast.LENGTH_LONG).show();
+  }
+
+  @Override
+  public void onPermissionResult(boolean granted) {
+    if (granted) {
+      if (mapboxMap.getStyle() != null) {
+        enableLocationComponent(mapboxMap.getStyle());
+      }
+    } else {
+      Toast.makeText(this, R.string.user_location_permission_not_granted, Toast.LENGTH_LONG).show();
+      finish();
+    }
+  }
+
+  private static class LocationChangeListeningActivityLocationCallback
+          implements LocationEngineCallback<LocationEngineResult> {
+
+    private final WeakReference<LocationChangeListeningActivity> activityWeakReference;
+
+    LocationChangeListeningActivityLocationCallback(LocationChangeListeningActivity activity) {
+      this.activityWeakReference = new WeakReference<>(activity);
+    }
+
+    /**
+     * The LocationEngineCallback interface's method which fires when the device's location has changed.
+     *
+     * @param result the LocationEngineResult object which has the last known location within it.
+     */
+    @Override
+    public void onSuccess(LocationEngineResult result) {
+      LocationChangeListeningActivity activity = activityWeakReference.get();
+
+      if (activity != null) {
+        Location location = result.getLastLocation();
+
+        if (location == null) {
+          return;
+        }
+
+        // Create a Toast which displays the new location's coordinates
+        Toast.makeText(activity, String.format(activity.getString(R.string.new_location),
+                String.valueOf(result.getLastLocation().getLatitude()), String.valueOf(result.getLastLocation().getLongitude())),
+                Toast.LENGTH_SHORT).show();
+
+        // Pass the new location to the Maps SDK's LocationComponent
+        if (activity.mapboxMap != null && result.getLastLocation() != null) {
+          activity.mapboxMap.getLocationComponent().forceLocationUpdate(result.getLastLocation());
+        }
+      }
+    }
+
+    /**
+     * The LocationEngineCallback interface's method which fires when the device's location can not be captured
+     *
+     * @param exception the exception message
+     */
+    @Override
+    public void onFailure(@NonNull Exception exception) {
+      Log.d("LocationChangeActivity", exception.getLocalizedMessage());
+      LocationChangeListeningActivity activity = activityWeakReference.get();
+      if (activity != null) {
+        Toast.makeText(activity, exception.getLocalizedMessage(),
+                Toast.LENGTH_SHORT).show();
+      }
+    }
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // Prevent leaks
+    if (locationEngine != null) {
+      locationEngine.removeLocationUpdates(callback);
+    }
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/RuntimeStylingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/RuntimeStylingActivity.java
@@ -1,0 +1,109 @@
+package com.mapbox.mapboxandroiddemo.examples.styles;
+
+import com.mapbox.mapboxandroiddemo.R;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.FloatingActionButton;
+import android.support.v7.app.AppCompatActivity;
+
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.Layer;
+
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+
+import android.graphics.Color;
+import android.view.View;
+
+public class RuntimeStylingActivity extends AppCompatActivity  {
+
+  private MapView mapView;
+  private FloatingActionButton changeMapPropertiesFab;
+  private Layer waterLayer;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    Mapbox.getInstance(this, getString(R.string.access_token));
+    setContentView(R.layout.activity_styles_runtime_styling);
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    changeMapPropertiesFab = findViewById(R.id.floatingActionButton);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+        mapboxMap.setStyle(Style.MAPBOX_STREETS, new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull final Style style) {
+            waterLayer = style.getLayer("water");
+            changeMapPropertiesFab.setOnClickListener(new View.OnClickListener() {
+              @Override
+              public void onClick(View v) {
+                if (waterLayer != null) {
+                  waterLayer.setProperties(PropertyFactory.fillColor(Color.parseColor("#023689"))
+                  );
+                }
+                for (Layer singleMapLayer : style.getLayers()) {
+                  if (singleMapLayer.getId().contains("water-") && !singleMapLayer.getId().equals("water-shadow")) {
+                    singleMapLayer.setProperties(
+                            PropertyFactory.textHaloBlur(10f),
+                            PropertyFactory.textSize(25f),
+                            PropertyFactory.textColor(Color.parseColor("#00FF08")),
+                            PropertyFactory.textOpacity(1f)
+                    );
+                  }
+                }
+              }
+            });
+          }
+        });
+      }
+    });
+  }
+
+  // Add the mapView's own lifecycle methods to the activity's lifecycle methods
+  @Override
+  public void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/RuntimeStylingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/RuntimeStylingActivity.java
@@ -1,27 +1,26 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
-import com.mapbox.mapboxandroiddemo.R;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
+import android.view.View;
 
+import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.Layer;
-
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 
-import android.graphics.Color;
-import android.view.View;
-
+/**
+ * Change various properties of a map based on user interaction and other runtime situations.
+ */
 public class RuntimeStylingActivity extends AppCompatActivity  {
 
   private MapView mapView;
-  private FloatingActionButton changeMapPropertiesFab;
   private Layer waterLayer;
 
   @Override
@@ -31,7 +30,6 @@ public class RuntimeStylingActivity extends AppCompatActivity  {
     setContentView(R.layout.activity_styles_runtime_styling);
     mapView = findViewById(R.id.mapView);
     mapView.onCreate(savedInstanceState);
-    changeMapPropertiesFab = findViewById(R.id.floatingActionButton);
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
       public void onMapReady(@NonNull final MapboxMap mapboxMap) {
@@ -39,9 +37,9 @@ public class RuntimeStylingActivity extends AppCompatActivity  {
           @Override
           public void onStyleLoaded(@NonNull final Style style) {
             waterLayer = style.getLayer("water");
-            changeMapPropertiesFab.setOnClickListener(new View.OnClickListener() {
+            findViewById(R.id.floatingActionButton).setOnClickListener(new View.OnClickListener() {
               @Override
-              public void onClick(View v) {
+              public void onClick(View view) {
                 if (waterLayer != null) {
                   waterLayer.setProperties(PropertyFactory.fillColor(Color.parseColor("#023689"))
                   );

--- a/MapboxAndroidDemo/src/main/res/layout/activity_circle_radius_activity.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_circle_radius_activity.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.mapbox.mapboxandroiddemo.examples.dds.CircleRadiusActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="parent"
+        mapbox:mapbox_cameraTargetLat="38.9098"
+        mapbox:mapbox_cameraTargetLng="-77.0295"
+        mapbox:mapbox_cameraZoom="15" />
+
+</android.support.constraint.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_location_change_listening.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_location_change_listening.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="parent"
+        mapbox:mapbox_cameraTargetLat="36.16266"
+        mapbox:mapbox_cameraTargetLng="-86.78160"
+        mapbox:mapbox_cameraZoom="12" />
+
+</android.support.constraint.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_styles_runtime_styling.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_styles_runtime_styling.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.mapbox.mapboxandroiddemo.examples.styles.RuntimeStylingActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/runtime_mapview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="19.948045"
+        mapbox:mapbox_cameraTargetLng="-84.654463"
+        mapbox:mapbox_cameraZoom="3.371717" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/floatingActionButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_styles_runtime_styling.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_styles_runtime_styling.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:mapbox="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -8,7 +9,7 @@
     tools:context="com.mapbox.mapboxandroiddemo.examples.styles.RuntimeStylingActivity">
 
     <com.mapbox.mapboxsdk.maps.MapView
-        android:id="@+id/runtime_mapview"
+        android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         mapbox:mapbox_cameraTargetLat="19.948045"
@@ -19,6 +20,7 @@
         android:id="@+id/floatingActionButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        app:srcCompat="@drawable/ic_swap_horiz_white_24dp"
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
         android:layout_marginBottom="16dp"

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -42,6 +42,11 @@
     <!--Location Component on Fragment below textview in test activity-->
     <string name="location_component_fragment_text">User\'s current location on a map fragment</string>
 
+    <!-- Location change listening -->
+    <string name="title_location_tracking">Location tracking</string>
+    <string name="description_location_tracking">Use the Mapbox Core Library to receive device location updates</string>
+    <string name="new_location">New lat: %1$s New longitude: %2$s</string>
+
     <!-- Settings dialog -->
     <string name="settings_dialog_title">Settings</string>
     <string name="settings_dialog_positive_button_text">Save</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -57,7 +57,7 @@
     <string name="activity_dds_expression_integration_description">Use multiple expressions to convert and visualize data.</string>
     <string name="activity_dds_satellite_land_select_description">View satellite photos and click to outline an area of land.</string>
     <string name="activity_dds_symbol_zoom_switch_description">Change SymbolLayer icons based on the camera\'s zoom level.</string>
-    <string name="activity_dds_circle_radius_description">Set the circle radius of features in a circle layer based on a data property.</string>
+    <string name="activity_dds_circle_radius_description">Set the radii of a circle layer\'s circles based on a data property.</string>
     <string name="activity_annotation_marker_description">Create a default marker with an InfoWindow.</string>
     <string name="activity_dds_geojson_line_description">Draw a polyline by parsing a GeoJSON file with the Mapbox Maps SDK.</string>
     <string name="activity_dds_polygon_select_toggle_description">Tap on various polygons to "select" them and toggle their colors.</string>
@@ -106,7 +106,7 @@
     <string name="activity_location_user_location_map_frag_plugin_description">Use the LocationComponent to display a user\'s location on a map fragment.</string>
     <string name="activity_location_location_component_options_description">Use LocationComponent options to customize the user location information.</string>
     <string name="activity_location_location_component_camera_options_description">Use LocationComponent camera options to customize map camera behavior.</string>
-    <string name="activity_location_location_change_listening_description">Display a Mapbox map on an Android device and receive updates on the current device location.</string>
+    <string name="activity_location_location_change_listening_description">Receive updates when the device changes location.</string>
     <string name="activity_image_generator_snapshot_share_description">Send and share a map snapshot image.</string>
     <string name="activity_image_generator_snapshot_notification_description">Show a snapshotted image in a notification.</string>
     <string name="activity_lab_animated_marker_description">Animate the marker to a new position on the map.</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -56,6 +56,7 @@
     <string name="activity_dds_expression_integration_description">Use multiple expressions to convert and visualize data.</string>
     <string name="activity_dds_satellite_land_select_description">View satellite photos and click to outline an area of land.</string>
     <string name="activity_dds_symbol_zoom_switch_description">Change SymbolLayer icons based on the camera\'s zoom level.</string>
+    <string name="activity_dds_circle_radius_description">Set the circle radius of features in a circle layer based on a data property.</string>
     <string name="activity_annotation_marker_description">Create a default marker with an InfoWindow.</string>
     <string name="activity_dds_geojson_line_description">Draw a polyline by parsing a GeoJSON file with the Mapbox Maps SDK.</string>
     <string name="activity_dds_polygon_select_toggle_description">Tap on various polygons to "select" them and toggle their colors.</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -37,6 +37,7 @@
     <string name="activity_styles_rotating_anchor_text_description">Adjust the anchor position of SymbolLayer text fields.</string>
     <string name="activity_styles_missing_icon_description">Provide an icon when a Style failed to load one.</string>
     <string name="activity_styles_variable_label_placement_description">To increase the chance of high-priority labels staying visible, provide the map renderer a list of preferred text anchor positions.</string>
+    <string name="activity_styles_runtime_styling_description">Change various properties of a map based on user interaction and other runtime situations.</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_description">Use data-driven styling and GeoJSON data to set extrusions\' heights.</string>
     <string name="activity_extrusions_population_density_extrusions_description">Use extrusions to display 3D building height based on imported vector data.</string>
     <string name="activity_extrusions_adjust_extrusions_description">Change the location and color of the light shined on extrusions.</string>
@@ -105,6 +106,7 @@
     <string name="activity_location_user_location_map_frag_plugin_description">Use the LocationComponent to display a user\'s location on a map fragment.</string>
     <string name="activity_location_location_component_options_description">Use LocationComponent options to customize the user location information.</string>
     <string name="activity_location_location_component_camera_options_description">Use LocationComponent camera options to customize map camera behavior.</string>
+    <string name="activity_location_location_change_listening_description">Display a Mapbox map on an Android device and receive updates on the current device location.</string>
     <string name="activity_image_generator_snapshot_share_description">Send and share a map snapshot image.</string>
     <string name="activity_image_generator_snapshot_notification_description">Show a snapshotted image in a notification.</string>
     <string name="activity_lab_animated_marker_description">Animate the marker to a new position on the map.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -34,7 +34,7 @@
     <string name="activity_styles_rotating_anchor_text_title">Text anchor position</string>
     <string name="activity_styles_missing_icon_title">Style with missing icon</string>
     <string name="activity_styles_variable_label_placement_title">Variable label placement</string>
-    <string name="activity_styles_runtime_styling_title">Style features at runtime</string>
+    <string name="activity_styles_runtime_styling_title">Button interaction styling</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_title">Use GeoJSON data to set extrusion height</string>
     <string name="activity_extrusions_population_density_extrusions_title">Display 3D building height based on vector data</string>
     <string name="activity_extrusions_adjust_extrusions_title">Adjust light location and color</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -34,6 +34,7 @@
     <string name="activity_styles_rotating_anchor_text_title">Text anchor position</string>
     <string name="activity_styles_missing_icon_title">Style with missing icon</string>
     <string name="activity_styles_variable_label_placement_title">Variable label placement</string>
+    <string name="activity_styles_runtime_styling_title">Style features at runtime</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_title">Use GeoJSON data to set extrusion height</string>
     <string name="activity_extrusions_population_density_extrusions_title">Display 3D building height based on vector data</string>
     <string name="activity_extrusions_adjust_extrusions_title">Adjust light location and color</string>
@@ -103,6 +104,7 @@
     <string name="activity_location_location_component_title">Show a user\'s location</string>
     <string name="activity_location_location_component_camera_options_title">Location camera options</string>
     <string name="activity_location_location_component_options_title">Customized location icon</string>
+    <string name="activity_location_location_change_listening_title">Track device location</string>
     <string name="activity_image_generator_snapshot_notification_title">Snapshot Notification</string>
     <string name="activity_image_generator_snapshot_share_title">Share snapshot image</string>
     <string name="activity_lab_animated_marker_title">Animate marker position</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -48,6 +48,7 @@
     <string name="activity_dds_multiple_geometries_title">Draw multiple geometries</string>
     <string name="activity_dds_heatmap_title">Show heatmap data</string>
     <string name="activity_dds_multiple_heatmap_styling_title">Styling heatmaps</string>
+    <string name="activity_dds_circle_radius_title">Circle radius</string>
     <string name="activity_lab_space_station_location_title">Space station current location</string>
     <string name="activity_dds_bathymetry_title">Display water depth</string>
     <string name="activity_dds_info_window_symbol_layer_title">Symbol layer info window</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -36,6 +36,7 @@
     <string name="activity_styles_rotating_anchor_text_url" translatable="false">https://i.imgur.com/w8cP6Wn.png</string>
     <string name="activity_styles_missing_icon_url" translatable="false">https://i.imgur.com/lSk2tDB.png</string>
     <string name="activity_styles_variable_label_placement_url" translatable="false">https://i.imgur.com/vLgFvlZ.jpg</string>
+    <string name="activity_styles_runtime_styling_url" translatable="false">https://i.imgur.com/1l6YUFG.png</string>
     <string name="activity_extrusions_population_density_extrusions_url" translatable="false">http://i.imgur.com/se1z8Wb.png</string>
     <string name="activity_extrusions_catalina_marathon_extrusions_url" translatable="false">http://i.imgur.com/6j848JL.jpg</string>
     <string name="activity_extrusions_adjust_extrusions_url" translatable="false">http://i.imgur.com/XNTyIO5.png</string>
@@ -104,6 +105,7 @@
     <string name="activity_location_user_location_fragment_plugin_url" translatable="false">https://i.imgur.com/1jG8WQG.png</string>
     <string name="activity_location_location_component_options_url" translatable="false">https://i.imgur.com/4HiEJC1.png</string>
     <string name="activity_location_location_component_camera_options_url" translatable="false">https://i.imgur.com/Q2cB3NY.png</string>
+    <string name="activity_location_location_change_listening_url" translatable="false">https://i.imgur.com/ReiY5jj.png</string>
     <string name="activity_image_generator_snapshot_notification_url" translatable="false">https://i.imgur.com/OiveDFG.png</string>
     <string name="activity_image_generator_snapshot_share_url" translatable="false">https://i.imgur.com/KgfsY3s.png</string>
     <string name="activity_lab_animated_marker_url" translatable="false">http://i.imgur.com/XegvIKr.png</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -61,6 +61,7 @@
     <string name="activity_dds_polygon_holes_url" translatable="false">https://i.imgur.com/6hcqbNw.png</string>
     <string name="activity_dds_symbol_collision_detection_url" translatable="false">https://i.imgur.com/nV1YnIv.png</string>
     <string name="activity_dds_polygon_revealed_hole_outline_url" translatable="false">http://i.imgur.com/19GZh8H.jpg</string>
+    <string name="activity_dds_circle_radius_url" translatable="false">https://i.imgur.com/MrablT6.png</string>
     <string name="activity_styles_text_field_formatting_url" translatable="false">https://i.imgur.com/MSoIYmU.png</string>
     <string name="activity_annotation_basic_marker_view_url" translatable="false">http://i.imgur.com/vbWTLIE.png</string>
     <string name="activity_annotation_custom_info_window_url" translatable="false">http://i.imgur.com/mCWbosy.png</string>


### PR DESCRIPTION
Adds the demos needed for the following [tutorials](https://docs.mapbox.com/help/tutorials/#mobile-apps):

- [Tracking device location for Android](https://docs.mapbox.com/help/tutorials/android-location-listening/) as `LocationChangeListeningActivity`
- [Data-driven styling for Android](https://docs.mapbox.com/help/tutorials/android-dds-circle-layer/) as `CircleRadiusActivity`
- [Runtime styling for Android](https://docs.mapbox.com/help/tutorials/android-runtime-styling-intro/) as `RuntimeStylingActivity `

Note: @langsmith the _Runtime styling for Android_ demo is not working -- it crashes when trying to open from the demo app. Can you take a look at what might be happening there? Also, changes to titles and descriptions are very welcome! 