### PR TITLE
Fix NPE in MarkerFollowingRouteActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MarkerFollowingRouteActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MarkerFollowingRouteActivity.java
@@ -128,7 +128,8 @@ public class MarkerFollowingRouteActivity extends AppCompatActivity {
           }
           if (latLngEvaluator != null) {
             markerIconAnimator = ObjectAnimator
-              .ofObject(latLngEvaluator, count == 0 ? new LatLng(37.61501, -122.385374)
+              .ofObject(latLngEvaluator, count == 0 || markerIconCurrentLocation == null
+                  ? new LatLng(37.61501, -122.385374)
                   : markerIconCurrentLocation,
                 new LatLng(nextLocation.latitude(), nextLocation.longitude()))
               .setDuration(300);


### PR DESCRIPTION
Run monkey test in Ali cloud test platform and find the following error, this PR fix this crash.
```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
	at android.animation.PropertyValuesHolder.setObjectValues(PropertyValuesHolder.java:663)
	at android.animation.PropertyValuesHolder.ofObject(PropertyValuesHolder.java:406)
	at android.animation.ValueAnimator.setObjectValues(ValueAnimator.java:506)
	at android.animation.ValueAnimator.ofObject(ValueAnimator.java:417)
	at com.mapbox.mapboxandroiddemo.examples.labs.MarkerFollowingRouteActivity$2.run(MarkerFollowingRouteActivity.java:132)
	at android.os.Handler.handleCallback(Handler.java:873)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:201)
	at android.app.ActivityThread.main(ActivityThread.java:6806)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:547)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:873)
```