### PR TITLE
Adding example of directions route with 2-color gradient styling

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -63,6 +63,7 @@ import com.mapbox.mapboxandroiddemo.examples.extrusions.MarathonExtrusionActivit
 import com.mapbox.mapboxandroiddemo.examples.extrusions.PopulationDensityExtrusionActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.RotationExtrusionActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.DirectionsActivity;
+import com.mapbox.mapboxandroiddemo.examples.javaservices.DirectionsGradientLineActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.GeocodingActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.IsochroneActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.IsochroneSeekbarActivity;
@@ -1050,6 +1051,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, TurfLineDistanceActivity.class),
       null,
       R.string.activity_java_services_turf_line_distance_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_java_services,
+      R.string.activity_java_services_directions_gradient_title,
+      R.string.activity_java_services_directions_gradient_description,
+      new Intent(MainActivity.this, DirectionsGradientLineActivity.class),
+      null,
+      R.string.activity_java_services_directions_gradient_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_snapshot_image_generator,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -279,6 +279,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.javaservices.DirectionsGradientLineActivity"
+            android:label="@string/activity_java_services_directions_gradient_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.RecyclerViewDirectionsActivity"
             android:label="@string/activity_lab_rv_directions_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/DirectionsActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/DirectionsActivity.java
@@ -32,6 +32,7 @@ import retrofit2.Response;
 import timber.log.Timber;
 
 import static com.mapbox.core.constants.Constants.PRECISION_6;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
