### PR TITLE
Refactoring GeoJsonSource creation with URL to URI

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleLayerClusteringActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CircleLayerClusteringActivity.java
@@ -2,9 +2,6 @@ package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
-import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Toast;
 
 import com.mapbox.mapboxandroiddemo.R;
@@ -22,9 +19,12 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.all;
@@ -151,15 +151,15 @@ public class CircleLayerClusteringActivity extends AppCompatActivity {
         // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes from
         // 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
         new GeoJsonSource("earthquakes",
-          new URL("https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"),
+          new URI("https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"),
           new GeoJsonOptions()
             .withCluster(true)
             .withClusterMaxZoom(14)
             .withClusterRadius(50)
         )
       );
-    } catch (MalformedURLException malformedUrlException) {
-      Timber.e("Check the URL %s", malformedUrlException.getMessage());
+    } catch (URISyntaxException uriSyntaxException) {
+      Timber.e("Check the URL %s", uriSyntaxException.getMessage());
     }
 
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CreateHotspotsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/CreateHotspotsActivity.java
@@ -2,8 +2,6 @@ package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -16,9 +14,11 @@ import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
@@ -69,15 +69,15 @@ public class CreateHotspotsActivity extends AppCompatActivity {
         // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes from
         // 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
         new GeoJsonSource("earthquakes",
-          new URL("https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"),
+          new URI("https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"),
           new GeoJsonOptions()
             .withCluster(true)
             .withClusterMaxZoom(15) // Max zoom to cluster points on
             .withClusterRadius(20) // Use small cluster radius for the hotspots look
         )
       );
-    } catch (MalformedURLException malformedUrlException) {
-      Timber.e("Check the URL %s", malformedUrlException.getMessage());
+    } catch (URISyntaxException uriSyntaxException) {
+      Timber.e("Check the URL %s", uriSyntaxException.getMessage());
     }
 
     // Use the earthquakes source to create four layers:

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/HeatmapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/HeatmapActivity.java
@@ -1,8 +1,6 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -14,9 +12,11 @@ import com.mapbox.mapboxsdk.style.layers.CircleLayer;
 import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
@@ -79,9 +79,9 @@ public class HeatmapActivity extends AppCompatActivity {
 
   private void addEarthquakeSource(@NonNull Style loadedMapStyle) {
     try {
-      loadedMapStyle.addSource(new GeoJsonSource(EARTHQUAKE_SOURCE_ID, new URL(EARTHQUAKE_SOURCE_URL)));
-    } catch (MalformedURLException malformedUrlException) {
-      Timber.e(malformedUrlException, "That's not an url... ");
+      loadedMapStyle.addSource(new GeoJsonSource(EARTHQUAKE_SOURCE_ID, new URI(EARTHQUAKE_SOURCE_URL)));
+    } catch (URISyntaxException uriSyntaxException) {
+      Timber.e(uriSyntaxException, "That's not an url... ");
     }
   }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ImageClusteringActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/ImageClusteringActivity.java
@@ -2,8 +2,6 @@ package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Toast;
 
 import com.mapbox.mapboxandroiddemo.R;
@@ -18,9 +16,11 @@ import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 import com.mapbox.mapboxsdk.utils.BitmapUtils;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.all;
@@ -90,15 +90,15 @@ public class ImageClusteringActivity extends AppCompatActivity implements OnMapR
         // Point to GeoJSON data. This example visualizes all M1.0+ earthquakes from
         // 12/22/15 to 1/21/16 as logged by USGS' Earthquake hazards program.
         new GeoJsonSource("earthquakes",
-          new URL("https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"),
+          new URI("https://www.mapbox.com/mapbox-gl-js/assets/earthquakes.geojson"),
           new GeoJsonOptions()
             .withCluster(true)
             .withClusterMaxZoom(14)
             .withClusterRadius(50)
         )
       );
-    } catch (MalformedURLException malformedUrlException) {
-      Timber.e("Check the URL %s" , malformedUrlException.getMessage());
+    } catch (URISyntaxException uriSyntaxException) {
+      Timber.e("Check the URL %s" , uriSyntaxException.getMessage());
     }
 
     //Creating a SymbolLayer icon layer for single data/icon points

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/ClickOnLayerActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/ClickOnLayerActivity.java
@@ -3,8 +3,6 @@ package com.mapbox.mapboxandroiddemo.examples.query;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Toast;
 
 import com.mapbox.geojson.Feature;
@@ -18,9 +16,11 @@ import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillOpacity;
@@ -92,7 +92,7 @@ public class ClickOnLayerActivity extends AppCompatActivity implements OnMapRead
   private void addGeoJsonSourceToMap(@NonNull Style loadedMapStyle) {
     try {
       // Add GeoJsonSource to map
-      loadedMapStyle.addSource(new GeoJsonSource(geoJsonSourceId, new URL("https://gist.githubusercontent"
+      loadedMapStyle.addSource(new GeoJsonSource(geoJsonSourceId, new URI("https://gist.githubusercontent"
         + ".com/tobrun/cf0d689c8187d42ebe62757f6d0cf137/raw/4d8ac3c8333f1517df9d303"
         + "d58f20f4a1d8841e8/regions.geojson")));
     } catch (Throwable throwable) {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/GeojsonLayerInStackActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/GeojsonLayerInStackActivity.java
@@ -2,8 +2,6 @@ package com.mapbox.mapboxandroiddemo.examples.styles;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -14,8 +12,11 @@ import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillOpacity;
@@ -48,8 +49,8 @@ public class GeojsonLayerInStackActivity extends AppCompatActivity {
           @Override
           public void onStyleLoaded(@NonNull Style style) {
             try {
-              URL geoJsonUrl = new URL("https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_urban_areas.geojson");
-              GeoJsonSource urbanAreasSource = new GeoJsonSource("urban-areas", geoJsonUrl);
+              GeoJsonSource urbanAreasSource = new GeoJsonSource("urban-areas",
+                new URI("https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_50m_urban_areas.geojson"));
               style.addSource(urbanAreasSource);
 
               FillLayer urbanArea = new FillLayer("urban-areas-fill", "urban-areas");
@@ -60,8 +61,8 @@ public class GeojsonLayerInStackActivity extends AppCompatActivity {
               );
 
               style.addLayerBelow(urbanArea, "water");
-            } catch (MalformedURLException malformedUrlException) {
-              malformedUrlException.printStackTrace();
+            } catch (URISyntaxException uriSyntaxException) {
+              uriSyntaxException.printStackTrace();
             }
           }
         });


### PR DESCRIPTION
URL usage in creating a `GeoJsonSource` was deprecated a little while ago. `URI` is now the default. This pr makes necessary adjustments to swap out `URL` for `URI`. All refactored examples are working as intended on the device when I did QA for this pr. 