### PR TITLE
Updates WMS source example to fix missing 3rd party satellite imagery

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/AddWmsSourceActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/AddWmsSourceActivity.java
@@ -20,7 +20,7 @@ import com.mapbox.mapboxsdk.style.sources.TileSet;
  */
 public class AddWmsSourceActivity extends AppCompatActivity {
 
-  MapView mapView;
+  private MapView mapView;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -43,16 +43,20 @@ public class AddWmsSourceActivity extends AppCompatActivity {
           @Override
           public void onStyleLoaded(@NonNull Style style) {
 
+            // Add the web map source to the map
             style.addSource(new RasterSource(
               "web-map-source",
-              new TileSet("tileset", "https://geodata.state.nj.us/imagerywms/Natural2015?bbox={"
-                + "bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&"
-                + "srs=EPSG:3857&width=256&height=256&layers=Natural2015"), 256));
+              new TileSet("tileset", "https://img.nj.gov/imagerywms/Natural2015?bbox={"
+                + "bbox-epsg-3857}&format=image/png&service=WMS&version=1.1.1&request=GetMap&srs=EPSG:"
+                + "3857&transparent=true&width=256&height=256&layers=Natural2015"), 256));
 
-            // Add the web map source to the map.
-            style.addLayerBelow(
-              new RasterLayer("web-map-layer", "web-map-source"), "aeroway-taxiway");
-
+            // Create a RasterLayer with the source created above and then add the layer to the map
+            if (style.getLayer("tunnel-street-minor-low") != null) {
+              style.addLayerBelow(
+                new RasterLayer("web-map-layer", "web-map-source"), "tunnel-street-minor-low");
+            } else {
+              style.addLayer(new RasterLayer("web-map-layer", "web-map-source"));
+            }
           }
         });
       }


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-android-demo/issues/1020 by updating `AddWmsSourceActivity`. The URL needed to be updated. It now matches the one used in the working GL-JS example: https://docs.mapbox.com/mapbox-gl-js/example/wms/

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/68260715-a9f3b380-fff2-11e9-8e7b-61685c9c76a8.gif)
