### PR TITLE
Adding kotlin lint plugin and needed tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 checkstyle:
-	./gradlew checkstyle
+	./gradlew checkstyle && ./gradlew lintKotlin
 
 graph:
 	./gradlew generateDependencyGraphMapboxLibraries
 
 sanity-test-example-activities:
 	node scripts/generate-test-code.js
+
+kotlin-lint:
+	./gradlew lintKotlin

--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.github.triplet.play'
 apply plugin: 'io.fabric'
+apply plugin: 'org.jmailen.kotlinter'
 apply from: "$project.rootDir/gradle/script-git-version.gradle"
 apply from: "$project.rootDir/gradle/gradle-dependencies-graph.gradle"
 
@@ -101,6 +102,10 @@ android {
         track = 'alpha'
         untrackOld = true
     }
+}
+
+kotlinter {
+    indentSize = 2
 }
 
 if (isGlobal) {

--- a/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -31,8 +31,8 @@ import com.mapbox.mapboxandroiddemo.commons.AnalyticsTracker;
 import com.mapbox.mapboxandroiddemo.commons.FirstTimeRunChecker;
 import com.mapbox.mapboxandroiddemo.examples.SimpleChinaMapViewActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.AnimatedMarkerActivity;
+import com.mapbox.mapboxandroiddemo.examples.basics.KotlinSimpleMapViewActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.DrawPolygonActivity;
-import com.mapbox.mapboxandroiddemo.examples.basics.SimpleMapViewActivityKotlin;
 import com.mapbox.mapboxandroiddemo.examples.camera.AnimateMapCameraActivity;
 import com.mapbox.mapboxandroiddemo.examples.camera.BoundingBoxCameraActivity;
 import com.mapbox.mapboxandroiddemo.examples.camera.RestrictCameraActivity;
@@ -708,7 +708,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       R.id.nav_basics,
       R.string.activity_basic_mapbox_kotlin_title,
       R.string.activity_basic_mapbox_kotlin_description,
-      new Intent(MainActivity.this, SimpleMapViewActivityKotlin.class),
+      new Intent(MainActivity.this, KotlinSimpleMapViewActivity.class),
       null,
       R.string.activity_basic_simple_mapview_url, true, BuildConfig.MIN_SDK_VERSION));
   }

--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -6,15 +6,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import androidx.annotation.NonNull;
-import com.google.android.material.navigation.NavigationView;
-import androidx.core.view.GravityCompat;
-import androidx.drawerlayout.widget.DrawerLayout;
-import androidx.appcompat.app.ActionBarDrawerToggle;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -26,14 +17,15 @@ import android.widget.TextView;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.github.javiersantos.materialstyleddialogs.MaterialStyledDialog;
+import com.google.android.material.navigation.NavigationView;
 import com.google.firebase.perf.metrics.AddTrace;
 import com.mapbox.mapboxandroiddemo.account.LandingActivity;
 import com.mapbox.mapboxandroiddemo.adapter.ExampleAdapter;
 import com.mapbox.mapboxandroiddemo.commons.AnalyticsTracker;
 import com.mapbox.mapboxandroiddemo.commons.FirstTimeRunChecker;
+import com.mapbox.mapboxandroiddemo.examples.basics.KotlinSimpleMapViewActivity;
 import com.mapbox.mapboxandroiddemo.examples.basics.MapboxMapOptionActivity;
 import com.mapbox.mapboxandroiddemo.examples.basics.SimpleMapViewActivity;
-import com.mapbox.mapboxandroiddemo.examples.basics.SimpleMapViewActivityKotlin;
 import com.mapbox.mapboxandroiddemo.examples.basics.SupportMapFragmentActivity;
 import com.mapbox.mapboxandroiddemo.examples.camera.AnimateMapCameraActivity;
 import com.mapbox.mapboxandroiddemo.examples.camera.BoundingBoxCameraActivity;
@@ -159,6 +151,14 @@ import com.mapbox.mapboxandroiddemo.utils.SettingsDialogView;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBarDrawerToggle;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxandroiddemo.commons.AnalyticsTracker.CLICKED_ON_INFO_DIALOG_NOT_NOW;
@@ -1398,7 +1398,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       R.string.activity_basic_simple_mapview_title,
       R.string.activity_basic_simple_mapview_description,
       new Intent(MainActivity.this, SimpleMapViewActivity.class),
-      new Intent(MainActivity.this, SimpleMapViewActivityKotlin.class),
+      new Intent(MainActivity.this, KotlinSimpleMapViewActivity.class),
       R.string.activity_basic_simple_mapview_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -54,7 +54,7 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
-            android:name=".examples.basics.SimpleMapViewActivityKotlin"
+            android:name=".examples.basics.MapViewActivityKotlin"
             android:label="@string/activity_basic_mapbox_kotlin_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/KotlinSimpleMapViewActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/KotlinSimpleMapViewActivity.kt
@@ -10,7 +10,7 @@ import kotlinx.android.synthetic.main.activity_basic_simple_kotlin.*
 /**
  * The most basic example of adding a map to an activity with Kotlin code
  */
-class SimpleMapViewActivityKotlin : AppCompatActivity() {
+class KotlinSimpleMapViewActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,7 +26,6 @@ class SimpleMapViewActivityKotlin : AppCompatActivity() {
             mapboxMap.setStyle(Style.MAPBOX_STREETS) {
 
                 // Map is set up and the style has loaded. Now you can add data or make other map adjustments.
-
             }
         }
     }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/KotlinStyleCirclesCategoricallyActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/KotlinStyleCirclesCategoricallyActivity.kt
