### PR TITLE
Adding bordered circle Kotlin example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -39,6 +39,7 @@ import com.mapbox.mapboxandroiddemo.examples.dds.ChoroplethZoomChangeActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.CircleLayerClusteringActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.CircleRadiusActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.CircleToIconTransitionActivity;
+import com.mapbox.mapboxandroiddemo.examples.javaservices.KotlinBorderedCircleActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.CreateHotspotsActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.DrawGeojsonLineActivity;
 import com.mapbox.mapboxandroiddemo.examples.dds.DrawPolygonActivity;
@@ -1100,6 +1101,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       null,
       R.string.activity_java_services_multiple_geometries_from_directions_route_url,
       true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_java_services,
+      R.string.activity_java_services_bordered_circle_title,
+      R.string.activity_java_services_bordered_circle_description,
+      null,
+      new Intent(MainActivity.this, KotlinBorderedCircleActivity.class),
+      R.string.activity_java_services_bordered_circle_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_snapshot_image_generator,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -111,6 +111,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.javaservices.KotlinBorderedCircleActivity"
+            android:label="@string/activity_java_services_bordered_circle_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.camera.AnimateMapCameraActivity"
             android:label="@string/activity_camera_animate_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/KotlinBorderedCircleActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/KotlinBorderedCircleActivity.kt
