### PR TITLE
Adding addtional 4g max heap size declarations

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -96,7 +96,9 @@ android {
         abortOnError false
         disable 'MissingTranslation', 'ExtraTranslation'
     }
-
+    dexOptions {
+        javaMaxHeapSize "4g"
+    }
 }
 
 play {

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ jobs:
           command: |
             echo "android.useAndroidX=true" >> gradle.properties
             echo "android.enableJetifier=true" >> gradle.properties
-            echo "org.gradle.jvmargs=-Xmx4608M" >> gradle.properties
+            echo "org.gradle.jvmargs=-Xmx4608m" >> gradle.properties
             echo "android.enableR8=false" >> gradle.properties
       - run:
           name: Download Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8=false
+org.gradle.jvmargs=-Xmx4608m


### PR DESCRIPTION
This pr declares the set max heap size in additional places as a double down to make sure the preference is correctly captured by CI. I've opened this pr to see whether this will prevent the release process from receiving a `Received 'killed' signal`. 

The `Received 'killed' signal` message is _still_ preventing me from releasing a new version of the app to the Play Store.

https://circleci.com/gh/mapbox/mapbox-android-demo/2618

![Screen Shot 2019-10-07 at 1 41 49 PM](https://user-images.githubusercontent.com/4394910/66347008-3c2b6d80-e908-11e9-9484-cbd925bfb097.png)



Related:

https://circleci.com/blog/how-to-handle-java-oom-errors/

https://discuss.circleci.com/t/build-ending-with-received-killed-signal/20610/2