### PR TITLE
Maps SDK to v8.4.0 update

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ ext {
 
             // Mapbox
             mapboxMapPrefix          : 'v8',
-            mapboxMapSdk             : '8.3.0',
+            mapboxMapSdk             : '8.4.0',
             mapboxTurf               : '4.9.0',
             mapboxServices           : '4.9.0',
             mapboxPluginBuilding     : '0.6.0',


### PR DESCRIPTION
- [x] `v8.4.0-alpha.2`
- [x] `v8.4.0-beta.1`
- [x] stable `v8.4.0`

Issues found during `v8.4.0-alpha.2` QA:


- https://github.com/mapbox/mapbox-android-demo/pull/1215

- https://github.com/mapbox/mapbox-android-demo/pull/1216