### PR TITLE
Fixes to Localization Plugin XML so that language switch buttons appear

### DIFF
--- a/MapboxAndroidDemo/src/china/res/layout/activity_basic_simple_china_mapview.xml
+++ b/MapboxAndroidDemo/src/china/res/layout/activity_basic_simple_china_mapview.xml
@@ -7,7 +7,6 @@
     android:layout_height="match_parent"
     tools:context=".examples.basics.SimpleMapViewActivity">
 
-    <!-- Set the starting camera position and map style using xml-->
     <com.mapbox.mapboxsdk.plugins.china.maps.ChinaMapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"

--- a/MapboxAndroidDemo/src/china/res/layout/activity_basic_simple_kotlin.xml
+++ b/MapboxAndroidDemo/src/china/res/layout/activity_basic_simple_kotlin.xml
@@ -6,7 +6,6 @@
     android:layout_height="match_parent"
     tools:context=".examples.basics.SimpleMapViewActivity">
 
-    <!-- Set the starting camera position and map style using xml-->
     <com.mapbox.mapboxsdk.plugins.china.maps.ChinaMapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"

--- a/MapboxAndroidDemo/src/china/res/layout/activity_localization_plugin.xml
+++ b/MapboxAndroidDemo/src/china/res/layout/activity_localization_plugin.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.mapbox.mapboxsdk.plugins.china.maps.ChinaMapView
+    <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -13,76 +13,50 @@
         app:mapbox_cameraTargetLng="136.711369"
         app:mapbox_cameraZoom="4.5257" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="16dp"
+        android:orientation="horizontal">
 
-        <androidx.cardview.widget.CardView
-            android:id="@+id/language_one_cardview"
+        <Button
+            android:id="@+id/language_one_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:backgroundTint="@color/mapboxOrangeDark"
-            app:layout_constraintEnd_toStartOf="@+id/language_two_cardview"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="parent">
+            android:background="@color/mapboxOrangeDark"
+            android:text="@string/arabic"
+            android:textColor="@color/mapboxWhite" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="16dp"
-                android:text="@string/arabic"
-                android:textColor="@color/mapboxWhite" />
-
-        </androidx.cardview.widget.CardView>
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/language_two_cardview"
+        <Button
+            android:id="@+id/language_two_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:backgroundTint="@color/mapboxPurpleDark"
-            app:layout_constraintEnd_toStartOf="@+id/language_three_cardview"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toEndOf="@+id/language_one_cardview"
-            app:layout_constraintTop_toTopOf="@id/language_one_cardview">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="16dp"
-                android:text="@string/russian"
-                android:textColor="@color/mapboxWhite" />
-
-        </androidx.cardview.widget.CardView>
+            android:layout_marginStart="32dp"
+            android:layout_marginLeft="32dp"
+            android:background="@color/mapboxPurpleDark"
+            android:text="@string/russian"
+            android:textColor="@color/mapboxWhite" />
 
 
-        <androidx.cardview.widget.CardView
-            android:id="@+id/language_three_cardview"
+        <Button
+            android:id="@+id/language_three_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:backgroundTint="@color/mapboxGreenDark"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toEndOf="@+id/language_two_cardview"
-            app:layout_constraintTop_toTopOf="@id/language_two_cardview">
+            android:layout_marginStart="32dp"
+            android:layout_marginLeft="32dp"
+            android:background="@color/mapboxGreenDark"
+            android:text="@string/chinese"
+            android:textColor="@color/mapboxWhite" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="16dp"
-                android:text="@string/chinese"
-                android:textColor="@color/mapboxWhite" />
-
-        </androidx.cardview.widget.CardView>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/match_map_to_device_language"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|right"
+        android:layout_gravity="bottom|end"
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
         android:layout_marginBottom="16dp"
@@ -90,6 +64,5 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:srcCompat="@drawable/ic_swap_horiz_white_24dp"
         mapbox:fabSize="small" />
-
 
 </FrameLayout>

--- a/MapboxAndroidDemo/src/china/res/layout/activity_query_redo_search_in_area.xml
+++ b/MapboxAndroidDemo/src/china/res/layout/activity_query_redo_search_in_area.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <!-- Set the starting camera position and map style using xml-->
     <com.mapbox.mapboxsdk.plugins.china.maps.ChinaMapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocalizationPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/LocalizationPluginActivity.java
