### PR TITLE
Removed `class` where needed in proguard rules

### DIFF
--- a/MapboxAndroidDemo/proguard-rules.pro
+++ b/MapboxAndroidDemo/proguard-rules.pro
@@ -120,9 +120,9 @@
 -keep class com.mapbox.android.core.location.**
 -keep class android.arch.lifecycle.** { *; }
 -keep class com.mapbox.android.core.location.** { *; }
--dontnote class com.mapbox.mapboxsdk.**
--dontnote class com.mapbox.android.gestures.**
--dontnote class com.mapbox.mapboxsdk.plugins.**
+-dontnote com.mapbox.mapboxsdk.**
+-dontnote com.mapbox.android.gestures.**
+-dontnote com.mapbox.mapboxsdk.plugins.**
 
 # Other Android
 -dontnote android.net.http.*

--- a/MapboxAndroidWearDemo/proguard-rules.pro
+++ b/MapboxAndroidWearDemo/proguard-rules.pro
@@ -97,9 +97,9 @@
 -keep class com.mapbox.android.core.location.**
 -keep class android.arch.lifecycle.** { *; }
 -keep class com.mapbox.android.core.location.** { *; }
--dontnote class com.mapbox.mapboxsdk.**
--dontnote class com.mapbox.android.gestures.**
--dontnote class com.mapbox.mapboxsdk.plugins.**
+-dontnote com.mapbox.mapboxsdk.**
+-dontnote com.mapbox.android.gestures.**
+-dontnote com.mapbox.mapboxsdk.plugins.**
 
 # Other Android
 -keep public class com.google.firebase.** { public *; }


### PR DESCRIPTION
This pr makes continued adjustments to the proguard files in hopes of a successful play store release. Follow up to https://github.com/mapbox/mapbox-android-demo/pull/1174 and https://github.com/mapbox/mapbox-android-demo/pull/1213

