### PR TITLE
Refactoring changes to switch loadGeoJsonFromAsset() usage to URI

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/BathymetryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/BathymetryActivity.java
@@ -2,10 +2,7 @@ package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 
-import com.mapbox.geojson.FeatureCollection;
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.geometry.LatLng;
@@ -18,8 +15,11 @@ import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.eq;
@@ -44,7 +44,6 @@ public class BathymetryActivity extends AppCompatActivity implements OnMapReadyC
     .include(new LatLng(44.936236, -85.673450))
     .include(new LatLng(44.932955, -85.669272))
     .build();
-  private FeatureCollection featureCollection;
   private MapView mapView;
 
   @Override
@@ -75,13 +74,12 @@ public class BathymetryActivity extends AppCompatActivity implements OnMapReadyC
         // Remove lake label layer
         style.removeLayer("water-label");
 
-        // Initialize FeatureCollection object for future use with layers
-        featureCollection = FeatureCollection.fromJson(loadGeoJsonFromAsset(
-            "bathymetry-data.geojson"));
-
-        // Retrieve GeoJSON from local file and add it to the map
-        style.addSource(new GeoJsonSource(GEOJSON_SOURCE_ID,
-            featureCollection));
+        try {
+          // Retrieve GeoJSON from local file and add it to the map's style
+          style.addSource(new GeoJsonSource(GEOJSON_SOURCE_ID, new URI("asset://bathymetry-data.geojson")));
+        } catch (URISyntaxException exception) {
+          Timber.d(exception);
+        }
 
         setUpDepthFillLayers(style);
         setUpDepthNumberSymbolLayer(style);
@@ -165,22 +163,5 @@ public class BathymetryActivity extends AppCompatActivity implements OnMapReadyC
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  private String loadGeoJsonFromAsset(String filename) {
-    try {
-      // Load GeoJSON file
-      InputStream is = getAssets().open(filename);
-      int size = is.available();
-      byte[] buffer = new byte[size];
-      is.read(buffer);
-      is.close();
-      return new String(buffer, "UTF-8");
-
-    } catch (Exception exception) {
-      Timber.e("Exception Loading GeoJSON: %s", exception.toString());
-      exception.printStackTrace();
-      return null;
-    }
   }
 }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/MultipleGeometriesActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/MultipleGeometriesActivity.java
@@ -2,8 +2,6 @@ package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -16,8 +14,12 @@ import com.mapbox.mapboxsdk.style.layers.FillLayer;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.eq;
 import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
@@ -56,9 +58,13 @@ public class MultipleGeometriesActivity extends AppCompatActivity implements OnM
   }
 
   private void createGeoJsonSource(@NonNull Style loadedMapStyle) {
-    // Load data from GeoJSON file in the assets folder
-    loadedMapStyle.addSource(new GeoJsonSource(GEOJSON_SOURCE_ID,
-      loadJsonFromAsset("fake_norway_campsites.geojson")));
+    try {
+      // Load data from GeoJSON file in the assets folder
+      loadedMapStyle.addSource(new GeoJsonSource(GEOJSON_SOURCE_ID,
+        new URI("asset://fake_norway_campsites.geojson")));
+    } catch (URISyntaxException exception) {
+      Timber.d(exception);
+    }
   }
 
   private void addPolygonLayer(@NonNull Style loadedMapStyle) {
@@ -122,20 +128,5 @@ public class MultipleGeometriesActivity extends AppCompatActivity implements OnM
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  private String loadJsonFromAsset(String filename) {
-    try {
-      InputStream is = getAssets().open(filename);
-      int size = is.available();
-      byte[] buffer = new byte[size];
-      is.read(buffer);
-      is.close();
-      return new String(buffer, "UTF-8");
-
-    } catch (IOException ex) {
-      ex.printStackTrace();
-      return null;
-    }
   }
 }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/MultipleHeatmapStylingActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/MultipleHeatmapStylingActivity.java
