### PR TITLE
update Android Maps SDK to 8.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
 
             // Mapbox
             mapboxMapPrefix          : 'v8',
-            mapboxMapSdk             : '8.1.0',
+            mapboxMapSdk             : '8.2.0',
             mapboxTurf               : '4.8.0',
             mapboxServices           : '4.8.0',
             mapboxPluginBuilding     : '0.6.0',


### PR DESCRIPTION
This PR updates the Mapbox Maps SDK dependency to 8.2.0