### PR TITLE
Adding Kotlin example of adding a map fragment to container

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -24,6 +24,7 @@ import com.mapbox.mapboxandroiddemo.adapter.ExampleAdapter;
 import com.mapbox.mapboxandroiddemo.commons.AnalyticsTracker;
 import com.mapbox.mapboxandroiddemo.commons.FirstTimeRunChecker;
 import com.mapbox.mapboxandroiddemo.examples.basics.KotlinSimpleMapViewActivity;
+import com.mapbox.mapboxandroiddemo.examples.basics.KotlinSupportMapFragmentActivity;
 import com.mapbox.mapboxandroiddemo.examples.basics.MapboxMapOptionActivity;
 import com.mapbox.mapboxandroiddemo.examples.basics.SimpleMapViewActivity;
 import com.mapbox.mapboxandroiddemo.examples.basics.SupportMapFragmentActivity;
@@ -1442,6 +1443,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, MapboxMapOptionActivity.class),
       null,
       R.string.activity_basic_mapbox_options_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_basics,
+      R.string.activity_basic_kotlin_support_map_frag_title,
+      R.string.activity_basic_kotlin_support_map_frag_description,
+      null,
+      new Intent(MainActivity.this, KotlinSupportMapFragmentActivity.class),
+      R.string.activity_basic_kotlin_support_map_frag_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_dds,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -649,6 +649,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.basics.KotlinSupportMapFragmentActivity"
+            android:label="@string/activity_basic_kotlin_support_map_frag_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.dds.BathymetryActivity"
             android:label="@string/activity_dds_bathymetry_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/KotlinSupportMapFragmentActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/basics/KotlinSupportMapFragmentActivity.kt
@@ -1,0 +1,58 @@
+package com.mapbox.mapboxandroiddemo.examples.basics
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.mapboxandroiddemo.R
+import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.mapboxsdk.camera.CameraPosition
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapboxMapOptions
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.maps.SupportMapFragment
+
+/**
+ * Use Kotlin to add a map into a fragment container.
+ */
+class KotlinSupportMapFragmentActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_basic_kotlin_support_map_frag)
+
+        // Mapbox access token is configured here. This needs to be called either in your application
+        // object or in the same activity which contains the mapview.
+        Mapbox.getInstance(this, getString(R.string.access_token))
+
+        // Create supportMapFragment
+        val mapFragment: SupportMapFragment
+        if (savedInstanceState == null) {
+
+            // Create fragment
+            val transaction = supportFragmentManager.beginTransaction()
+
+            // Build mapboxMap
+            val options = MapboxMapOptions.createFromAttributes(this, null)
+            options.camera(CameraPosition.Builder()
+                    .target(LatLng(-52.6885, -70.1395))
+                    .zoom(9.0)
+                    .build())
+
+            // Create map fragment
+            mapFragment = SupportMapFragment.newInstance(options)
+
+            // Add map fragment to parent container
+            transaction.add(R.id.container, mapFragment, "com.mapbox.map")
+            transaction.commit()
+        } else {
+            mapFragment = supportFragmentManager.findFragmentByTag("com.mapbox.map") as SupportMapFragment
+        }
+
+        mapFragment.getMapAsync {
+            mapboxMap -> mapboxMap.setStyle(Style.SATELLITE) {
+
+            // Map in fragment container is set up and the style has loaded.
+            // Now you can add data or make other map adjustments.
+            }
+        }
+    }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_basic_kotlin_support_map_frag.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_basic_kotlin_support_map_frag.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/md_divider_white"
+    tools:context=".examples.basics.SupportMapFragmentActivity">
+
+    <TextView
+        android:id="@+id/fragment_below_textview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center_horizontal"
+        android:text="@string/fragment_in_card_below"/>
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cardview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/fragment_below_textview"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:cardCornerRadius="2dp"
+        app:cardElevation="@dimen/cardview_default_elevation">
+
+        <FrameLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+    </androidx.cardview.widget.CardView>
+
+
+</RelativeLayout>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -5,9 +5,10 @@
     each example's recyclerview card ****** -->
 
     <string name="activity_basic_simple_mapview_description">Show a map in your app using the Mapbox Maps SDK.</string>
-    <string name="activity_basic_support_map_frag_description">Include a map fragment within your app using Android support library.</string>
+    <string name="activity_basic_support_map_frag_description">Place a map fragment inside of a container.</string>
     <string name="activity_basic_mapbox_options_description">Add a mapview in a dynamically created layout.</string>
     <string name="activity_basic_mapbox_kotlin_description">Display a basic map with Kotlin code.</string>
+    <string name="activity_basic_kotlin_support_map_frag_description">Place a map fragment inside of a container.</string>
     <string name="activity_styles_mapbox_studio_description">Use a custom Mapbox-hosted style.</string>
     <string name="activity_style_raster_description">Use legacy raster tiles in your app.</string>
     <string name="activity_styles_default_description">Use a variety of professionally designed styles with the Mapbox Maps SDK.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -8,6 +8,7 @@
     <string name="activity_basic_support_map_frag_title">Support map fragment</string>
     <string name="activity_basic_mapbox_options_title">Dynamically build a map view</string>
     <string name="activity_basic_mapbox_kotlin_title">Use Kotlin to show a map</string>
+    <string name="activity_basic_kotlin_support_map_frag_title">Support map fragment</string>
     <string name="activity_styles_mapbox_studio_title">Mapbox Studio style</string>
     <string name="activity_styles_default_title">Default styles</string>
     <string name="activity_styles_show_hide_layer_title">Show and hide layers</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -8,6 +8,7 @@
     <string name="activity_basic_simple_mapview_url" translatable="false">https://i.imgur.com/UF3B0o8.png</string>
     <string name="activity_basic_support_map_frag_url" translatable="false">https://i.imgur.com/y5QIBeM.png</string>
     <string name="activity_basic_mapbox_options_url" translatable="false">https://i.imgur.com/CRtK8UE.png</string>
+    <string name="activity_basic_kotlin_support_map_frag_url" translatable="false">https://i.imgur.com/y5QIBeM.png</string>
     <string name="activity_styles_mapbox_studio_url" translatable="false">http://i.imgur.com/MbR2zbD.png</string>
     <string name="activity_style_raster_url" translatable="false">http://i.imgur.com/QpFmrdR.png</string>
     <string name="activity_styles_default_url" translatable="false">http://i.imgur.com/ZuUhFHw.jpg</string>


### PR DESCRIPTION
Resolves https://github.com/mapbox/android-docs/issues/1031 by adding a Kotlin example of setting up a Mapbox map in a fragment container. We already have Java version in the app.

@pengdev , FYI that this pr is a good place to see the bare minimum changes needed for adding a new example to the demo app.

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/63815484-94268b80-c8e9-11e9-9144-3f91a8cf6dba.gif)
