### PR TITLE
Fixed turf physical circle units image url duplication

### DIFF
--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -95,7 +95,7 @@
     <string name="activity_java_services_simplify_polyline_url" translatable="false">http://i.imgur.com/uATgul1.png</string>
     <string name="activity_java_services_map_matching_url" translatable="false">https://i.imgur.com/ig8gGnY.png</string>
     <string name="activity_java_services_turf_ring_url" translatable="false">https://i.imgur.com/nG8xeXH.png</string>
-    <string name="activity_java_services_turf_physical_circle_url" translatable="false">https://i.imgur.com/nG8xeXH.png</string>
+    <string name="activity_java_services_turf_physical_circle_url" translatable="false">https://i.imgur.com/uPQXVbv.png</string>
     <string name="activity_java_services_multiple_geometries_from_directions_route_url" translatable="false">https://i.imgur.com/Tz35fHA.png</string>
     <string name="activity_java_services_turf_elevation_query_url" translatable="false">https://i.imgur.com/zrE2oSR.png</string>
     <string name="activity_plugins_traffic_plugin_url" translatable="false">http://i.imgur.com/HRriOVR.png</string>


### PR DESCRIPTION
This pr resolves https://github.com/mapbox/mapbox-android-demo/issues/1223 by updating the photo for `TurfPhysicalCircleActivity`.

![uPQXVbv](https://user-images.githubusercontent.com/4394910/65554233-ca9df900-dedd-11e9-9467-a28bc63f0c75.png)
