### PR TITLE
Shortened the latest default.txt file to below 500 characters limit

### DIFF
--- a/MapboxAndroidDemo/src/global/play/release-notes/en-US/default.txt
+++ b/MapboxAndroidDemo/src/global/play/release-notes/en-US/default.txt
@@ -1,17 +1,16 @@
-This update is in line with the 8.4.0 release of the Mapbox Maps SDK for Android and includes several fixes and new examples:
+This update is part of the 8.4.0 release of the Mapbox Maps SDK for Android. New examples include:
 
-- Isochrone API data + seekbar slider
-- RecyclerView + Directions API route
+- Isochrone + seekbar
+- RecyclerView + Directions routes
 - Location change listening
 - Circle radius based on data
 - Runtime styling
-- Define a circle's radius with distance units
+- Circle's radius with distance
 - Cache management
 - Kotlin map fragment
 - Spinning icons
-- Measuring line length in distance units
-- Saving and retrieving coordinates in shared preferences
+- Measuring line distance
+- Saving & retrieving coordinates in shared preferences
 - Elevation query
 - Attribution color change
-- Multiple geometries based on Directions route
-
+- Multiple geometries of Directions route


### PR DESCRIPTION
This pr shortens the latest `default.txt` file to below 500 characters. The text in this file is what's added to the new release notes section of the app on Google Play via the Play Publishing Gradle plugin used in this repo. The text _was_ over 500 characters, which was blocking a new release to Google Play.

![Screen Shot 2019-10-08 at 11 19 10 AM](https://user-images.githubusercontent.com/4394910/66421845-7c005c80-e9bd-11e9-8125-ecd3c5d2630d.png)