@@ -44,25 +44,24 @@ public class LocalizationPluginActivity extends AppCompatActivity implements OnM
 
   @Override
   public void onMapReady(@NonNull final MapboxMap mapboxMap) {
-
     mapboxMap.setStyle(Style.MAPBOX_STREETS, new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {
         localizationPlugin = new LocalizationPlugin(mapView, mapboxMap, style);
 
-        findViewById(R.id.language_one_cardview).setOnClickListener(new View.OnClickListener() {
+        findViewById(R.id.language_one_button).setOnClickListener(new View.OnClickListener() {
           @Override
           public void onClick(View view) {
             localizationPlugin.setMapLanguage(MapLocale.ARABIC);
           }
         });
-        findViewById(R.id.language_two_cardview).setOnClickListener(new View.OnClickListener() {
+        findViewById(R.id.language_two_button).setOnClickListener(new View.OnClickListener() {
           @Override
           public void onClick(View view) {
             localizationPlugin.setMapLanguage(MapLocale.RUSSIAN);
           }
         });
-        findViewById(R.id.language_three_cardview).setOnClickListener(new View.OnClickListener() {
+        findViewById(R.id.language_three_button).setOnClickListener(new View.OnClickListener() {
           @Override
           public void onClick(View view) {
             localizationPlugin.setMapLanguage(MapLocale.SIMPLIFIED_CHINESE);
@@ -86,7 +85,6 @@ public class LocalizationPluginActivity extends AppCompatActivity implements OnM
             }
           }
         });
-
         Toast.makeText(LocalizationPluginActivity.this, R.string.instruction_description,
           Toast.LENGTH_LONG).show();
       }

--- a/MapboxAndroidDemo/src/main/res/layout/activity_basic_simple_kotlin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_basic_simple_kotlin.xml
@@ -6,7 +6,6 @@
     android:layout_height="match_parent"
     tools:context=".examples.basics.MapViewActivityKotlin">
 
-    <!-- Set the starting camera position and map style using xml-->
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"

--- a/MapboxAndroidDemo/src/main/res/layout/activity_basic_simple_mapview.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_basic_simple_mapview.xml
@@ -7,7 +7,6 @@
     android:layout_height="match_parent"
     tools:context=".examples.basics.SimpleMapViewActivity">
 
-    <!-- Set the starting camera position and map style using xml-->
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"

--- a/MapboxAndroidDemo/src/main/res/layout/activity_localization_plugin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_localization_plugin.xml
@@ -13,83 +13,56 @@
         app:mapbox_cameraTargetLng="136.711369"
         app:mapbox_cameraZoom="4.5257" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="16dp"
+        android:orientation="horizontal">
 
-        <androidx.cardview.widget.CardView
-            android:id="@+id/language_one_cardview"
+        <Button
+            android:id="@+id/language_one_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:backgroundTint="@color/mapboxOrangeDark"
-            app:layout_constraintEnd_toStartOf="@+id/language_two_cardview"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="parent">
+            android:background="@color/mapboxOrangeDark"
+            android:text="@string/arabic"
+            android:textColor="@color/mapboxWhite" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="16dp"
-                android:text="@string/arabic"
-                android:textColor="@color/mapboxWhite" />
-
-        </androidx.cardview.widget.CardView>
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/language_two_cardview"
+        <Button
+            android:id="@+id/language_two_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:backgroundTint="@color/mapboxPurpleDark"
-            app:layout_constraintEnd_toStartOf="@+id/language_three_cardview"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toEndOf="@+id/language_one_cardview"
-            app:layout_constraintTop_toTopOf="@id/language_one_cardview">
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="16dp"
-                android:text="@string/russian"
-                android:textColor="@color/mapboxWhite" />
-
-        </androidx.cardview.widget.CardView>
+            android:layout_marginStart="32dp"
+            android:layout_marginLeft="32dp"
+            android:background="@color/mapboxPurpleDark"
+            android:text="@string/russian"
+            android:textColor="@color/mapboxWhite" />
 
 
-        <androidx.cardview.widget.CardView
-            android:id="@+id/language_three_cardview"
+        <Button
+            android:id="@+id/language_three_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:backgroundTint="@color/mapboxGreenDark"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toEndOf="@+id/language_two_cardview"
-            app:layout_constraintTop_toTopOf="@id/language_two_cardview">
+            android:layout_marginStart="32dp"
+            android:layout_marginLeft="32dp"
+            android:background="@color/mapboxGreenDark"
+            android:text="@string/chinese"
+            android:textColor="@color/mapboxWhite" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_margin="16dp"
-                android:text="@string/chinese"
-                android:textColor="@color/mapboxWhite" />
-
-        </androidx.cardview.widget.CardView>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/match_map_to_device_language"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|right"
-        android:layout_marginBottom="16dp"
+        android:layout_gravity="bottom|end"
         android:layout_marginEnd="16dp"
         android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:srcCompat="@drawable/ic_swap_horiz_white_24dp"
         mapbox:fabSize="small" />
-
 
 </FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_offline_cache_manipulation.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_offline_cache_manipulation.xml
@@ -8,7 +8,6 @@
     android:background="@color/materialGrey"
     tools:context=".examples.offline.CacheManagementActivity">
 
-    <!-- Set the starting camera position and map style using xml-->
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="0dp"

--- a/MapboxAndroidDemo/src/main/res/layout/activity_query_redo_search_in_area.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_query_redo_search_in_area.xml
@@ -4,7 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <!-- Set the starting camera position and map style using xml-->
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -235,7 +235,7 @@
     <string name="arabic">Arabic</string>
     <string name="change_device_language_instruction">Change the device\'s language to German and then tap this button. Already in German? Try French</string>
     <string name="try_different_language_instruction">Try setting your phone to a different language. German or French perhaps?</string>
-    <string name="instruction_description">Tap the buttons below to
+    <string name="instruction_description">Tap the buttons above to
         switch the map\'s language.</string>
 
     <!-- Matrix API -->


### PR DESCRIPTION
Somehow, the XML for the Localization Plugin example got messed up and the language switch buttons disappeared. This pr fixes the layout and does some other XML refactoring.


![ezgif com-resize](https://user-images.githubusercontent.com/4394910/63730805-adfc9b80-c821-11e9-9a7e-f71c4bb4773c.gif)