@@ -109,7 +110,7 @@ public class DirectionsActivity extends AppCompatActivity {
   }
 
   /**
-   * Add the route and maker icon layers to the map
+   * Add the route and marker icon layers to the map
    */
   private void initLayers(@NonNull Style loadedMapStyle) {
     LineLayer routeLayer = new LineLayer(ROUTE_LAYER_ID, ROUTE_SOURCE_ID);
@@ -131,8 +132,8 @@ public class DirectionsActivity extends AppCompatActivity {
     loadedMapStyle.addLayer(new SymbolLayer(ICON_LAYER_ID, ICON_SOURCE_ID).withProperties(
       iconImage(RED_PIN_ICON_ID),
       iconIgnorePlacement(true),
-      iconIgnorePlacement(true),
-      iconOffset(new Float[] {0f, -4f})));
+      iconAllowOverlap(true),
+      iconOffset(new Float[] {0f, -9f})));
   }
 
   /**
@@ -154,8 +155,6 @@ public class DirectionsActivity extends AppCompatActivity {
     client.enqueueCall(new Callback<DirectionsResponse>() {
       @Override
       public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
-        System.out.println(call.request().url().toString());
-
         // You can get the generic HTTP info about the response
         Timber.d("Response code: " + response.code());
         if (response.body() == null) {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/DirectionsGradientLineActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/DirectionsGradientLineActivity.java
@@ -1,0 +1,306 @@
+package com.mapbox.mapboxandroiddemo.examples.javaservices;
+
+import android.os.Bundle;
+import android.widget.Toast;
+
+import com.mapbox.api.directions.v5.DirectionsCriteria;
+import com.mapbox.api.directions.v5.MapboxDirections;
+import com.mapbox.api.directions.v5.models.DirectionsResponse;
+import com.mapbox.api.directions.v5.models.DirectionsRoute;
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.layers.Property;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonOptions;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import timber.log.Timber;
+
+import static android.graphics.Color.parseColor;
+import static com.mapbox.core.constants.Constants.PRECISION_6;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.color;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.interpolate;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.lineProgress;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.linear;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.match;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.stop;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineGradient;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+
+/**
+ * Make a directions request with the Mapbox Directions API and then draw a line behind a moving
+ * SymbolLayer icon which moves along the Directions response route.
+ */
+public class DirectionsGradientLineActivity extends AppCompatActivity implements MapboxMap.OnMapClickListener {
+
+  private static final String ORIGIN_ICON_ID = "origin-icon-id";
+  private static final String DESTINATION_ICON_ID = "destination-icon-id";
+  private static final String ROUTE_LAYER_ID = "route-layer-id";
+  private static final String ROUTE_LINE_SOURCE_ID = "route-source-id";
+  private static final String ICON_LAYER_ID = "icon-layer-id";
+  private static final String ICON_SOURCE_ID = "icon-source-id";
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private DirectionsRoute currentRoute;
+  private MapboxDirections client;
+
+  // Adjust variables below to change the example's UI
+  private static Point ORIGIN_POINT = Point.fromLngLat(106.7140180, -6.149120972);
+  private static Point DESTINATION_POINT = Point.fromLngLat(106.9687635, -6.304752436);
+  private static final float LINE_WIDTH = 6f;
+  private static final String ORIGIN_COLOR = "#2096F3";
+  private static final String DESTINATION_COLOR = "#F84D4D";
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_javaservices_directions_gradient);
+
+    // Setup the MapView
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+        DirectionsGradientLineActivity.this.mapboxMap = mapboxMap;
+        mapboxMap.setStyle(new Style.Builder().fromUri(Style.DARK)
+          .withImage(ORIGIN_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+            getResources().getDrawable(R.drawable.blue_marker)))
+          .withImage(DESTINATION_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+            getResources().getDrawable(R.drawable.red_marker))), new Style.OnStyleLoaded() {
+              @Override
+                public void onStyleLoaded(@NonNull Style style) {
+                  initSources(style);
+                  initLayers(style);
+
+                  // Get the directions route from the Mapbox Directions API
+                  getRoute(mapboxMap, ORIGIN_POINT, DESTINATION_POINT);
+
+                  mapboxMap.addOnMapClickListener(DirectionsGradientLineActivity.this);
+
+                  Toast.makeText(DirectionsGradientLineActivity.this,
+                    getString(R.string.tap_map_instruction_gradient_directions), Toast.LENGTH_SHORT).show();
+              }
+            });
+      }
+    });
+  }
+
+  /**
+   * Add the route and marker sources to the map
+   */
+  private void initSources(@NonNull Style loadedMapStyle) {
+    loadedMapStyle.addSource(new GeoJsonSource(ROUTE_LINE_SOURCE_ID, new GeoJsonOptions().withLineMetrics(true)));
+    loadedMapStyle.addSource(new GeoJsonSource(ICON_SOURCE_ID, getOriginAndDestinationFeatureCollection()));
+  }
+
+  /**
+   * Util method that returns a {@link FeatureCollection} with the latest origin and destination locations.
+   *
+   * @return a {@link FeatureCollection} to be used for creating a new {@link GeoJsonSource} or
+   * updating a source's GeoJSON.
+   */
+  private FeatureCollection getOriginAndDestinationFeatureCollection() {
+    Feature originFeature = Feature.fromGeometry(ORIGIN_POINT);
+    originFeature.addStringProperty("originDestination", "origin");
+    Feature destinationFeature = Feature.fromGeometry(DESTINATION_POINT);
+    destinationFeature.addStringProperty("originDestination", "destination");
+    return FeatureCollection.fromFeatures(new Feature[] {originFeature, destinationFeature});
+  }
+
+  /**
+   * Add the route and marker icon layers to the map
+   */
+  private void initLayers(@NonNull Style loadedMapStyle) {
+    // Add the LineLayer to the map. This layer will display the directions route.
+    loadedMapStyle.addLayer(new LineLayer(ROUTE_LAYER_ID, ROUTE_LINE_SOURCE_ID).withProperties(
+      lineCap(Property.LINE_CAP_ROUND),
+      lineJoin(Property.LINE_JOIN_ROUND),
+      lineWidth(LINE_WIDTH),
+      lineGradient(interpolate(
+        linear(), lineProgress(),
+
+        // This is where the gradient color effect is set. 0 -> 1 makes it a two-color gradient
+        // See LineGradientActivity for an example of a 2+ multiple color gradient line.
+        stop(0f, color(parseColor(ORIGIN_COLOR))),
+        stop(1f, color(parseColor(DESTINATION_COLOR)))
+      ))));
+
+    // Add the SymbolLayer to the map to show the origin and destination pin markers
+    loadedMapStyle.addLayer(new SymbolLayer(ICON_LAYER_ID, ICON_SOURCE_ID).withProperties(
+      iconImage(match(get("originDestination"), literal("origin"),
+        stop("origin", ORIGIN_ICON_ID),
+        stop("destination", DESTINATION_ICON_ID))),
+      iconIgnorePlacement(true),
+      iconAllowOverlap(true),
+      iconOffset(new Float[] {0f, -4f})));
+  }
+
+  /**
+   * Make a request to the Mapbox Directions API. Once successful, pass the route to the
+   * route layer.
+   *
+   * @param mapboxMap   the Mapbox map object that the route will be drawn on
+   * @param origin      the starting point of the route
+   * @param destination the desired finish point of the route
+   */
+  private void getRoute(MapboxMap mapboxMap, Point origin, Point destination) {
+    client = MapboxDirections.builder()
+      .origin(origin)
+      .destination(destination)
+      .overview(DirectionsCriteria.OVERVIEW_FULL)
+      .profile(DirectionsCriteria.PROFILE_WALKING)
+      .accessToken(getString(R.string.access_token))
+      .build();
+    client.enqueueCall(new Callback<DirectionsResponse>() {
+      @Override
+      public void onResponse(Call<DirectionsResponse> call, Response<DirectionsResponse> response) {
+        // You can get the generic HTTP info about the response
+        Timber.d("Response code: %s", response.code());
+
+        if (response.body() == null) {
+          Timber.e("No routes found, make sure you set the right user and access token.");
+          return;
+        } else if (response.body().routes().size() < 1) {
+          Timber.e("No routes found");
+          return;
+        }
+
+        // Get the Direction API response's route
+        currentRoute = response.body().routes().get(0);
+
+        if (currentRoute != null) {
+          if (mapboxMap != null) {
+            mapboxMap.getStyle(new Style.OnStyleLoaded() {
+              @Override
+              public void onStyleLoaded(@NonNull Style style) {
+
+                // Retrieve and update the source designated for showing the directions route
+                GeoJsonSource originDestinationPointGeoJsonSource = style.getSourceAs(ICON_SOURCE_ID);
+
+                if (originDestinationPointGeoJsonSource != null) {
+                  originDestinationPointGeoJsonSource.setGeoJson(getOriginAndDestinationFeatureCollection());
+                }
+
+                // Retrieve and update the source designated for showing the directions route
+                GeoJsonSource lineLayerRouteGeoJsonSource = style.getSourceAs(ROUTE_LINE_SOURCE_ID);
+
+                // Create a LineString with the directions route's geometry and
+                // reset the GeoJSON source for the route LineLayer source
+                if (lineLayerRouteGeoJsonSource != null) {
+                  // Create the LineString from the list of coordinates and then make a GeoJSON
+                  // FeatureCollection so we can add the line to our map as a layer.
+                  LineString lineString = LineString.fromPolyline(currentRoute.geometry(), PRECISION_6);
+                  lineLayerRouteGeoJsonSource.setGeoJson(Feature.fromGeometry(lineString));
+                }
+              }
+            });
+          }
+        } else {
+          Timber.d("Directions route is null");
+          Toast.makeText(DirectionsGradientLineActivity.this,
+            getString(R.string.route_can_not_be_displayed), Toast.LENGTH_SHORT).show();
+        }
+      }
+
+      @Override
+      public void onFailure(Call<DirectionsResponse> call, Throwable throwable) {
+        Toast.makeText(DirectionsGradientLineActivity.this,
+            getString(R.string.route_call_failure), Toast.LENGTH_SHORT).show();
+      }
+    });
+  }
+
+
+  @Override
+  public boolean onMapClick(@NonNull LatLng mapClickPoint) {
+    // Move the destination point to wherever the map was tapped
+    DESTINATION_POINT = Point.fromLngLat(mapClickPoint.getLongitude(), mapClickPoint.getLatitude());
+
+    // Get a new Directions API route to that new destination and eventually re-draw the
+    // gradient route line.
+    getRoute(mapboxMap, ORIGIN_POINT, DESTINATION_POINT);
+    return true;
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    // Cancel the Directions API request
+    if (client != null) {
+      client.cancelCall();
+    }
+    if (mapboxMap != null) {
+      mapboxMap.removeOnMapClickListener(this);
+    }
+    mapView.onDestroy();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+}
+
+

