### PR TITLE
Switched fromUrl to fromUri in SimpleChinaMapViewActivity

### DIFF
--- a/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/examples/SimpleChinaMapViewActivity.java
+++ b/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/examples/SimpleChinaMapViewActivity.java
@@ -41,7 +41,7 @@ public class SimpleChinaMapViewActivity extends AppCompatActivity {
       @Override
       public void onMapReady(@NonNull MapboxMap mapboxMap) {
         SimpleChinaMapViewActivity.this.mapboxMap = mapboxMap;
-        mapboxMap.setStyle(new Style.Builder().fromUrl(ChinaStyle.MAPBOX_STREETS_CHINESE), new Style.OnStyleLoaded() {
+        mapboxMap.setStyle(new Style.Builder().fromUri(ChinaStyle.MAPBOX_STREETS_CHINESE), new Style.OnStyleLoaded() {
           @Override
           public void onStyleLoaded(@NonNull Style style) {
 
@@ -66,17 +66,17 @@ public class SimpleChinaMapViewActivity extends AppCompatActivity {
     switch (item.getItemId()) {
       case R.id.menu_streets:
         if (mapboxMap != null) {
-          mapboxMap.setStyle(new Style.Builder().fromUrl(ChinaStyle.MAPBOX_STREETS_CHINESE));
+          mapboxMap.setStyle(new Style.Builder().fromUri(ChinaStyle.MAPBOX_STREETS_CHINESE));
         }
         return true;
       case R.id.menu_dark:
         if (mapboxMap != null) {
-          mapboxMap.setStyle(new Style.Builder().fromUrl(ChinaStyle.MAPBOX_DARK_CHINESE));
+          mapboxMap.setStyle(new Style.Builder().fromUri(ChinaStyle.MAPBOX_DARK_CHINESE));
         }
         return true;
       case R.id.menu_light:
         if (mapboxMap != null) {
-          mapboxMap.setStyle(new Style.Builder().fromUrl(ChinaStyle.MAPBOX_LIGHT_CHINESE));
+          mapboxMap.setStyle(new Style.Builder().fromUri(ChinaStyle.MAPBOX_LIGHT_CHINESE));
         }
         return true;
       default:


### PR DESCRIPTION
This pr adjusts `fromUrl` usage to `fromUri` because `fromUrl` is now deprecated.

https://github.com/mapbox/mapbox-android-demo/pull/1120 is related