@@ -1,8 +1,6 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 
 import com.mapbox.mapboxandroiddemo.R;
@@ -18,8 +16,11 @@ import com.mapbox.mapboxsdk.style.expressions.Expression;
 import com.mapbox.mapboxsdk.style.layers.HeatmapLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.heatmapDensity;
@@ -71,8 +72,11 @@ public class MultipleHeatmapStylingActivity extends AppCompatActivity
           .build();
         mapboxMap.animateCamera(
           CameraUpdateFactory.newCameraPosition(cameraPositionForFragmentMap), 2600);
-        style.addSource(new GeoJsonSource(HEATMAP_SOURCE_ID,
-          loadGeoJsonFromAsset("la_heatmap_styling_points.geojson")));
+        try {
+          style.addSource(new GeoJsonSource(HEATMAP_SOURCE_ID, new URI("asset://la_heatmap_styling_points.geojson")));
+        } catch (URISyntaxException exception) {
+          Timber.d(exception);
+        }
         initHeatmapColors();
         initHeatmapRadiusStops();
         initHeatmapIntensityStops();
@@ -411,22 +415,5 @@ public class MultipleHeatmapStylingActivity extends AppCompatActivity
       // 11
       0.5f
     };
-  }
-
-  private String loadGeoJsonFromAsset(String filename) {
-    try {
-      // Load GeoJSON file
-      InputStream is = getAssets().open(filename);
-      int size = is.available();
-      byte[] buffer = new byte[size];
-      is.read(buffer);
-      is.close();
-      return new String(buffer, "UTF-8");
-
-    } catch (Exception exception) {
-      Timber.e("Exception loading GeoJSON: %s", exception.toString());
-      exception.printStackTrace();
-      return null;
-    }
   }
 }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/StyleLineIdentityPropertyActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/StyleLineIdentityPropertyActivity.java
@@ -1,8 +1,6 @@
 package com.mapbox.mapboxandroiddemo.examples.dds;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -15,8 +13,11 @@ import com.mapbox.mapboxsdk.style.layers.Property;
 import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
