### PR TITLE
Added try/catch when TileLoadingInterceptor tries to get country code

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/utils/TileLoadingInterceptor.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/utils/TileLoadingInterceptor.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.MissingResourceException;
 
 import okhttp3.Interceptor;
 import okhttp3.Request;
@@ -101,7 +102,11 @@ public class TileLoadingInterceptor implements Interceptor {
       metaData.addProperty("device", Build.MODEL);
       metaData.addProperty("version", Build.VERSION.RELEASE);
       metaData.addProperty("abi", Build.CPU_ABI);
-      metaData.addProperty("country", Locale.getDefault().getISO3Country());
+      try {
+        metaData.addProperty("country", Locale.getDefault().getISO3Country());
+      } catch (MissingResourceException exception) {
+        metaData.addProperty("country", "none");
+      }
       metaData.addProperty("ram", getRam());
       metaData.addProperty("screenSize", getWindowSize());
       metaData.addProperty("buildFlavor", BuildConfig.FLAVOR);


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1132 by adding a try/catch when the `TileLoadingInterceptor` class tries to get the device's ISO3Country code. Apparently, there are situations when the code isn't available.

Related:
- https://github.com/mapbox/mapbox-android-demo/pull/1182