### PR TITLE
Downgraded gradle version to 3.3.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -65,7 +65,7 @@ ext {
     pluginVersion = [
             checkstyle          : '8.2',
             firebasePerformance : '1.2.1',
-            gradle              : '3.4.2',
+            gradle              : '3.3.0',
             gradlePlayPublisher : '2.0.0',
             kotlin              : '1.3.41',
             dependencyGraph     : '0.3.0',


### PR DESCRIPTION
This pr downgrades the Gradle version. It was bumped to `3.4.2` in https://github.com/mapbox/mapbox-android-demo/commit/fdbb9e1d5f00b88343bfa8fb698e1149f892efbd#diff-6512f838e273b79676cac5f72456127fL66. However, `3.4.2` makes R8 enabled by default (https://developer.android.com/studio/releases/gradle-plugin#3-3-0), which led to downstream issues when trying to get `8.2.1` of this app to the Play Store. We don't need R8 at this moment. Proguard is fine for now.

![Screen Shot 2019-08-13 at 1 44 02 PM](https://user-images.githubusercontent.com/4394910/62975966-6eb95e00-bdd0-11e9-929a-ec4a8039fdf7.png)


I'm hoping that dropping down to the latest pre-`3.4.0` version will hopefully get rid of 💥s.