@@ -51,10 +52,13 @@ public class StyleLineIdentityPropertyActivity extends AppCompatActivity {
         mapboxMap.setStyle(Style.MAPBOX_STREETS, new Style.OnStyleLoaded() {
           @Override
           public void onStyleLoaded(@NonNull Style style) {
-
-            // Retrieve GeoJSON from local file and add it to the map
-            style.addSource(new GeoJsonSource("lines",
-                loadGeoJsonFromAsset("golden_gate_lines.geojson")));
+            try {
+              // Retrieve GeoJSON from local file and add it to the map
+              style.addSource(new GeoJsonSource("lines",
+                new URI("asset://golden_gate_lines.geojson")));
+            } catch (URISyntaxException exception) {
+              Timber.d(exception);
+            }
 
             // Create a LineLayer. Use lineColor and stops to draw red and blue lines on the map
             style.addLayer(new LineLayer("finalLines", "lines").withProperties(
@@ -111,24 +115,5 @@ public class StyleLineIdentityPropertyActivity extends AppCompatActivity {
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  private String loadGeoJsonFromAsset(String filename) {
-
-    try {
-      // Load GeoJSON file
-      InputStream is = getAssets().open(filename);
-      int size = is.available();
-      byte[] buffer = new byte[size];
-      is.read(buffer);
-      is.close();
-      return new String(buffer, "UTF-8");
-
-    } catch (Exception exception) {
-      Timber.e("Exception Loading GeoJSON: %s", exception.toString());
-      exception.printStackTrace();
-      return null;
-    }
-
   }
 }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/Indoor3DMapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/Indoor3DMapActivity.java
@@ -1,9 +1,6 @@
 package com.mapbox.mapboxandroiddemo.examples.extrusions;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -14,8 +11,13 @@ import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionBase;
@@ -49,17 +51,19 @@ public class Indoor3DMapActivity extends AppCompatActivity {
         mapboxMap.setStyle(Style.MAPBOX_STREETS, new Style.OnStyleLoaded() {
           @Override
           public void onStyleLoaded(@NonNull Style style) {
-            style.addSource(
-                new GeoJsonSource("room-data",
-                    loadJsonFromAsset("indoor-3d-map.geojson")));
+            try {
+              style.addSource(new GeoJsonSource("room-data", new URI("asset://indoor-3d-map.geojson")));
 
-            style.addLayer(new FillExtrusionLayer(
-              "room-extrusion", "room-data").withProperties(
-              fillExtrusionColor(get("color")),
-              fillExtrusionHeight(get("height")),
-              fillExtrusionBase(get("base_height")),
-              fillExtrusionOpacity(0.5f)
-            ));
+              style.addLayer(new FillExtrusionLayer(
+                "room-extrusion", "room-data").withProperties(
+                fillExtrusionColor(get("color")),
+                fillExtrusionHeight(get("height")),
+                fillExtrusionBase(get("base_height")),
+                fillExtrusionOpacity(0.5f)
+              ));
+            } catch (URISyntaxException exception) {
+              Timber.d(exception);
+            }
           }
         });
       }
@@ -106,22 +110,5 @@ public class Indoor3DMapActivity extends AppCompatActivity {
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  private String loadJsonFromAsset(String filename) {
-    // Using this method to load in GeoJSON files from the assets folder.
-
-    try {
-      InputStream is = getAssets().open(filename);
-      int size = is.available();
-      byte[] buffer = new byte[size];
-      is.read(buffer);
-      is.close();
-      return new String(buffer, "UTF-8");
-
-    } catch (IOException ex) {
-      ex.printStackTrace();
-      return null;
-    }
   }
 }

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/HighlightedLineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/query/HighlightedLineActivity.java
@@ -4,8 +4,6 @@ import android.graphics.Color;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import android.widget.Toast;
 
 import com.mapbox.geojson.Feature;
@@ -19,9 +17,12 @@ import com.mapbox.mapboxsdk.maps.Style;
 import com.mapbox.mapboxsdk.style.layers.LineLayer;
 import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
 
-import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.mapbox.mapboxsdk.style.layers.Property.LINE_CAP_ROUND;
@@ -105,8 +106,11 @@ public class HighlightedLineActivity extends AppCompatActivity implements
    * Set up the line layer source
    */
   private void initSource(@NonNull Style loadedMapStyle) {
-    loadedMapStyle.addSource(new GeoJsonSource("source-id", loadGeoJsonFromAsset(
-      "brussels_station_exits.geojson")));
+    try {
+      loadedMapStyle.addSource(new GeoJsonSource("source-id", new URI("asset://brussels_station_exits.geojson")));
+    } catch (URISyntaxException exception) {
+      Timber.d(exception);
+    }
     loadedMapStyle.addSource(new GeoJsonSource("background-geojson-source-id"));
   }
 
@@ -184,21 +188,5 @@ public class HighlightedLineActivity extends AppCompatActivity implements
   protected void onSaveInstanceState(Bundle outState) {
     super.onSaveInstanceState(outState);
     mapView.onSaveInstanceState(outState);
-  }
-
-  private String loadGeoJsonFromAsset(String filename) {
-    try {
-      // Load GeoJSON file from local asset folder
-      InputStream is = getAssets().open(filename);
-      int size = is.available();
-      byte[] buffer = new byte[size];
-      is.read(buffer);
-      is.close();
-      return new String(buffer, "UTF-8");
-    } catch (Exception exception) {
-      Timber.d("Exception loading GeoJSON: %s", exception.toString());
-      exception.printStackTrace();
-      return null;
-    }
   }
 }


### PR DESCRIPTION
Based on the comment at https://github.com/mapbox/mapbox-android-demo/pull/1177#discussion_r316585337, this pr refactors usage of `loadGeoJsonFromAsset()` to use `new URI()` instead, where possible. Examples are working fine after refactoring.