### PR TITLE
Adding CameraPosition to snapshotter share example

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotShareActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/snapshot/SnapshotShareActivity.java
@@ -101,14 +101,17 @@ public class SnapshotShareActivity extends AppCompatActivity {
         if (mapSnapshotter == null) {
           // Initialize snapshotter with map dimensions and given bounds
           MapSnapshotter.Options options =
-            new MapSnapshotter.Options(width, height).withRegion(latLngBounds).withStyle(style.getUri());
+            new MapSnapshotter.Options(width, height)
+              .withRegion(latLngBounds)
+              .withCameraPosition(mapboxMap.getCameraPosition())
+              .withStyle(style.getUri());
 
           mapSnapshotter = new MapSnapshotter(SnapshotShareActivity.this, options);
         } else {
           // Reuse pre-existing MapSnapshotter instance
           mapSnapshotter.setSize(width, height);
           mapSnapshotter.setRegion(latLngBounds);
-          mapSnapshotter.setRegion(latLngBounds);
+          mapSnapshotter.setCameraPosition(mapboxMap.getCameraPosition());
         }
 
         mapSnapshotter.start(new MapSnapshotter.SnapshotReadyCallback() {


### PR DESCRIPTION
This pr improves https://docs.mapbox.com/android/maps/examples/share-a-snapshot by including the camera's position when the 📸 button is clicked.