### PR TITLE
Refactor QueryFeatureActivity to use SymbolLayer instead of MarkerViewOptions

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/QueryFeatureActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/QueryFeatureActivity.java
@@ -1,34 +1,59 @@
 package com.mapbox.mapboxandroiddemo.examples.query;
 
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.PointF;
+import android.os.AsyncTask;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.google.gson.JsonElement;
 import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
-import com.mapbox.mapboxsdk.annotations.Marker;
-import com.mapbox.mapboxsdk.annotations.MarkerOptions;
+import com.mapbox.mapboxsdk.annotations.BubbleLayout;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import static com.mapbox.mapboxsdk.style.layers.Property.ICON_ANCHOR_BOTTOM;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAnchor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
+
 /**
- * Display map property information for a clicked map feature
+ * Display map property information for a clicked map feature.
  */
 public class QueryFeatureActivity extends AppCompatActivity implements OnMapReadyCallback,
   MapboxMap.OnMapClickListener {
 
+  private static final String GEOJSON_SOURCE_ID = "GEOJSON_SOURCE_ID";
+  private static final String MARKER_IMAGE_ID = "MARKER_IMAGE_ID";
+  private static final String CALLOUT_IMAGE_ID = "CALLOUT_IMAGE_ID";
+  private static final String MARKER_LAYER_ID = "MARKER_LAYER_ID";
+  private static final String CALLOUT_LAYER_ID = "CALLOUT_LAYER_ID";
+  private GeoJsonSource source;
   private MapView mapView;
-  private Marker featureMarker;
   private MapboxMap mapboxMap;
 
   @Override
@@ -53,6 +78,7 @@ public class QueryFeatureActivity extends AppCompatActivity implements OnMapRead
     mapboxMap.setStyle(Style.MAPBOX_STREETS, new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {
+        setUpData();
         mapboxMap.addOnMapClickListener(QueryFeatureActivity.this);
         Toast.makeText(QueryFeatureActivity.this,
           getString(R.string.click_on_map_instruction), Toast.LENGTH_SHORT).show();
@@ -60,46 +86,216 @@ public class QueryFeatureActivity extends AppCompatActivity implements OnMapRead
     });
   }
 
