### PR TITLE
Release 8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## 8.2.1 - August 7, 2019
+
+* Added example of cache management methods usage #1139
+* Bumped maps sdk to 8.2.1 #1155
+* Scalebar plugin bump to 0.2.0 #1154
+* Bumped Maps SDK to stable 8.2.0 #1129 
+* Refactoring GeoJsonSource creation with URL to URI #1150
+* Refactor QueryFeatureActivity to use SymbolLayer instead of MarkerViewOptions #1148  
+* Adjusted manifest to fix SimpleMapView kotlin example #1149
+* Add gradle.properties file to fix compile error. #1147
+* Define a Circle's Radius with Physical Units #1047 
+* Polygon hole layer below null check #1145
+* Adding kotlin lint plugin and needed tweaks #1140
+* Fix NPE #1130
+* Adding Firebase crashlytics and AndroidX support #1104
+* Add tutorial demos #1127)  
+* Added RecyclerView + Directions route example #1123
+* Refactoring fromUrl() to fromUri() #1120  
+* Adding interactive isochrone + seekbar slider example #1121
+* Removing a duplicate globalImplementation dependenciesList.firebaseCrash line #1115
+* Adjusted strings for trailing line example and dashed directions example ##111
+
 ## 8.1.0 - June 21, 2019
 
 * Adding LocationComponent camera mode example #1038

--- a/MapboxAndroidDemo/src/global/play/en-US/whatsnew
+++ b/MapboxAndroidDemo/src/global/play/en-US/whatsnew
@@ -1,4 +1,9 @@
-This update is in line with the 8.1.0 release of the Mapbox Maps SDK for Android and includes several fixes and new examples:
+This update is in line with the 8.2.1 release of the Mapbox Maps SDK for Android and includes several fixes and new examples:
 
-- LocationComponent camera mode example
-- Drawn line behind moving SymbolLayer icon
+- Isochrone API data + seekbar slider
+- RecyclerView + Directions API route
+- Location change listening
+- Circle radius based on data
+- Runtime styling
+- Define a circle's radius with physical units
+- Cache management


### PR DESCRIPTION
This is the release pr to originally cover the `8.2.0` release of the Maps SDK. `8.2.1` of the Maps SDK went out before the `8.2.0` release of this demo app could go out. That's why `8.1.0 - June 21, 2019` is the previous entry in this demo app's changelog.

References https://github.com/mapbox/mapbox-android-demo/issues/1152