--- a/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_directions_gradient.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_directions_gradient.xml
@@ -11,8 +11,8 @@
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        mapbox:mapbox_cameraTargetLat="38.875"
-        mapbox:mapbox_cameraTargetLng="-77.035"
-        mapbox:mapbox_cameraZoom="12" />
+        mapbox:mapbox_cameraTargetLat="-6.161038"
+        mapbox:mapbox_cameraTargetLng="106.825398"
+        mapbox:mapbox_cameraZoom="9.8" />
 
 </FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -436,4 +436,9 @@
     <string name="line_distance_tap_instruction">Tap on map at least twice to create and measure a line</string>
     <string name="line_distance_textview">Line distance in %1$s: %2$s</string>
 
+    <!-- Directions route gradient -->
+    <string name="route_can_not_be_displayed">The directions route can\'t be displayed at this time</string>
+    <string name="route_call_failure">Directions API call failed. Try again later.</string>
+    <string name="tap_map_instruction_gradient_directions">Tap the map to change the route destination.</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -97,6 +97,7 @@
     <string name="activity_java_services_turf_ring_description">Use Turf to calculate coordinates to eventually draw a ring around a center coordinate.</string>
     <string name="activity_java_services_turf_physical_circle_description">Use Turf to generate a circle with a radius expressed in physical units (e.g. miles, kilometers, etc).</string>
     <string name="activity_java_services_turf_line_distance_description">Use Turf to generate a circle with a radius expressed in physical units (e.g. miles, kilometers, etc).</string>
