### PR TITLE
Adding example of saving and retrieving coordinates in shared preferences

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -95,6 +95,7 @@ import com.mapbox.mapboxandroiddemo.examples.labs.PictureInPictureActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.PulsingLayerOpacityColorActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.RecyclerViewDirectionsActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.RecyclerViewOnMapActivity;
+import com.mapbox.mapboxandroiddemo.examples.labs.SharedPreferencesActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SnakingDirectionsRouteActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SpaceStationLocationActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SpinningSymbolLayerIconActivity;
@@ -1277,6 +1278,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       new Intent(MainActivity.this, ChangeAttributionColorActivity.class),
       null,
       R.string.activity_lab_change_attribution_color_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+        R.id.nav_lab,
+        R.string.activity_lab_shared_preferences_title,
+        R.string.activity_lab_shared_preferences_description,
+        new Intent(MainActivity.this, SharedPreferencesActivity.class),
+        null,
+        R.string.activity_lab_shared_preferences_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_dds,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -286,6 +286,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.labs.SharedPreferencesActivity"
+            android:label="@string/activity_lab_shared_preferences_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.RecyclerViewOnMapActivity"
             android:label="@string/activity_lab_rv_on_map_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TilequeryActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TilequeryActivity.java
@@ -288,6 +288,9 @@ public class TilequeryActivity extends AppCompatActivity implements
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    if (mapboxMap != null) {
+      mapboxMap.removeOnMapClickListener(this);
+    }
     mapView.onDestroy();
   }
 

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SharedPreferencesActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SharedPreferencesActivity.java
@@ -1,0 +1,247 @@
+package com.mapbox.mapboxandroiddemo.examples.labs;
+
+import android.content.SharedPreferences;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.camera.CameraPosition;
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOffset;
+
+
+/**
+ * Use shared preferences to save and retrieve data, so that the data can be displayed after closing the app.
+ */
+public class SharedPreferencesActivity extends AppCompatActivity implements OnMapReadyCallback,
+  MapboxMap.OnMapClickListener {
+
+  private static final String SAVED_LAT_KEY = "SAVED_LAT_KEY";
+  private static final String SAVED_LONG_KEY = "SAVED_LONG_KEY";
+  private static final String CLICK_LOCATION_SOURCE_ID = "CLICK_LOCATION_SOURCE_ID";
+  private static final String CLICK_LOCATION_ICON_ID = "CLICK_LOCATION_ICON_ID";
+  private static final String CLICK_LOCATION_LAYER_ID = "CLICK_LOCATION_LAYER_ID";
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private SharedPreferences sharedPreferences;
+  private TextView longTextView;
+  private TextView latTextView;
+  private double savedLat;
+  private double savedLong;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_lab_shared_preferences);
+
+    longTextView = findViewById(R.id.shared_pref_saved_long_textview);
+    latTextView = findViewById(R.id.shared_pref_saved_lat_textview);
+    longTextView.setText(String.format(getString(R.string.saved_long_textview), String.valueOf(0)));
+    latTextView.setText(String.format(getString(R.string.saved_lat_textview), String.valueOf(0)));
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(this);
+  }
+
+  @Override
+  public void onMapReady(@NonNull MapboxMap mapboxMap) {
+    SharedPreferencesActivity.this.mapboxMap = mapboxMap;
+    mapboxMap.setStyle(
+
+      // Set the map to Mapbox's daytime traffic style
+      new Style.Builder().fromUri(Style.TRAFFIC_DAY)
+
+      // Add the SymbolLayer icon image to the map style
+      .withImage(CLICK_LOCATION_ICON_ID, BitmapFactory.decodeResource(
+        SharedPreferencesActivity.this.getResources(), R.drawable.red_marker))
+
+      // Adding a GeoJson source for the SymbolLayer icons.
+      .withSource(new GeoJsonSource(CLICK_LOCATION_SOURCE_ID))
+
+      // Adding the actual SymbolLayer to the map style. An offset is added that the bottom of the red
+      // marker icon gets fixed to the coordinate, rather than the middle of the icon being fixed to
+      // the coordinate point. This is offset is not always needed and is dependent on the image
+      // that you use for the SymbolLayer icon.
+      .withLayer(new SymbolLayer(CLICK_LOCATION_LAYER_ID, CLICK_LOCATION_SOURCE_ID)
+        .withProperties(PropertyFactory.iconImage(CLICK_LOCATION_ICON_ID),
+          iconAllowOverlap(true),
+          iconOffset(new Float[] {0f, -9f}))
+      ), new Style.OnStyleLoaded() {
+          @Override
+          public void onStyleLoaded(@NonNull Style style) {
+
+            mapboxMap.addOnMapClickListener(SharedPreferencesActivity.this);
+
+            // Get the coordinates from shared preferences
+            savedLong = getCoordinateFromSharedPref(SAVED_LONG_KEY);
+            savedLat = getCoordinateFromSharedPref(SAVED_LAT_KEY);
+
+            // Coordinates haven't been saved if both == 0
+            if (savedLong == 0 && savedLat == 0) {
+              Toast.makeText(SharedPreferencesActivity.this,
+                getString(R.string.tap_on_map_save_to_shared_pref), Toast.LENGTH_SHORT).show();
+
+              longTextView.setText(String.format(getString(R.string.saved_long_textview),
+                getString(R.string.not_saved_yet)));
+              latTextView.setText(String.format(getString(R.string.saved_lat_textview),
+                getString(R.string.not_saved_yet)));
+
+            } else {
+
+              // Move the camera to the previously-saved coordinates
+              mapboxMap.animateCamera(CameraUpdateFactory
+                .newCameraPosition(new CameraPosition.Builder()
+                  .target(new LatLng(savedLat, savedLong))
+                  .zoom(4)
+                  .build()), 1200);
+
+              Toast.makeText(SharedPreferencesActivity.this,
+                getString(R.string.shared_pref_marker_placement), Toast.LENGTH_SHORT).show();
+
+              // Move the marker to the previously-saved coordinates
+              moveMarkerToLngLat(savedLong, savedLat);
+
+              longTextView.setText(String.format(
+                getString(R.string.saved_long_textview), String.valueOf(savedLong)));
+
+              latTextView.setText(String.format(
+                getString(R.string.saved_lat_textview), String.valueOf(savedLat)));
+            }
+          }
+      });
+  }
+
+  @Override
+  public boolean onMapClick(@NonNull LatLng mapClickPoint) {
+    double clickLatitude = mapClickPoint.getLatitude();
+    double clickLongitude = mapClickPoint.getLongitude();
+
+    longTextView.setText(String.format(
+        getString(R.string.saved_long_textview), String.valueOf(clickLongitude)));
+    latTextView.setText(String.format(
+        getString(R.string.saved_lat_textview), String.valueOf(clickLatitude)));
+
+    // Save the map click point coordinates to shared preferences
+    if (sharedPreferences != null) {
+      putCoordinateToSharedPref(SAVED_LAT_KEY, clickLatitude);
+      putCoordinateToSharedPref(SAVED_LONG_KEY, clickLongitude);
+    }
+
+    // Move the marker to the newly-saved coordinates
+    moveMarkerToLngLat(clickLongitude, clickLatitude);
+    return true;
+  }
+
+  /**
+   * Move the SymbolLayer icon to a new location
+   *
+   * @param newLong the new longitude
+   * @param newLat  the new latitude
+   */
+  private void moveMarkerToLngLat(double newLong, double newLat) {
+    // Move and display the click center layer's red marker icon to
+    // wherever the map was clicked on
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        GeoJsonSource clickLocationSource = style.getSourceAs(CLICK_LOCATION_SOURCE_ID);
+        if (clickLocationSource != null) {
+          clickLocationSource.setGeoJson(Point.fromLngLat(newLong, newLat));
+        }
+      }
+    });
+  }
+
+  /**
+   * Save a specific number to shared preferences
+   *
+   * @param key   the number's key
+   * @param value the actual number
+   */
+  private void putCoordinateToSharedPref(final String key, final double value) {
+    sharedPreferences.edit().putLong(key, Double.doubleToRawLongBits(value)).apply();
+  }
+
+  /**
+   * Retrieve a specific number from shared preferences
+   *
+   * @param key the key to use for retrieval
+   * @return the saved number
+   */
+  double getCoordinateFromSharedPref(final String key) {
+    return Double.longBitsToDouble(sharedPreferences.getLong(key, 0));
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    if (mapboxMap != null) {
+      mapboxMap.removeOnMapClickListener(this);
+    }
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_lab_shared_preferences.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_lab_shared_preferences.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.basics.SimpleMapViewActivity">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline10"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        mapbox:layout_constraintGuide_begin="512dp" />
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        mapbox:layout_constraintBottom_toTopOf="@+id/guideline10"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/shared_pref_saved_lat_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginLeft="32dp"
+        android:layout_marginTop="24dp"
+        android:text="@string/saved_lat_textview"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="@+id/guideline10" />
+
+    <TextView
+        android:id="@+id/shared_pref_saved_long_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginLeft="32dp"
+        android:layout_marginTop="24dp"
+        android:text="@string/saved_long_textview"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toBottomOf="@+id/shared_pref_saved_lat_textview" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -453,4 +453,11 @@
     <string name="elevation_tilequery_api_response_error">Error with the request. Do you have internet access?</string>
     <string name="elevation_tilequery_no_features">No features in the response.</string>
     <string name="elevation_numbers_only_textview">%1$d Features in the API response: %2$s</string>
+
+    <!-- Shared preferences save -->
+    <string name="not_saved_yet">Not saved yet</string>
+    <string name="saved_lat_textview">Saved latitude: %1$s</string>
+    <string name="saved_long_textview">Saved longitude: %1$s</string>
+    <string name="tap_on_map_save_to_shared_pref">Tap on the map to save coordinates to the device\'s Shared Preferences</string>
+    <string name="shared_pref_marker_placement">Marker placed at coordinates saved in Shared Preferences.</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -140,6 +140,7 @@
     <string name="activity_lab_rv_directions_description">Quickly show the directions route associated with a RecyclerView item.</string>
     <string name="activity_lab_spinning_icon_description">Use a ValueAnimator to adjust SymbolLayer icons\' rotation values and create a spinning effect.</string>
     <string name="activity_lab_change_attribution_color_description">Adjust the attribution "i" to match a map style, app UI, or color motif.</string>
+    <string name="activity_lab_shared_preferences_description">Use the Android system\'s Shared Preferences to save and retrieve coordinates.</string>
     <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
 
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -139,4 +139,5 @@
     <string name="activity_lab_rv_directions_title">RecyclerView Directions</string>
     <string name="activity_lab_spinning_icon_title">Spinning icon</string>
     <string name="activity_lab_change_attribution_color_title">Style attribution</string>
+    <string name="activity_lab_shared_preferences_title">Shared preferences</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -139,5 +139,6 @@
     <string name="activity_lab_rv_directions_url" translatable="false">https://i.imgur.com/LurOuXQ.png</string>
     <string name="activity_lab_spinning_icon_url" translatable="false">https://i.imgur.com/jxQpAt2.png</string>
     <string name="activity_lab_change_attribution_color_url" translatable="false">https://i.imgur.com/cGv98jb.png</string>
+    <string name="activity_lab_shared_preferences_url" translatable="false">https://i.imgur.com/znxAhDG.png</string>
     <string name="activity_china_simple_china_mapview_url" translatable="false">https://i.imgur.com/KwoEynZ.png</string>
 </resources>


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1209 by adding an example that shows how to save coordinates and retrieve them to display a marker. cc @Presidente27 who requested this in https://github.com/mapbox/mapbox-android-demo/issues/1209


![ezgif com-resize](https://user-images.githubusercontent.com/4394910/64981732-7fe30800-d871-11e9-82e2-513e8180a0c7.gif)