@@ -1,0 +1,294 @@
+package com.mapbox.mapboxandroiddemo.examples.javaservices
+
+import android.graphics.Color
+import android.os.Bundle
+import android.widget.SeekBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.geojson.Feature
+import com.mapbox.geojson.LineString
+import com.mapbox.geojson.Point
+import com.mapbox.geojson.Polygon
+import com.mapbox.mapboxandroiddemo.R
+import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.mapboxsdk.camera.CameraUpdateFactory
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.style.layers.FillLayer
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillOpacity
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import com.mapbox.turf.TurfConstants.UNIT_KILOMETERS
+import com.mapbox.turf.TurfMeta
+import com.mapbox.turf.TurfTransformation
+import kotlinx.android.synthetic.main.activity_lab_turf_thick_bordered_circle.*
+
+/**
+ * Use [TurfTransformation.circle] to eventually create a thick border around a circular-shaped [Polygon].
+ */
+class KotlinBorderedCircleActivity : AppCompatActivity(), MapboxMap.OnMapClickListener {
+
+    private var mapboxMap: MapboxMap ? = null
+    private lateinit var circlePolygonArea: Polygon
+    private var lastClickPoint = STARTING_CAMERA_POINT
+    private var circleRadiusUnits = UNIT_KILOMETERS
+    private var currentSetCircleRadius = 25
+    private var currentSetCircleBorderDifference = 2
+    private var borderDifferenceUnitSeekbarMax = 200
+    private var radiusSeekbarMax = 500
+    private var circleOpacity = .7f
+
+    companion object {
+        private const val CIRCLE_CENTER_SOURCE_ID = "CIRCLE_CENTER_SOURCE_ID"
+        private const val CIRCLE_COLOR = "#2643ff"
+        private const val CIRCLE_BORDER_COLOR = "#132287"
+        private const val CIRCLE_BORDER_GEOJSON_SOURCE_ID = "CIRCLE_BORDER_GEOJSON_SOURCE_ID"
+        private const val CIRCLE_GEOJSON_SOURCE_ID = "CIRCLE_GEOJSON_SOURCE_ID"
+        private const val CIRCLE_BORDER_LAYER_ID = "CIRCLE_BORDER_LAYER_ID"
+        private const val CIRCLE_LAYER_ID = "CIRCLE_LAYER_ID"
+        private const val CIRCLE_STEPS = 360
+        private const val RADIUS_SEEKBAR_DIFFERENCE = 1
+        private const val BORDER_DIFFERENCE_SEEKBAR_DIFFERENCE = 1
+        private val STARTING_CAMERA_POINT = Point.fromLngLat(33.22424223, 34.99415092)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Mapbox access token is configured here. This needs to be called either in your application
+        // object or in the same activity which contains the mapview.
+        Mapbox.getInstance(this, getString(R.string.access_token))
+
+        // This contains the MapView in XML and needs to be called after the access token is configured.
+        setContentView(R.layout.activity_lab_turf_thick_bordered_circle)
+        mapView?.onCreate(savedInstanceState)
+        mapView?.getMapAsync { mapboxMap ->
+            mapboxMap.setStyle(Style.Builder().fromUri(Style.MAPBOX_STREETS)
+                    .withSource(GeoJsonSource(CIRCLE_CENTER_SOURCE_ID,
+                            Feature.fromGeometry(STARTING_CAMERA_POINT)))
+                    .withSource(GeoJsonSource(CIRCLE_BORDER_GEOJSON_SOURCE_ID))
+                    .withSource(GeoJsonSource(CIRCLE_GEOJSON_SOURCE_ID))
+                    .withLayer(FillLayer(CIRCLE_BORDER_LAYER_ID, CIRCLE_BORDER_GEOJSON_SOURCE_ID).withProperties(
+                            fillColor(Color.parseColor(CIRCLE_BORDER_COLOR))
+                    ))
+                    .withLayer(FillLayer(CIRCLE_LAYER_ID, CIRCLE_GEOJSON_SOURCE_ID).withProperties(
+                            fillColor(Color.parseColor(CIRCLE_COLOR)),
+                            fillOpacity(circleOpacity)
+                    ))) {
+
+                this@KotlinBorderedCircleActivity.mapboxMap = mapboxMap
+
+                drawPolygonCircle(lastClickPoint)
+
+                drawCircleBorder(lastClickPoint)
+
+                mapboxMap.addOnMapClickListener(this@KotlinBorderedCircleActivity)
+
+                Toast.makeText(this@KotlinBorderedCircleActivity,
+                        getString(R.string.tap_on_map_to_move_bordered_circle), Toast.LENGTH_SHORT).show()
+
+                initRadiusSeekbar()
+
+                initBorderDifferenceSeekbar()
+            }
+        }
+    }
+
+    /**
+     * Initialize the seekbar slider to adjust the circle radius
+     */
+    private fun initRadiusSeekbar() {
+        thick_bordered_circle_radius_seekbar?.apply {
+            max = radiusSeekbarMax + RADIUS_SEEKBAR_DIFFERENCE
+            incrementProgressBy(RADIUS_SEEKBAR_DIFFERENCE)
+            progress = radiusSeekbarMax / 2
+
+            thick_bordered_circle_radius_textview?.text = String.format(getString(
+                    R.string.thick_bordered_circle_radius), progress)
+
+            this.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+                    adjustCircleRadius(thick_bordered_circle_radius_textview, seekBar.progress)
+                }
+
+                override fun onStartTrackingTouch(seekBar: SeekBar) {
+                    // Not needed in this example.
+                }
+
+                override fun onStopTrackingTouch(seekBar: SeekBar) {
+                    adjustCircleRadius(thick_bordered_circle_radius_textview, seekBar.progress)
+                }
+            })
+        }
+    }
+
+    /**
+     * Initialize the seekbar slider to adjust the distance that represents the circle border size
+     */
+    private fun initBorderDifferenceSeekbar() {
+        thick_bordered_circle_border_difference_seekbar?.apply {
+            max = borderDifferenceUnitSeekbarMax + BORDER_DIFFERENCE_SEEKBAR_DIFFERENCE
+            incrementProgressBy(BORDER_DIFFERENCE_SEEKBAR_DIFFERENCE)
+            progress = borderDifferenceUnitSeekbarMax / 2
+
+            thick_bordered_circle_border_difference_textview?.text = String.format(getString(
+                    R.string.thick_bordered_circle_border_difference), progress)
+
+            this.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+                override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
+                    adjustCircleBorderDifference(thick_bordered_circle_border_difference_textview,
+                            seekBar.progress)
+                }
+
+                override fun onStartTrackingTouch(seekBar: SeekBar) {
+                    // Not needed in this example.
+                }
+
+                override fun onStopTrackingTouch(seekBar: SeekBar) {
+                    adjustCircleBorderDifference(thick_bordered_circle_border_difference_textview,
+                            seekBar.progress)
+                }
+            })
+        }
+    }
+
+    /**
+     * Make the necessary GeoJSON adjustments to account for a new circle radius
+     *
+     * @param textView the TextView to update
+     * @param progress the new progress value to add to the TextView
+     */
+    private fun adjustCircleRadius(textView: TextView, progress: Int) {
+        adjustSeekBarProgressTextView(R.string.thick_bordered_circle_radius, textView, progress)
+        currentSetCircleRadius = progress
+        drawPolygonCircle(lastClickPoint)
+        drawCircleBorder(lastClickPoint)
+    }
+
+    /**
+     * Make the necessary GeoJSON adjustments to account for a new circle border size
+     *
+     * @param textView the TextView to update
+     * @param progress the new progress value to add to the TextView
+     */
+    private fun adjustCircleBorderDifference(textView: TextView, progress: Int) {
+        adjustSeekBarProgressTextView(R.string.thick_bordered_circle_border_difference, textView, progress)
+        currentSetCircleBorderDifference = progress
+        drawCircleBorder(lastClickPoint)
+    }
+
+    /**
+     * Adjust the textView
+     *
+     * @param string the string resource to update
+     * @param textView the TextView to update
+     * @param progress the new progress value to add to the TextView
+     */
+    private fun adjustSeekBarProgressTextView(string: Int, textView: TextView, progress: Int) {
+        var newProgress = progress
+        newProgress /= 1
+        newProgress *= 1
+        textView.text = String.format(getString(string), newProgress)
+    }
+
+    /**
+     * Make necessary camera and GeoJSON adjustments when the map is tapped on.
+     * @param mapClickLatLng where the map was tapped
+     */
+    override fun onMapClick(mapClickLatLng: LatLng): Boolean {
+        mapboxMap?.easeCamera(CameraUpdateFactory.newLatLng(mapClickLatLng))
+        lastClickPoint = Point.fromLngLat(mapClickLatLng.longitude, mapClickLatLng.latitude)
+        drawPolygonCircle(lastClickPoint)
+        drawCircleBorder(lastClickPoint)
+        return true
+    }
+
+    /**
+     * Update the [FillLayer] based on the GeoJSON retrieved via [getTurfPolygon].
+     *
+     * @param newCircleCenter the center coordinate to be used in the Turf calculation.
+     */
+    private fun drawPolygonCircle(newCircleCenter: Point) {
+        mapboxMap?.getStyle { style ->
+            // Use Turf to calculate the coordinates for the circular-shaped Polygon
+            circlePolygonArea = getTurfPolygon(newCircleCenter, currentSetCircleRadius.toDouble())
+
+            // Set the source with the circle's GeoJSON
+            val polygonCircleSource = style.getSourceAs<GeoJsonSource>(CIRCLE_GEOJSON_SOURCE_ID)
+            polygonCircleSource?.setGeoJson(Polygon.fromOuterInner(
+                    LineString.fromLngLats(TurfMeta.coordAll(circlePolygonArea, false))))
+        }
+    }
+
+    /**
+     * Update the [FillLayer] based on the GeoJSON retrieved via [getTurfPolygon].
+     *
+     * @param newCircleCenter the center coordinate to be used in the Turf calculation.
+     */
+    private fun drawCircleBorder(newCircleCenter: Point) {
+        mapboxMap?.getStyle {
+            // Use Turf to calculate the coordinates for the circular-shaped Polygon's border
+            val circleBorderPolygon = getTurfPolygon(newCircleCenter,
+                    currentSetCircleRadius.toDouble() - currentSetCircleBorderDifference)
+
+            // Set the source with the border's GeoJSON
+            val circleBorderSource = it.getSourceAs<GeoJsonSource>(CIRCLE_BORDER_GEOJSON_SOURCE_ID)
+            circleBorderSource?.setGeoJson(Polygon.fromOuterInner(
+                    // Create outer LineString
+                    LineString.fromLngLats(TurfMeta.coordAll(circleBorderPolygon, false)),
+                    // Create inter LineString
+                    LineString.fromLngLats(TurfMeta.coordAll(circlePolygonArea, false))
+            ))
+        }
+    }
+
+    /**
+     * Use the Turf library [TurfTransformation.circle] method to
+     * retrieve a [Polygon].
+     *
+     * @param centerPoint a [Point] which the circle will center around
+     * @param radius the radius of the circle
+     * @return a [Polygon] which represents the newly created circle
+     */
+    private fun getTurfPolygon(centerPoint: Point, radius: Double): Polygon {
+        return TurfTransformation.circle(centerPoint, radius, CIRCLE_STEPS, circleRadiusUnits)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView?.onStart()
+    }
+
+    public override fun onResume() {
+        super.onResume()
+        mapView?.onResume()
+    }
+
+    public override fun onPause() {
+        super.onPause()
+        mapView?.onPause()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView?.onLowMemory()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView?.onStop()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapboxMap?.removeOnMapClickListener(this)
+        mapView?.onDestroy()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView?.onSaveInstanceState(outState)
+    }
+}

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TurfPhysicalCircleActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TurfPhysicalCircleActivity.java
@@ -356,6 +356,9 @@ public class TurfPhysicalCircleActivity extends AppCompatActivity implements Map
   @Override
   protected void onDestroy() {
     super.onDestroy();
+    if (mapboxMap != null) {
+      mapboxMap.removeOnMapClickListener(this);
+    }
     mapView.onDestroy();
   }
 

