### PR TITLE
Added TurfMeasurement distance example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -72,6 +72,7 @@ import com.mapbox.mapboxandroiddemo.examples.javaservices.OptimizationActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.SimplifyPolylineActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.StaticImageActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TilequeryActivity;
+import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfLineDistanceActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfRingActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfPhysicalCircleActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.AnimatedImageGifActivity;
@@ -1042,6 +1043,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, TurfPhysicalCircleActivity.class),
       null,
       R.string.activity_java_services_tilequery_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_java_services,
+      R.string.activity_java_services_turf_line_distance_title,
+      R.string.activity_java_services_turf_line_distance_description,
+      new Intent(MainActivity.this, TurfLineDistanceActivity.class),
+      null,
+      R.string.activity_java_services_turf_line_distance_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_snapshot_image_generator,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -915,6 +915,14 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.javaservices.TurfLineDistanceActivity"
+            android:label="@string/activity_java_services_turf_line_distance_title"
+            android:screenOrientation="portrait">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.ValueAnimatorIconAnimationActivity"
             android:label="@string/activity_lab_animated_interpolator_icon_drop_title"
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TurfLineDistanceActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TurfLineDistanceActivity.java
@@ -1,0 +1,211 @@
+package com.mapbox.mapboxandroiddemo.examples.javaservices;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.CircleLayer;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.turf.TurfMeasurement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import static com.mapbox.mapboxsdk.style.layers.Property.LINE_JOIN_ROUND;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+import static com.mapbox.turf.TurfConstants.UNIT_KILOMETERS;
+
+/**
+ * Use {@link com.mapbox.turf.TurfMeasurement#distance(Point, Point)} to measure the distance of a drawn line.
+ */
+public class TurfLineDistanceActivity extends AppCompatActivity implements MapboxMap.OnMapClickListener {
+
+  private static final String SOURCE_ID = "SOURCE_ID";
+  private static final String CIRCLE_LAYER_ID = "CIRCLE_LAYER_ID";
+  private static final String LINE_LAYER_ID = "LINE_LAYER_ID";
+
+  // Adjust private static final variables below to change the example's UI
+  private static final String STYLE_URI = "mapbox://styles/mapbox/cjv6rzz4j3m4b1fqcchuxclhb";
+  private static final int CIRCLE_COLOR = Color.RED;
+  private static final int LINE_COLOR = CIRCLE_COLOR;
+  private static final float CIRCLE_RADIUS = 6f;
+  private static final float LINE_WIDTH = 4f;
+  private static final String DISTANCE_UNITS = UNIT_KILOMETERS; // DISTANCE_UNITS must be equal to a String
+  // found in the TurfConstants class
+
+  private List<Point> pointList = new ArrayList<>();
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private TextView lineLengthTextView;
+  private double totalLineDistance = 0;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_javaservices_turf_measure_line);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+
+        lineLengthTextView = findViewById(R.id.line_length_textView);
+
+        // DISTANCE_UNITS must be equal to a String found in the TurfConstants class
+        lineLengthTextView.setText(String.format(getString(R.string.line_distance_textview),
+          DISTANCE_UNITS, String.valueOf(totalLineDistance)));
+
+        TurfLineDistanceActivity.this.mapboxMap = mapboxMap;
+        mapboxMap.setStyle(new Style.Builder()
+              .fromUri(STYLE_URI)
+
+              // Add the source to the map
+              .withSource(new GeoJsonSource(SOURCE_ID))
+
+              // Style and add the CircleLayer to the map
+              .withLayer(new CircleLayer(CIRCLE_LAYER_ID, SOURCE_ID).withProperties(
+                circleColor(CIRCLE_COLOR),
+                circleRadius(CIRCLE_RADIUS)
+              ))
+
+            // Style and add the LineLayer to the map. The LineLayer is placed below the CircleLayer.
+            .withLayerBelow(new LineLayer(LINE_LAYER_ID, SOURCE_ID).withProperties(
+              lineColor(LINE_COLOR),
+              lineWidth(LINE_WIDTH),
+              lineJoin(LINE_JOIN_ROUND)
+            ), CIRCLE_LAYER_ID), new Style.OnStyleLoaded() {
+              @Override
+              public void onStyleLoaded(@NonNull Style style) {
+                TurfLineDistanceActivity.this.mapboxMap.addOnMapClickListener(TurfLineDistanceActivity.this);
+                Toast.makeText(TurfLineDistanceActivity.this, getString(
+                  R.string.line_distance_tap_instruction), Toast.LENGTH_SHORT).show();
+              }
+            }
+        );
+      }
+    });
+  }
+
+  @Override
+  public boolean onMapClick(@NonNull LatLng point) {
+    addClickPointToLine(point);
+    return true;
+  }
+
+  /**
+   * Handle the map click location and re-draw the circle and line data.
+   *
+   * @param clickLatLng where the map was tapped on.
+   */
+  private void addClickPointToLine(@NonNull LatLng clickLatLng) {
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        // Get the source from the map's style
+        GeoJsonSource geoJsonSource = style.getSourceAs(SOURCE_ID);
+        if (geoJsonSource != null) {
+
+          pointList.add(Point.fromLngLat(clickLatLng.getLongitude(), clickLatLng.getLatitude()));
+
+          int pointListSize = pointList.size();
+
+          double distanceBetweenLastAndSecondToLastClickPoint = 0;
+
+          // Make the Turf calculation between the last tap point and the second-to-last tap point.
+          if (pointList.size() >= 2) {
+            distanceBetweenLastAndSecondToLastClickPoint = TurfMeasurement.distance(
+              pointList.get(pointListSize - 2), pointList.get(pointListSize - 1));
+          }
+
+          // Re-draw the new GeoJSON data
+          if (pointListSize >= 2 && distanceBetweenLastAndSecondToLastClickPoint > 0) {
+
+            // Add the last TurfMeasurement#distance calculated distance to the total line distance.
+            totalLineDistance += distanceBetweenLastAndSecondToLastClickPoint;
+
+            // Adjust the TextView to display the new total line distance.
+            // DISTANCE_UNITS must be equal to a String found in the TurfConstants class
+            lineLengthTextView.setText(String.format(getString(R.string.line_distance_textview), DISTANCE_UNITS,
+              String.valueOf(totalLineDistance)));
+
+            // Set the specific source's GeoJSON data
+            geoJsonSource.setGeoJson(Feature.fromGeometry(LineString.fromLngLats(pointList)));
+          }
+        }
+      }
+    });
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    if (mapboxMap != null) {
+      mapboxMap.removeOnMapClickListener(this);
+    }
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_turf_measure_line.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_turf_measure_line.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraint_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.javaservices.TurfLineDistanceActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="21.3011229"
+        mapbox:mapbox_cameraTargetLng="-157.851376"
+        mapbox:mapbox_cameraZoom="12" />
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cardView7"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|center"
+        android:layout_marginTop="8dp">
+
+        <TextView
+            android:id="@+id/line_length_textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="@string/line_distance_textview" />
+
+    </androidx.cardview.widget.CardView>
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -426,4 +426,9 @@
     <string name="invalid_max_ambient_cache_size">Set ambient\nmax cache</string>
     <string name="clear_ambient_cache_button">Clear ambient\ncache</string>
     <string name="adjust_map_button">Adjust map</string>
