### PR TITLE
Added -dontwarn proguard rule for java sdk notnull

### DIFF
--- a/MapboxAndroidDemo/proguard-rules.pro
+++ b/MapboxAndroidDemo/proguard-rules.pro
@@ -80,7 +80,7 @@
 -dontwarn java.awt.Color
 -dontwarn com.mapbox.api.staticmap.v1.models.StaticMarkerAnnotation
 -dontwarn com.mapbox.api.staticmap.v1.models.StaticPolylineAnnotation
-
+-dontwarn com.sun.istack.internal.NotNull
 
 ## Android architecture components: Lifecycle
 # LifecycleObserver's empty constructor is considered to be unused by proguard

--- a/MapboxAndroidWearDemo/proguard-rules.pro
+++ b/MapboxAndroidWearDemo/proguard-rules.pro
@@ -91,6 +91,7 @@
 -dontwarn java.awt.Color
 -dontwarn com.mapbox.api.staticmap.v1.models.StaticMarkerAnnotation
 -dontwarn com.mapbox.api.staticmap.v1.models.StaticPolylineAnnotation
+-dontwarn com.sun.istack.internal.NotNull
 
 # Mapbox
 -keep class com.mapbox.android.telemetry.**


### PR DESCRIPTION
This pr adds a proguard rule to resolve a CI issue that blocked the release of the demo app to the Play Store.

<img width="862" alt="Screen Shot 2019-10-02 at 8 55 19 AM" src="https://user-images.githubusercontent.com/4394910/66060382-63da9a00-e4f2-11e9-8ebf-799509ccaff1.png">
<img width="837" alt="Screen Shot 2019-10-02 at 8 55 11 AM" src="https://user-images.githubusercontent.com/4394910/66060383-64733080-e4f2-11e9-8c85-ebf6d669e9de.png">


Similar to https://github.com/mapbox/mapbox-navigation-android/pull/2043/files#diff-db99abd1916f498907ae6c3edd4141a4