--- a/MapboxAndroidDemo/src/main/res/layout/activity_lab_turf_thick_bordered_circle.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_lab_turf_thick_bordered_circle.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.javaservices.KotlinBorderedCircleActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/guideline9"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        mapbox:mapbox_cameraTargetLat="34.99415092"
+        mapbox:mapbox_cameraTargetLng="33.224242235"
+        mapbox:mapbox_cameraZoom="7" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline9"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.7" />
+
+    <TextView
+        android:id="@+id/thick_bordered_circle_radius_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="27dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:gravity="center"
+        android:text="Radius: 250 kilometers"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/mapView" />
+
+    <SeekBar
+        android:id="@+id/thick_bordered_circle_radius_seekbar"
+        android:layout_width="395dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/thick_bordered_circle_radius_textview" />
+
+    <TextView
+        android:id="@+id/thick_bordered_circle_border_difference_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="27dp"
+        android:layout_marginTop="80dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:gravity="center"
+        android:text="Border difference: 20 kilometers"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/mapView" />
+
+    <SeekBar
+        android:id="@+id/thick_bordered_circle_border_difference_seekbar"
+        android:layout_width="395dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/thick_bordered_circle_border_difference_textview" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -439,4 +439,9 @@
     <string name="fingerprint_not_possible">Fingerprint authentication not set up on this device or not available yet.</string>
     <string name="fingerprint_fail">Didn\'t recognize your fingerprint. Please try again!</string>
 
