### PR TITLE
Add gradlew.properties file to fix compile error.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
Currently we are using AndroidX in android demo, so it will cause case error for fragment etc.
According https://developer.android.com/jetpack/androidx/migrate, add gradlew.properties file to fix it.