### PR TITLE
Proguard tweak to remove { *; } where needed

### DIFF
--- a/MapboxAndroidDemo/proguard-rules.pro
+++ b/MapboxAndroidDemo/proguard-rules.pro
@@ -120,9 +120,9 @@
 -keep class com.mapbox.android.core.location.**
 -keep class android.arch.lifecycle.** { *; }
 -keep class com.mapbox.android.core.location.** { *; }
--dontnote class com.mapbox.mapboxsdk.** { *; }
--dontnote class com.mapbox.android.gestures.** { *; }
--dontnote class com.mapbox.mapboxsdk.plugins.** { *; }
+-dontnote class com.mapbox.mapboxsdk.**
+-dontnote class com.mapbox.android.gestures.**
+-dontnote class com.mapbox.mapboxsdk.plugins.**
 
 # Other Android
 -dontnote android.net.http.*

--- a/MapboxAndroidWearDemo/proguard-rules.pro
+++ b/MapboxAndroidWearDemo/proguard-rules.pro
@@ -97,9 +97,9 @@
 -keep class com.mapbox.android.core.location.**
 -keep class android.arch.lifecycle.** { *; }
 -keep class com.mapbox.android.core.location.** { *; }
--dontnote class com.mapbox.mapboxsdk.** { *; }
--dontnote class com.mapbox.android.gestures.** { *; }
--dontnote class com.mapbox.mapboxsdk.plugins.** { *; }
+-dontnote class com.mapbox.mapboxsdk.**
+-dontnote class com.mapbox.android.gestures.**
+-dontnote class com.mapbox.mapboxsdk.plugins.**
 
 # Other Android
 -keep public class com.google.firebase.** { public *; }


### PR DESCRIPTION
Follow up to https://github.com/mapbox/mapbox-android-demo/pull/1174 and #1211 . This pr removes `{ *; }` from the `dontnote` lines because I got the following 💥 in CircleCI when releasing to the play store. The other `dontnote` lines don't have `{ *; }`  .

<img width="997" alt="Screen Shot 2019-09-17 at 9 02 24 AM" src="https://user-images.githubusercontent.com/4394910/65058883-e592cb00-d929-11e9-82b0-bf7dd3f788b7.png">