+    <!-- Thick bordered circle-->
+    <string name="thick_bordered_circle_radius">Radius: %1$d kilometers</string>
+    <string name="thick_bordered_circle_border_difference">Border difference: %1$d kilometers</string>
+    <string name="tap_on_map_to_move_bordered_circle">Tap on the map to move the bordered circle</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -92,10 +92,11 @@
     <string name="activity_java_services_map_matching_description">Match raw GPS points to the map so they aligns with the roads/pathways.</string>
     <string name="activity_java_services_turf_ring_description">Use Turf to calculate coordinates to eventually draw a ring around a center coordinate.</string>
     <string name="activity_java_services_turf_physical_circle_description">Use Turf to generate a circle with a radius expressed in physical units (e.g. miles, kilometers, etc).</string>
-    <string name="activity_java_services_turf_line_distance_description">Use Turf to generate a circle with a radius expressed in physical units (e.g. miles, kilometers, etc).</string>
+    <string name="activity_java_services_turf_line_distance_description">Use Turf to measure the distance of a line.</string>
     <string name="activity_java_services_directions_gradient_description">Apply a two-color gradient to a Directions API route line.</string>
     <string name="activity_java_services_multiple_geometries_from_directions_route_description">Show multiple geometries based on a single Mapbox Directions API response.</string>
     <string name="activity_java_services_turf_elevation_query_description">Use the Tilequery API to query the Mapbox Terrain vector tileset and retrieve elevation information for a specific location.</string>
