### PR TITLE
Adding attribution color change example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -80,6 +80,7 @@ import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfPhysicalCircleActi
 import com.mapbox.mapboxandroiddemo.examples.labs.AnimatedImageGifActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.AnimatedMarkerActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.CalendarIntegrationActivity;
+import com.mapbox.mapboxandroiddemo.examples.labs.ChangeAttributionColorActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.DashedLineDirectionsPickerActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.HomeScreenWidgetActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.IndoorMapActivity;
@@ -1259,6 +1260,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, SpinningSymbolLayerIconActivity.class),
       null,
       R.string.activity_lab_spinning_icon_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_lab,
+      R.string.activity_lab_change_attribution_color_title,
+      R.string.activity_lab_change_attribution_color_description,
+      new Intent(MainActivity.this, ChangeAttributionColorActivity.class),
+      null,
+      R.string.activity_lab_change_attribution_color_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_dds,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -300,6 +300,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.labs.ChangeAttributionColorActivity"
+            android:label="@string/activity_lab_change_attribution_color_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.AnimatedImageGifActivity"
             android:label="@string/activity_labs_gif_on_map_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/ChangeAttributionColorActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/ChangeAttributionColorActivity.java
@@ -1,0 +1,135 @@
+package com.mapbox.mapboxandroiddemo.examples.labs;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.ImageView;
+
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+
+/**
+ * Adjust the Maps SDK's attribution ImageView color so that it matches the map style or app UI
+ */
+public class ChangeAttributionColorActivity extends AppCompatActivity implements OnMapReadyCallback {
+
+  private static final String CUSTOM_GREEN_MONOCHROME_STYLE_URI =
+      "mapbox://styles/appsatmapboxcom/ck0cyq1lt0bbo1cmwkpf2w7g9";
+  private MapView mapView;
+  private ImageView attributionView;
+  private int index = 0;
+  private int[] attributionColors;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    attributionColors = new int[] {
+      Color.RED,
+      Color.BLUE,
+      Color.YELLOW,
+      ContextCompat.getColor(this, R.color.colorAccent), // a runtime app UI color
+      ContextCompat.getColor(this, R.color.colorPrimaryDark), // a runtime app UI color
+      Color.parseColor("#1e7019"), // dark green
+    };
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    setContentView(R.layout.activity_lab_change_attribution_info_button_color);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+    mapboxMap.setStyle(Style.LIGHT, new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        // Get the ImageView from the MapView
+        attributionView = mapView.findViewById(R.id.attributionView);
+
+        // Change the color when the floating action button is clicked
+        findViewById(R.id.switch_attribution_color_fab).setOnClickListener(new View.OnClickListener() {
+          @Override
+          public void onClick(View view) {
+            if (index == attributionColors.length - 1) {
+              mapboxMap.setStyle(Style.LIGHT);
+              index = 0;
+            }
+
+            // Adjust map to the Maps SDK's Dark style
+            if (index == 2) {
+              mapboxMap.setStyle(Style.DARK);
+            }
+
+            // Adjust map to a custom monochrome dark green style to match the
+            // "i" attribution's dark green color
+            if (index == 4) {
+              mapboxMap.setStyle(new Style.Builder()
+                  .fromUri(CUSTOM_GREEN_MONOCHROME_STYLE_URI));
+            }
+
+            // Change the color of the "i" attribution button
+            attributionView.setColorFilter(attributionColors[index]);
+
+            index++;
+          }
+        });
+      }
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_lab_change_attribution_info_button_color.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_lab_change_attribution_info_button_color.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/switch_attribution_color_fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|right"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_swap_horiz_white_24dp"
+        mapbox:fabSize="normal" />
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -138,6 +138,7 @@
     <string name="activity_lab_home_screen_widget_description">Show the device\'s current location or other information in a homescreen widget.</string>
     <string name="activity_lab_rv_directions_description">Quickly show the directions route associated with a RecyclerView item.</string>
     <string name="activity_lab_spinning_icon_description">Use a ValueAnimator to adjust SymbolLayer icons\' rotation values and create a spinning effect.</string>
+    <string name="activity_lab_change_attribution_color_description">Adjust the attribution "i" to match a map style, app UI, or color motif.</string>
     <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
 
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -137,4 +137,5 @@
     <string name="activity_lab_home_screen_widget_title">Homescreen geocoding widget</string>
     <string name="activity_lab_rv_directions_title">RecyclerView Directions</string>
     <string name="activity_lab_spinning_icon_title">Spinning icon</string>
+    <string name="activity_lab_change_attribution_color_title">Style attribution</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -137,5 +137,6 @@
     <string name="activity_lab_home_screen_widget_url" translatable="false">https://i.imgur.com/H5N9jDn.png</string>
     <string name="activity_lab_rv_directions_url" translatable="false">https://i.imgur.com/LurOuXQ.png</string>
     <string name="activity_lab_spinning_icon_url" translatable="false">https://i.imgur.com/jxQpAt2.png</string>
+    <string name="activity_lab_change_attribution_color_url" translatable="false">https://i.imgur.com/cGv98jb.png</string>
     <string name="activity_china_simple_china_mapview_url" translatable="false">https://i.imgur.com/KwoEynZ.png</string>
 </resources>


### PR DESCRIPTION
This pr adds an example of how to change the color of the `i` attribution button. The color can be changed to match the map style, in-app UI, or some other motif.


![ezgif com-resize (2)](https://user-images.githubusercontent.com/4394910/64571965-60505a80-d31a-11e9-8f89-ddbff991e35f.gif)
