### PR TITLE
[repo steps] adding tilt to demonstrate bug on fit bounds

### DIFF
--- a/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
+++ b/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/MapboxApplication.java
@@ -17,7 +17,7 @@ public class MapboxApplication extends Application {
     super.onCreate();
     setUpPicasso();
     Mapbox.getInstance(this, getString(R.string.access_token));
-    Mapbox.getTelemetry().setDebugLoggingEnabled(true);
+//    Mapbox.getTelemetry().setDebugLoggingEnabled(true);
     setUpTileLoadingMeasurement();
   }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/BoundingBoxCameraActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/camera/BoundingBoxCameraActivity.java
@@ -99,7 +99,7 @@ public class BoundingBoxCameraActivity extends AppCompatActivity implements OnMa
       .include(locationTwo) // Southwest
       .build();
 
-    mapboxMap.easeCamera(CameraUpdateFactory.newLatLngBounds(latLngBounds, 50), 5000);
+    mapboxMap.easeCamera(CameraUpdateFactory.newLatLngBounds(latLngBounds, 0, 50, 50), 5000);
     return true;
   }
 


### PR DESCRIPTION
- tapping on map should display whole state of Texas, but this result is unpredictable depending on different zoom levels.

ie. zoom in on the map and tap anywhere so fitBounds happen.
try this with different zoom levels and see different results.

when tilt is 0 result is always predictable