### PR TITLE
Bumped China Plugin dependency to 2.3.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,7 +18,7 @@ ext {
             mapboxPluginPlaces       : '0.9.0',
             mapboxPluginLocalization : '0.11.0',
             mapboxPluginTraffic      : '0.9.0',
-            mapboxChinaPlugin        : '2.2.0',
+            mapboxChinaPlugin        : '2.3.0',
             mapboxPluginMarkerView   : '0.3.0',
             mapboxPluginAnnotation   : '0.7.0',
             mapboxPluginScalebar     : '0.3.0',


### PR DESCRIPTION
This pr bumps the China plugin dependency to `2.3.0` as part of its `2.3.0` release process