+
+    <!-- Turf measure line distance -->
+    <string name="line_distance_tap_instruction">Tap on map at least twice to create and measure a line</string>
+    <string name="line_distance_textview">Line distance in %1$s: %2$s</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -96,6 +96,7 @@
     <string name="activity_java_services_map_matching_description">Match raw GPS points to the map so they aligns with the roads/pathways.</string>
     <string name="activity_java_services_turf_ring_description">Use Turf to calculate coordinates to eventually draw a ring around a center coordinate.</string>
     <string name="activity_java_services_turf_physical_circle_description">Use Turf to generate a circle with a radius expressed in physical units (e.g. miles, kilometers, etc).</string>
+    <string name="activity_java_services_turf_line_distance_description">Use Turf to generate a circle with a radius expressed in physical units (e.g. miles, kilometers, etc).</string>
     <string name="activity_plugins_traffic_plugin_description">Use the traffic plugin to display live car congestion data on top of a map.</string>
     <string name="activity_plugins_building_plugin_description">Use the building plugin to easily display 3D building height</string>
     <string name="activity_plugins_geojson_plugin_description">Easily retrieve GeoJSON data from a url, asset, or path</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -94,6 +94,7 @@
     <string name="activity_java_services_map_matching_title">Map Matching</string>
     <string name="activity_java_services_turf_ring_title">Hollow circle</string>
     <string name="activity_java_services_turf_physical_circle_title">Define a circle in physical units</string>
+    <string name="activity_java_services_turf_line_distance_title">Measure line distance</string>
     <string name="activity_plugins_traffic_plugin_title">Display real-time traffic</string>
     <string name="activity_plugins_building_plugin_title">Display buildings in 3D</string>
     <string name="activity_plugins_localization_plugin_title">Change map text to device language</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -90,6 +90,7 @@
     <string name="activity_java_services_isochrone_url" translatable="false">https://i.imgur.com/eUByGvt.png</string>
     <string name="activity_java_services_isochrone_with_seekbar_url" translatable="false">https://i.imgur.com/hCVswtE.png</string>
     <string name="activity_java_services_tilequery_url" translatable="false">http://i.imgur.com/VkOCYwq.jpg</string>
+    <string name="activity_java_services_turf_line_distance_url" translatable="false">https://i.imgur.com/dQLvi1t.png</string>
     <string name="activity_java_services_simplify_polyline_url" translatable="false">http://i.imgur.com/uATgul1.png</string>
     <string name="activity_java_services_map_matching_url" translatable="false">https://i.imgur.com/ig8gGnY.png</string>
     <string name="activity_java_services_turf_ring_url" translatable="false">https://i.imgur.com/nG8xeXH.png</string>


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1191 by adding an example of using [TurfMeasurement#distance](https://github.com/mapbox/mapbox-java/blob/master/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java#L112-L135) to measure the length of a line.

@pengdev , [Turf is a package in our Java SDK ](https://github.com/mapbox/mapbox-java/tree/master/services-turf/src/main/java/com/mapbox/turf), which has Java methods ported over from http://turfjs.org

The list of methods that we've converted, can be found at https://github.com/mapbox/mapbox-java/blob/master/docs/turf-port.md. Once in awhile, we try to work on adding an additional port (https://github.com/mapbox/mapbox-java/pulls?q=is%3Apr+is%3Aopen+label%3ATurf). 

Turf-related tickets https://github.com/mapbox/mapbox-java/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+turf

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/64056904-b0c1fe00-cb4b-11e9-9496-877ca9af17ff.gif)