@@ -30,7 +30,7 @@ class KotlinStyleCirclesCategoricallyActivity : AppCompatActivity() {
         mapView.onCreate(savedInstanceState)
         mapView.getMapAsync { mapboxMap ->
 
-            mapboxMap.setStyle(Style.LIGHT){
+            mapboxMap.setStyle(Style.LIGHT) {
                 val vectorSource = VectorSource(
                         "ethnicity-source",
                         "http://api.mapbox.com/v4/examples.8fgz4egr.json?access_token=" + Mapbox.getAccessToken()!!

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/PolygonSelectToggleActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/PolygonSelectToggleActivity.kt
@@ -1,6 +1,5 @@
 package com.mapbox.mapboxandroiddemo.examples.dds
 
-
 import android.content.Context
 import android.graphics.Color
 import android.graphics.PointF
@@ -84,7 +83,7 @@ class PolygonSelectToggleActivity : AppCompatActivity(), MapboxMap.OnMapClickLis
         // Create a GeoJsonSource and add it to the map.
         geoJsonSource = GeoJsonSource(NEIGHBORHOOD_POLYGON_SOURCE_ID, featureCollection)
 
-        mapboxMap.getStyle {style ->
+        mapboxMap.getStyle { style ->
             style.addSource(geoJsonSource!!)
 
             // Create a FillLayer which will show a background of all neighborhoods on the map.

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MagicWindowKotlinActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/MagicWindowKotlinActivity.kt
@@ -99,7 +99,7 @@ class MagicWindowKotlinActivity : AppCompatActivity(), LocationEngineCallback<Lo
     }
 
     fun checkLocationPermissionsAndInitialize() {
-        val allowed = ContextCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+        val allowed = ContextCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
         if (allowed) {
             initializeLocationEngine()
         } else {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/KotlinLocationComponentActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/KotlinLocationComponentActivity.kt
@@ -1,7 +1,6 @@
 package com.mapbox.mapboxandroiddemo.examples.location
 
 import android.annotation.SuppressLint
-import android.graphics.Color
 import android.os.Bundle
 import androidx.core.content.ContextCompat
 import androidx.appcompat.app.AppCompatActivity
@@ -81,7 +80,6 @@ class KotlinLocationComponentActivity : AppCompatActivity(), OnMapReadyCallback,
         // Set the LocationComponent's render mode
         renderMode = RenderMode.COMPASS
       }
-
     } else {
       permissionsManager = PermissionsManager(this)
       permissionsManager.requestLocationPermissions(this)

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/model/ExampleItemModel.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/model/ExampleItemModel.kt
@@ -3,6 +3,13 @@ package com.mapbox.mapboxandroiddemo.model
 import android.content.Intent
 
 // Just a model for the detailed item recycler
-class ExampleItemModel(val categoryId: Int, val title: Int, val description: Int, val javaActivity: Intent?,
-                       val kotlinActivity: Intent?, val imageUrl: Int, val showNewIcon: Boolean,
-                       val minSdkVersion: Int)
+class ExampleItemModel(
+  val categoryId: Int,
+  val title: Int,
+  val description: Int,
+  val javaActivity: Intent?,
+  val kotlinActivity: Intent?,
+  val imageUrl: Int,
+  val showNewIcon: Boolean,
+  val minSdkVersion: Int
+)

--- a/MapboxAndroidDemo/src/main/res/layout/activity_basic_simple_kotlin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_basic_simple_kotlin.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".examples.basics.SimpleMapViewActivityKotlin">
+    tools:context=".examples.basics.MapViewActivityKotlin">
 
     <!-- Set the starting camera position and map style using xml-->
     <com.mapbox.mapboxsdk.maps.MapView

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         google()
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
+        maven { url 'https://plugins.gradle.org/m2/' }
     }
 
     dependencies {
@@ -17,6 +18,7 @@ buildscript {
         classpath pluginDependencies.kotlin
         classpath pluginDependencies.fabric
         classpath pluginDependencies.googleServices
+        classpath pluginDependencies.kotlinLint
     }
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,6 +70,7 @@ ext {
             grgit               : '2.3.0',
             fabric              : '1.29.0',
             googleServices      : '4.2.0',
+            kotlinLint          : '1.26.0',
     ]
 
     dependenciesList = [
@@ -142,6 +143,7 @@ ext {
             grgit               : "org.ajoberstar:grgit:${pluginVersion.grgit}",
             fabric              : "io.fabric.tools:gradle:${pluginVersion.fabric}",
             googleServices      : "com.google.gms:google-services:${pluginVersion.googleServices}",
+            kotlinLint          : "org.jmailen.gradle:kotlinter-gradle:${pluginVersion.kotlinLint}"
     ]
 
     wearDependencies = [


### PR DESCRIPTION
Inspired by @tobrun's addition of Kotlin lint checks in https://github.com/mapbox/mapbox-gl-native/pull/15052, this pr adds https://github.com/jeremymailen/kotlinter-gradle to create Kotlin lint checks of this repo's test app.  https://github.com/JLLeitschuh/ktlint-gradle, the other recommended plugin, wasn't working with this app for some reason. This pr also adds a separate `make kotlin-lint` command. The Kotlin lint check is also now a part of the already existing `make checkstyle` command. 

Kotlin lint checking was also added to the plugin test app: https://github.com/mapbox/mapbox-plugins-android/pull/1012

 
