### PR TITLE
Commented out PlaceSelectionPluginActivity place picker example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -114,7 +114,6 @@ import com.mapbox.mapboxandroiddemo.examples.offline.SimpleOfflineMapActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.BuildingPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.LocalizationPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.MarkerViewPluginActivity;
-import com.mapbox.mapboxandroiddemo.examples.plugins.PlaceSelectionPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.PlacesPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.ScalebarPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.SymbolListenerActivity;
@@ -781,14 +780,17 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       R.string.activity_plugins_localization_plugin_url, false, BuildConfig.MIN_SDK_VERSION)
     );
 
-    exampleItemModels.add(new ExampleItemModel(
-      R.id.nav_plugins,
-      R.string.activity_plugins_place_picker_plugin_title,
-      R.string.activity_plugins_place_picker_plugin_description,
-      new Intent(MainActivity.this, PlaceSelectionPluginActivity.class),
-      null,
-      R.string.activity_plugins_place_picker_plugin_url, false, BuildConfig.MIN_SDK_VERSION)
-    );
+    // TODO: The example below is currently commented out because it crashes due
+    //  to incompatibility between the Mapbox Places Plugin and this app's usage
+    //  of AndroidX. This is being tracked at:
+    //  https://github.com/mapbox/mapbox-plugins-android/issues/908
+    /* exampleItemModels.add(new ExampleItemModel(
+    R.id.nav_plugins,
+    R.string.activity_plugins_place_picker_plugin_title,
+    R.string.activity_plugins_place_picker_plugin_description,
+    new Intent(MainActivity.this, PlaceSelectionPluginActivity.class),
+    null, R.string.activity_plugins_place_picker_plugin_url, false, BuildConfig.MIN_SDK_VERSION)
+    );*/
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_plugins,


### PR DESCRIPTION
This pr resolves https://github.com/mapbox/mapbox-android-demo/issues/1164 (kinda') by commenting out `PlaceSelectionPluginActivity` from the MainActivity.java example list. The example will remain in this repo's codebase, but won't be selectable in the actual Plugins section of the app. 

As it says in #1164, all of this stems from AndroidX (in)compatibility: https://github.com/mapbox/mapbox-plugins-android/issues/908


No point in keeping it in the app UI and having it keep crashing when tapped on, until we solve https://github.com/mapbox/mapbox-plugins-android/issues/908