### PR TITLE
Bumped Java SDK Turf and Services to 4.9.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,8 +12,8 @@ ext {
             // Mapbox
             mapboxMapPrefix          : 'v8',
             mapboxMapSdk             : '8.3.0',
-            mapboxTurf               : '4.8.0',
-            mapboxServices           : '4.8.0',
+            mapboxTurf               : '4.9.0',
+            mapboxServices           : '4.9.0',
             mapboxPluginBuilding     : '0.6.0',
             mapboxPluginPlaces       : '0.9.0',
             mapboxPluginLocalization : '0.11.0',


### PR DESCRIPTION
Part of the `4.9.0` release of the Mapbox Java SDK: https://github.com/mapbox/mapbox-java/issues/1070