+    <string name="activity_java_services_directions_gradient_description">Apply a two-color gradient to a Directions API route line.</string>
     <string name="activity_plugins_traffic_plugin_description">Use the traffic plugin to display live car congestion data on top of a map.</string>
     <string name="activity_plugins_building_plugin_description">Use the building plugin to easily display 3D building height</string>
     <string name="activity_plugins_geojson_plugin_description">Easily retrieve GeoJSON data from a url, asset, or path</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -95,6 +95,7 @@
     <string name="activity_java_services_turf_ring_title">Hollow circle</string>
     <string name="activity_java_services_turf_physical_circle_title">Define a circle in physical units</string>
     <string name="activity_java_services_turf_line_distance_title">Measure line distance</string>
+    <string name="activity_java_services_directions_gradient_title">Directions route with gradient</string>
     <string name="activity_plugins_traffic_plugin_title">Display real-time traffic</string>
     <string name="activity_plugins_building_plugin_title">Display buildings in 3D</string>
     <string name="activity_plugins_localization_plugin_title">Change map text to device language</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -91,6 +91,7 @@
     <string name="activity_java_services_isochrone_with_seekbar_url" translatable="false">https://i.imgur.com/hCVswtE.png</string>
     <string name="activity_java_services_tilequery_url" translatable="false">http://i.imgur.com/VkOCYwq.jpg</string>
     <string name="activity_java_services_turf_line_distance_url" translatable="false">https://i.imgur.com/dQLvi1t.png</string>
+    <string name="activity_java_services_directions_gradient_url" translatable="false">https://i.imgur.com/TXCn9QH.png</string>
     <string name="activity_java_services_simplify_polyline_url" translatable="false">http://i.imgur.com/uATgul1.png</string>
     <string name="activity_java_services_map_matching_url" translatable="false">https://i.imgur.com/ig8gGnY.png</string>
     <string name="activity_java_services_turf_ring_url" translatable="false">https://i.imgur.com/nG8xeXH.png</string>


### PR DESCRIPTION
This pr adds an example of showing a Directions API route with 2-color gradient styling. Basically, a combination of `DirectionsActivity` and `LineGradientActivity`. 

This pr also makes some small tweaks to related examples.

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/64393266-7a7df600-d005-11e9-9be9-5a6fba49c317.gif)
