### PR TITLE
Bumped Scale Bar Plugin to 0.3.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ ext {
             mapboxChinaPlugin        : '2.2.0',
             mapboxPluginMarkerView   : '0.3.0',
             mapboxPluginAnnotation   : '0.7.0',
-            mapboxPluginScalebar     : '0.2.0',
+            mapboxPluginScalebar     : '0.3.0',
 
             // Support
             legacySupportV4          : '1.0.0',


### PR DESCRIPTION
This pr bumps the Scale Bar Plugin dependency to `0.3.0` as part of the `0.3.0` release: https://github.com/mapbox/mapbox-plugins-android/issues/1040