### PR TITLE
Disabling R8 usage for shrinking

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,6 +39,7 @@ jobs:
             echo "android.useAndroidX=true" >> gradle.properties
             echo "android.enableJetifier=true" >> gradle.properties
             echo "org.gradle.jvmargs=-Xmx4608M" >> gradle.properties
+            echo "android.enableR8=false" >> gradle.properties
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=false


### PR DESCRIPTION
R8 is causing some issues with releasing the app to the Play Store. Seems that others have had R8 blocking releases

https://circleci.com/gh/mapbox/mapbox-android-demo/2526

![Screen Shot 2019-09-06 at 11 21 06 AM](https://user-images.githubusercontent.com/4394910/64451476-24f32900-d099-11e9-89aa-1c11f5a429e5.png)


Proguard is fine for now. This pr disables R8 usage.