-  @Override
-  public boolean onMapClick(@NonNull LatLng point) {
+  /**
+   * Sets up all of the sources and layers needed for this example
+   */
+  public void setUpData() {
+    if (mapboxMap != null) {
+      mapboxMap.getStyle(style -> {
+        setupSource(style);
+        setUpClickLocationIconImage(style);
+        setUpClickLocationMarkerLayer(style);
+        setUpInfoWindowLayer(style);
+      });
+    }
+  }
 
-    final PointF pixel = mapboxMap.getProjection().toScreenLocation(point);
-    List<Feature> features = mapboxMap.queryRenderedFeatures(pixel);
+  /**
+   * Adds the GeoJSON source to the map
+   */
+  private void setupSource(@NonNull Style loadedStyle) {
+    source = new GeoJsonSource(GEOJSON_SOURCE_ID);
+    loadedStyle.addSource(source);
+  }
 
-    if (features.size() > 0) {
+  /**
+   * Adds the marker image to the map for use as a SymbolLayer icon
+   */
+  private void setUpClickLocationIconImage(@NonNull Style loadedStyle) {
+    loadedStyle.addImage(MARKER_IMAGE_ID, BitmapFactory.decodeResource(
+      this.getResources(), R.drawable.red_marker));
+  }
+
+  /**
+   * Needed to show the Feature properties info window.
+   */
+  private void refreshSource(Feature featureAtClickPoint) {
+    if (source != null) {
+      source.setGeoJson(featureAtClickPoint);
+    }
+  }
+
+  /**
+   * Adds a SymbolLayer to the map to show the click location marker icon.
+   */
+  private void setUpClickLocationMarkerLayer(@NonNull Style loadedStyle) {
+    loadedStyle.addLayer(new SymbolLayer(MARKER_LAYER_ID, GEOJSON_SOURCE_ID)
+      .withProperties(
+        iconImage(MARKER_IMAGE_ID),
+        iconAllowOverlap(true),
+        iconIgnorePlacement(true),
+        iconOffset(new Float[] {0f, -8f})
+      ));
+  }
+
+  /**
+   * Adds a SymbolLayer to the map to show the Feature properties info window.
+   */
+  private void setUpInfoWindowLayer(@NonNull Style loadedStyle) {
+    loadedStyle.addLayer(new SymbolLayer(CALLOUT_LAYER_ID, GEOJSON_SOURCE_ID)
+      .withProperties(
+        // show image with id title based on the value of the name feature property
+        iconImage(CALLOUT_IMAGE_ID),
+
+        // set anchor of icon to bottom-left
+        iconAnchor(ICON_ANCHOR_BOTTOM),
+
+        // prevent the feature property window icon from being visible even
+        // if it collides with other previously drawn symbols
+        iconAllowOverlap(false),
+
+        // prevent other symbols from being visible even if they collide with the feature property window icon
+        iconIgnorePlacement(false),
+
+        // offset the info window to be above the marker
+        iconOffset(new Float[] {-2f, -28f})
+      ));
+  }
+
+  /**
+   * This method handles click events for SymbolLayer symbols.
+   *
+   * @param screenPoint the point on screen clicked
+   */
+  private boolean handleClickIcon(PointF screenPoint) {
+    List<Feature> features = mapboxMap.queryRenderedFeatures(screenPoint);
+    if (!features.isEmpty()) {
       Feature feature = features.get(0);
 
-      String property;
-
       StringBuilder stringBuilder = new StringBuilder();
-      if (feature.properties() != null) {
-        for (Map.Entry<String, JsonElement> entry : feature.properties().entrySet()) {
+
+      for (Map.Entry<String, JsonElement> entry : feature.properties().entrySet()) {
+        stringBuilder.append(String.format("%s - %s", entry.getKey(), entry.getValue()));
+        stringBuilder.append(System.getProperty("line.separator"));
+      }
+      new GenerateViewIconTask(QueryFeatureActivity.this).execute(FeatureCollection.fromFeature(feature));
+    } else {
+      Toast.makeText(this, getString(R.string.query_feature_no_properties_found), Toast.LENGTH_SHORT).show();
+    }
+    return true;
+  }
+
+  @Override
+  public boolean onMapClick(@NonNull LatLng point) {
+    return handleClickIcon(mapboxMap.getProjection().toScreenLocation(point));
+  }
+
+  /**
+   * Invoked when the bitmap has been generated from a view.
+   */
+  public void setImageGenResults(HashMap<String, Bitmap> imageMap) {
+    if (mapboxMap != null) {
+      mapboxMap.getStyle(style -> {
+        style.addImages(imageMap);
+      });
+    }
+  }
+
+  /**
+   * AsyncTask to generate Bitmap from Views to be used as iconImage in a SymbolLayer.
+   * <p>
+   * Call be optionally be called to update the underlying data source after execution.
+   * </p>
+   * <p>
+   * Generating Views on background thread since we are not going to be adding them to the view hierarchy.
+   * </p>
+   */
+  private static class GenerateViewIconTask extends AsyncTask<FeatureCollection, Void, HashMap<String, Bitmap>> {
+
+    private final WeakReference<QueryFeatureActivity> activityRef;
+    private Feature featureAtMapClickPoint;
+
+    GenerateViewIconTask(QueryFeatureActivity activity) {
+      this.activityRef = new WeakReference<>(activity);
+    }
+
+    @SuppressWarnings("WrongThread")
+    @Override
+    protected HashMap<String, Bitmap> doInBackground(FeatureCollection... params) {
+      QueryFeatureActivity activity = activityRef.get();
+      HashMap<String, Bitmap> imagesMap = new HashMap<>();
+      if (activity != null) {
+        LayoutInflater inflater = LayoutInflater.from(activity);
+
+        featureAtMapClickPoint = params[0].features().get(0);
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        BubbleLayout bubbleLayout = (BubbleLayout) inflater.inflate(
+          R.layout.activity_query_feature_window_symbol_layer, null);
+
+        TextView titleTextView = bubbleLayout.findViewById(R.id.info_window_title);
+        titleTextView.setText(activity.getString(R.string.query_feature_marker_title));
+
+        for (Map.Entry<String, JsonElement> entry : featureAtMapClickPoint.properties().entrySet()) {
           stringBuilder.append(String.format("%s - %s", entry.getKey(), entry.getValue()));
           stringBuilder.append(System.getProperty("line.separator"));
         }
 
-        featureMarker = mapboxMap.addMarker(new MarkerOptions()
-          .position(point)
-          .title(getString(R.string.query_feature_marker_title))
-          .snippet(stringBuilder.toString())
-        );
+        TextView propertiesListTextView = bubbleLayout.findViewById(R.id.info_window_feature_properties_list);
+        propertiesListTextView.setText(stringBuilder.toString());
 
-      } else {
-        property = getString(R.string.query_feature_marker_snippet);
-        featureMarker = mapboxMap.addMarker(new MarkerOptions()
-          .position(point)
-          .snippet(property)
-        );
+        int measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+        bubbleLayout.measure(measureSpec, measureSpec);
+
+        int measuredWidth = bubbleLayout.getMeasuredWidth();
+
+        bubbleLayout.setArrowPosition(measuredWidth / 2 - 5);
+
+        Bitmap bitmap = QueryFeatureActivity.SymbolGenerator.generate(bubbleLayout);
+        imagesMap.put(CALLOUT_IMAGE_ID, bitmap);
       }
-    } else {
-      featureMarker = mapboxMap.addMarker(new MarkerOptions()
-        .position(point)
-        .snippet(getString(R.string.query_feature_marker_snippet))
-      );
-    }
-    mapboxMap.selectMarker(featureMarker);
 
-    return true;
+      return imagesMap;
+    }
+
+    @Override
+    protected void onPostExecute(HashMap<String, Bitmap> bitmapHashMap) {
+      super.onPostExecute(bitmapHashMap);
+      QueryFeatureActivity activity = activityRef.get();
+      if (activity != null && bitmapHashMap != null) {
+        activity.setImageGenResults(bitmapHashMap);
+        activity.refreshSource(featureAtMapClickPoint);
+      }
+    }
+
+  }
+
+  /**
+   * Utility class to generate Bitmaps for Symbol.
+   */
+  private static class SymbolGenerator {
+
+    /**
+     * Generate a Bitmap from an Android SDK View.
+     *
+     * @param view the View to be drawn to a Bitmap
+     * @return the generated bitmap
+     */
+    static Bitmap generate(@NonNull View view) {
+      int measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+      view.measure(measureSpec, measureSpec);
+
+      int measuredWidth = view.getMeasuredWidth();
+      int measuredHeight = view.getMeasuredHeight();
+
+      view.layout(0, 0, measuredWidth, measuredHeight);
+      Bitmap bitmap = Bitmap.createBitmap(measuredWidth, measuredHeight, Bitmap.Config.ARGB_8888);
+      bitmap.eraseColor(Color.TRANSPARENT);
+      Canvas canvas = new Canvas(bitmap);
+      view.draw(canvas);
+      return bitmap;
+    }
   }
 
   @Override

--- a/MapboxAndroidDemo/src/main/res/layout/activity_query_feature_window_symbol_layer.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_query_feature_window_symbol_layer.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.mapbox.mapboxsdk.annotations.BubbleLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="6dp"
+    android:paddingEnd="8dp"
+    android:paddingLeft="8dp"
+    android:paddingRight="8dp"
+    android:paddingStart="8dp"
+    app:mapbox_bl_arrowDirection="bottom"
+    app:mapbox_bl_arrowHeight="8dp"
+    app:mapbox_bl_arrowWidth="8dp"
+    app:mapbox_bl_arrowPosition="50dp"
+    app:mapbox_bl_bubbleColor="@android:color/white"
+    app:mapbox_bl_cornersRadius="6dp"
+    app:mapbox_bl_strokeColor="@android:color/darker_gray"
+    app:mapbox_bl_strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/info_window_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            tools:text="@string/query_feature_marker_title" />
+
+        <TextView
+            android:id="@+id/info_window_feature_properties_list"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            tools:text="Properties listed here" />
+
+    </LinearLayout>
+</com.mapbox.mapboxsdk.annotations.BubbleLayout>


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1144 by refactoring `QueryFeatureActivity` to use `SymbolLayer` instead of `MarkerViewOptions`.


![ezgif com-resize (11)](https://user-images.githubusercontent.com/4394910/61737380-e699e880-ad3c-11e9-9099-8381aeb930c7.gif)