+    <string name="activity_java_services_bordered_circle_description">Use Turf to generate a circle with a radius expressed in physical units and to create an adjustable border</string>
     <string name="activity_plugins_traffic_plugin_description">Use the traffic plugin to display live car congestion data on top of a map.</string>
     <string name="activity_plugins_building_plugin_description">Use the building plugin to easily display 3D building height</string>
     <string name="activity_plugins_places_plugin_description">Add location search ("geocoding") functionality and UI to search for any place in the world</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -96,6 +96,7 @@
     <string name="activity_java_services_directions_gradient_title">Directions route with gradient</string>
     <string name="activity_java_services_multiple_geometries_from_directions_route_title">Multiple geometries from Directions route</string>
     <string name="activity_java_services_turf_elevation_query_title">Retrieve elevation data</string>
+    <string name="activity_java_services_bordered_circle_title">Bordered circle</string>
     <string name="activity_plugins_traffic_plugin_title">Display real-time traffic</string>
     <string name="activity_plugins_building_plugin_title">Display buildings in 3D</string>
     <string name="activity_plugins_localization_plugin_title">Change map text to device language</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -94,6 +94,7 @@
     <string name="activity_java_services_turf_physical_circle_url" translatable="false">https://i.imgur.com/uPQXVbv.png</string>
     <string name="activity_java_services_multiple_geometries_from_directions_route_url" translatable="false">https://i.imgur.com/Tz35fHA.png</string>
     <string name="activity_java_services_turf_elevation_query_url" translatable="false">https://i.imgur.com/zrE2oSR.png</string>
+    <string name="activity_java_services_bordered_circle_url" translatable="false">https://i.imgur.com/cCbwj1y.png</string>
     <string name="activity_plugins_traffic_plugin_url" translatable="false">http://i.imgur.com/HRriOVR.png</string>
     <string name="activity_plugins_building_plugin_url" translatable="false">http://i.imgur.com/Vcu67UR.png</string>
     <string name="activity_plugins_places_plugin_url" translatable="false">https://i.imgur.com/oKHx3bv.png</string>


### PR DESCRIPTION
This pr adds an example of how to create a circular-shaped `Polygon` with a border, which I often see in various Android apps. This example is basically a mashup of https://docs.mapbox.com/android/java/examples/turf-ring/ and https://docs.mapbox.com/android/java/examples/turf-physical-circle/

![Screen Shot 2019-11-27 at 1 00 07 PM](https://user-images.githubusercontent.com/4394910/69764242-7fde6e80-1124-11ea-85ee-4aef2b713a0b.png)

![69764435-2591dd80-1125-11ea-92ee-4c49a3292e24](https://user-images.githubusercontent.com/4394910/69764590-bc5e9a00-1125-11ea-9842-f4606616f9f4.png)


![ezgif com-resize (3)](https://user-images.githubusercontent.com/4394910/69764614-d1d3c400-1125-11ea-860c-0b70ae47c076.gif)
