### PR TITLE
Proguard adjustments

### DIFF
--- a/MapboxAndroidDemo/proguard-rules.pro
+++ b/MapboxAndroidDemo/proguard-rules.pro
@@ -120,14 +120,16 @@
 -keep class com.mapbox.android.core.location.**
 -keep class android.arch.lifecycle.** { *; }
 -keep class com.mapbox.android.core.location.** { *; }
--keep class com.mapbox.mapboxsdk.** { *; }
+-dontnote class com.mapbox.mapboxsdk.** { *; }
+-dontnote class com.mapbox.android.gestures.** { *; }
+-dontnote class com.mapbox.mapboxsdk.plugins.** { *; }
 
 # Other Android
 -dontnote android.net.http.*
 -dontnote org.apache.commons.codec.**
 -dontnote org.apache.http.**
 
-
+-dontnote com.google.**
 -keep class com.google.firebase.**
 -dontwarn org.xmlpull.v1.**
 -dontnote org.xmlpull.v1.**

--- a/MapboxAndroidWearDemo/proguard-rules.pro
+++ b/MapboxAndroidWearDemo/proguard-rules.pro
@@ -97,11 +97,15 @@
 -keep class com.mapbox.android.core.location.**
 -keep class android.arch.lifecycle.** { *; }
 -keep class com.mapbox.android.core.location.** { *; }
--keep class com.mapbox.mapboxsdk.** { *; }
+-dontnote class com.mapbox.mapboxsdk.** { *; }
+-dontnote class com.mapbox.android.gestures.** { *; }
+-dontnote class com.mapbox.mapboxsdk.plugins.** { *; }
 
 # Other Android
 -keep public class com.google.firebase.** { public *; }
 -keep class com.google.firebase.** { *; }
+-dontnote com.google.firebase.**
+-dontnote com.google.android.gms.internal.**
 -dontnote android.net.http.*
 -dontnote org.apache.commons.codec.**
 -dontnote org.apache.http.**


### PR DESCRIPTION
I'm still trying get CircleCI to release the demo app to the Play Store. The current blocker seems to be the amount/type of Proguard messages, which then make the release process run out of memory. This pr adjusts the rules to cut down on the number of Proguard messages that are coming in.