### PR TITLE
Release 8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Mapbox welcomes participation and contributions from everyone.
 
+## 8.3.0 - September 3, 2019
+
+* Gradle Play Publisher plugin adjustments #1198  
+* Refactoring to replace style.isFullyLoaded() with the `onStyleLoaded()` callback #1192
+* Refactoring RelativeLayout to FrameLayout #1181  
+* Bumping maps sdk version to stable 8.3.0 #1161
+* Adding Kotlin example of adding a map fragment to container #1188  
+* Adding null checks in OptimizationActivity response #1184  
+* Refactored TilequeryActivity with appropriate null checks #1185  
+* Added try/catch for getting getISO3Country for analytics #1182  
+* Fixes to Localization Plugin XML so that language switch buttons appear #1186
+* Added try/catch when TileLoadingInterceptor tries to get country code #1183
+* Refactoring changes to switch loadGeoJsonFromAsset( usage to URI #1179
+* Adding spinning SymbolLayer icons example #1177
+* Added TurfMeasurement distance example #1193
+
 ## 8.2.1-3 - August 13, 2019
 
 * Downgraded gradle version to 3.3.0 #1171

--- a/MapboxAndroidDemo/src/global/play/release-notes/en-US/default.txt
+++ b/MapboxAndroidDemo/src/global/play/release-notes/en-US/default.txt
@@ -1,9 +1,12 @@
-This update is in line with the 8.2.1 release of the Mapbox Maps SDK for Android and includes several fixes and new examples:
+This update is in line with the 8.3.0 release of the Mapbox Maps SDK for Android and includes several fixes and new examples:
 
 - Isochrone API data + seekbar slider
 - RecyclerView + Directions API route
 - Location change listening
 - Circle radius based on data
 - Runtime styling
-- Define a circle's radius with physical units
+- Define a circle's radius with distance units
 - Cache management
+- Kotlin map fragment
+- Spinning icons
+- Measuring line length in distance units


### PR DESCRIPTION
References https://github.com/mapbox/mapbox-android-demo/issues/1200. This pr makes changes to release the `8.3.0` version of this app as part of the Maps SDK's `8.3.0` post-release process.