### PR TITLE
Adjusted manifest to fix SimpleMapView kotlin example

### DIFF
--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -54,7 +54,7 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
-            android:name=".examples.basics.MapViewActivityKotlin"
+            android:name=".examples.basics.KotlinSimpleMapViewActivity"
             android:label="@string/activity_basic_mapbox_kotlin_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"


### PR DESCRIPTION
App was crashing because the manifest was outdated with the previous name for the basic Kotlin `MapView` activity. Name refactoring happened in https://github.com/mapbox/mapbox-android-demo/pull/1140 .