### PR TITLE
Added CircleCI command to create google services json file in Release job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -112,6 +112,13 @@ jobs:
             #!/bin/bash
             echo "${PLAY_PUBLISH_AUTH_JSON}" > android-gl-native-6d21dd280e7b.json
       - run:
+          name: Create google-services.json file
+          shell: /bin/bash -euo pipefail
+          command: |
+            if [ -n "${GOOGLE_SERVICES_JSON_RELEASE}" ]; then
+              echo "${GOOGLE_SERVICES_JSON_RELEASE}" > MapboxAndroidDemo/google-services.json
+            fi      
+      - run:
           name: Release to Google Play
           command: ./gradlew publishGlobalRelease
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Based on https://circleci.com/gh/mapbox/mapbox-android-demo/2370 💥 , looks like the `google-services.json` file needs to be created again in the `Release` CircleCI job. Discovered this as I was trying to release `8.2.1` of this app to the Play Store.

<img width="844" alt="Screen Shot 2019-08-09 at 10 22 38 AM" src="https://user-images.githubusercontent.com/4394910/62797070-a1411f00-ba8f-11e9-9f7e-734f8934c7a1.png">
