### PR TITLE
Refactored TilequeryActivity with appropriate null checks

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TilequeryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TilequeryActivity.java
@@ -51,6 +51,8 @@ public class TilequeryActivity extends AppCompatActivity implements
   private static final String RESULT_GEOJSON_SOURCE_ID = "RESULT_GEOJSON_SOURCE_ID";
   private static final String CLICK_CENTER_GEOJSON_SOURCE_ID = "CLICK_CENTER_GEOJSON_SOURCE_ID";
   private static final String LAYER_ID = "LAYER_ID";
+  private static final String RESULT_ICON_ID = "RESULT_ICON_ID";
+  private static final String CLICK_ICON_ID = "CLICK_ICON_ID";
   private PermissionsManager permissionsManager;
   private MapboxMap mapboxMap;
   private MapView mapView;
@@ -95,14 +97,14 @@ public class TilequeryActivity extends AppCompatActivity implements
    * Add a map layer which will show a marker icon where the map was clicked
    */
   private void addClickLayer(@NonNull Style loadedMapStyle) {
-    loadedMapStyle.addImage("CLICK-ICON-ID", BitmapFactory.decodeResource(
+    loadedMapStyle.addImage(CLICK_ICON_ID, BitmapFactory.decodeResource(
       TilequeryActivity.this.getResources(), R.drawable.red_marker));
 
     loadedMapStyle.addSource(new GeoJsonSource(CLICK_CENTER_GEOJSON_SOURCE_ID,
       FeatureCollection.fromFeatures(new Feature[] {})));
 
     loadedMapStyle.addLayer(new SymbolLayer("click-layer", CLICK_CENTER_GEOJSON_SOURCE_ID).withProperties(
-      iconImage("CLICK-ICON-ID"),
+      iconImage(CLICK_ICON_ID),
       iconOffset(new Float[] {0f, -12f}),
       iconIgnorePlacement(true),
       iconAllowOverlap(true)
@@ -114,15 +116,14 @@ public class TilequeryActivity extends AppCompatActivity implements
    */
   private void addResultLayer(@NonNull Style loadedMapStyle) {
     // Add the marker image to map
-    loadedMapStyle.addImage("RESULT-ICON-ID", BitmapFactory.decodeResource(
+    loadedMapStyle.addImage(RESULT_ICON_ID, BitmapFactory.decodeResource(
       TilequeryActivity.this.getResources(), R.drawable.blue_marker));
 
     // Retrieve GeoJSON information from the Mapbox Tilequery API
-    loadedMapStyle.addSource(new GeoJsonSource(RESULT_GEOJSON_SOURCE_ID,
-      FeatureCollection.fromFeatures(new Feature[] {})));
+    loadedMapStyle.addSource(new GeoJsonSource(RESULT_GEOJSON_SOURCE_ID));
 
     loadedMapStyle.addLayer(new SymbolLayer(LAYER_ID, RESULT_GEOJSON_SOURCE_ID).withProperties(
-      iconImage("RESULT-ICON-ID"),
+      iconImage(RESULT_ICON_ID),
       iconOffset(new Float[] {0f, -12f}),
       iconIgnorePlacement(true),
       iconAllowOverlap(true)
@@ -132,22 +133,20 @@ public class TilequeryActivity extends AppCompatActivity implements
 
   @Override
   public boolean onMapClick(@NonNull LatLng point) {
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        // Move and display the click center layer's red marker icon to wherever the map was clicked on
+        GeoJsonSource clickLocationSource = style.getSourceAs(CLICK_CENTER_GEOJSON_SOURCE_ID);
+        if (clickLocationSource != null) {
+          clickLocationSource.setGeoJson(Point.fromLngLat(point.getLongitude(), point.getLatitude()));
+        }
 
-    Style style = mapboxMap.getStyle();
-    if (style != null) {
-      // Move and display the click center layer's red marker icon to wherever the map was clicked on
-      GeoJsonSource clickLocationSource = style.getSourceAs(CLICK_CENTER_GEOJSON_SOURCE_ID);
-      if (clickLocationSource != null) {
-        clickLocationSource.setGeoJson(Point.fromLngLat(point.getLongitude(), point.getLatitude()));
+        // Use the map click location to make a Tilequery API call
+        makeTilequeryApiCall(point);
       }
-
-      // Use the map click location to make a Tilequery API call
-      makeTilequeryApiCall(style, point);
-
-      return true;
-    }
-
-    return false;
+    });
+    return true;
   }
 
   /**
@@ -155,7 +154,7 @@ public class TilequeryActivity extends AppCompatActivity implements
    *
    * @param point the center point that the the tilequery will originate from.
    */
-  private void makeTilequeryApiCall(@NonNull final Style style, @NonNull LatLng point) {
+  private void makeTilequeryApiCall(@NonNull LatLng point) {
     MapboxTilequery tilequery = MapboxTilequery.builder()
       .accessToken(getString(R.string.access_token))
       .mapIds("mapbox.mapbox-streets-v7")
@@ -170,10 +169,24 @@ public class TilequeryActivity extends AppCompatActivity implements
     tilequery.enqueueCall(new Callback<FeatureCollection>() {
       @Override
       public void onResponse(Call<FeatureCollection> call, Response<FeatureCollection> response) {
-        tilequeryResponseTextView.setText(response.body().toJson());
-        GeoJsonSource resultSource = style.getSourceAs(RESULT_GEOJSON_SOURCE_ID);
-        if (resultSource != null && response.body().features() != null) {
-          resultSource.setGeoJson(FeatureCollection.fromFeatures(response.body().features()));
+        if (response.body() != null) {
+          FeatureCollection responseFeatureCollection = response.body();
+          tilequeryResponseTextView.setText(responseFeatureCollection.toJson());
+          mapboxMap.getStyle(new Style.OnStyleLoaded() {
+            @Override
+            public void onStyleLoaded(@NonNull Style style) {
+              GeoJsonSource resultSource = style.getSourceAs(RESULT_GEOJSON_SOURCE_ID);
+              if (resultSource != null && responseFeatureCollection.features() != null) {
+                List<Feature> featureList = responseFeatureCollection.features();
+                if (featureList.isEmpty()) {
+                  Toast.makeText(TilequeryActivity.this,
+                    getString(R.string.no_tilequery_response_features_toast), Toast.LENGTH_SHORT).show();
+                } else {
+                  resultSource.setGeoJson(FeatureCollection.fromFeatures(featureList));
+                }
+              }
+            }
+          });
         }
       }
 

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -311,6 +311,7 @@
     <!-- Tilequery API -->
     <string name="api_response">Tilequery API response:</string>
     <string name="api_error">Error with the request. Do you have internet access?</string>
+    <string name="no_tilequery_response_features_toast">No features found where you tapped. Find and tap on a building outline.</string>
 
     <!-- Magic window -->
     <string name="could_not_get_location">Couldn\'t retrieve the device\'s location</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -88,7 +88,7 @@
     <string name="activity_java_services_geocoding_url" translatable="false">https://i.imgur.com/9xl3EF8.png</string>
     <string name="activity_java_services_isochrone_url" translatable="false">https://i.imgur.com/eUByGvt.png</string>
     <string name="activity_java_services_isochrone_with_seekbar_url" translatable="false">https://i.imgur.com/hCVswtE.png</string>
-    <string name="activity_java_services_tilequery_url" translatable="false">https://i.imgur.com/mjUbe2H.png</string>
+    <string name="activity_java_services_tilequery_url" translatable="false">http://i.imgur.com/VkOCYwq.jpg</string>
     <string name="activity_java_services_simplify_polyline_url" translatable="false">http://i.imgur.com/uATgul1.png</string>
     <string name="activity_java_services_map_matching_url" translatable="false">https://i.imgur.com/ig8gGnY.png</string>
     <string name="activity_java_services_turf_ring_url" translatable="false">https://i.imgur.com/nG8xeXH.png</string>


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1134 by adding appropriate null checks and other refactorings. Seems that #1134 happened because the source couldn't be found in the style. Rather than passing the style object through as a parameter, I just get the style directly and run the subsequent code in the `onStyleLoaded()` callback. Hopefully, that'll cut down on flaky style/source-related 💥 