### PR TITLE
Adding straight line Turf distance measurement ("as the crow flies") example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -76,6 +76,7 @@ import com.mapbox.mapboxandroiddemo.examples.javaservices.MultipleGeometriesDire
 import com.mapbox.mapboxandroiddemo.examples.javaservices.OptimizationActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.SimplifyPolylineActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.StaticImageActivity;
+import com.mapbox.mapboxandroiddemo.examples.javaservices.StraightLineDistanceMapMovementActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TilequeryActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfLineDistanceActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfPhysicalCircleActivity;
@@ -1118,6 +1119,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       null,
       new Intent(MainActivity.this, KotlinBorderedCircleActivity.class),
       R.string.activity_java_services_bordered_circle_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_java_services,
+      R.string.activity_java_services_straight_line_distance_title,
+      R.string.activity_java_services_straight_line_distance_description,
+      new Intent(MainActivity.this, StraightLineDistanceMapMovementActivity.class),
+      null,
+      R.string.activity_java_services_straight_line_distance_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_snapshot_image_generator,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -514,6 +514,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.javaservices.StraightLineDistanceMapMovementActivity"
+            android:label="@string/activity_java_services_straight_line_distance_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.styles.TextFieldMultipleFormatsActivity"
             android:label="@string/activity_styles_text_field_multiple_formats_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/StraightLineDistanceMapMovementActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/StraightLineDistanceMapMovementActivity.java
@@ -1,0 +1,247 @@
+package com.mapbox.mapboxandroiddemo.examples.javaservices;
+
+import android.graphics.Color;
+import android.location.Location;
+import android.os.Bundle;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.mapbox.android.core.permissions.PermissionsListener;
+import com.mapbox.android.core.permissions.PermissionsManager;
+import com.mapbox.geojson.LineString;
+import com.mapbox.geojson.Point;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.location.LocationComponent;
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions;
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
+import com.mapbox.mapboxsdk.location.modes.RenderMode;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.layers.LineLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.turf.TurfMeasurement;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import static com.mapbox.mapboxsdk.style.layers.Property.LINE_JOIN_ROUND;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth;
+import static com.mapbox.turf.TurfConstants.UNIT_METERS;
+
+/**
+ * Use {@link com.mapbox.turf.TurfMeasurement#distance(Point, Point)} to calculate a straight line distance
+ * ("as the crow flies") between the device location and the map camera's target.
+ */
+public class StraightLineDistanceMapMovementActivity extends AppCompatActivity implements
+  PermissionsListener, MapboxMap.OnCameraMoveListener {
+
+  private static final String DISTANCE_SOURCE_ID = "DISTANCE_SOURCE_ID";
+  private static final String DISTANCE_LINE_LAYER_ID = "DISTANCE_LINE_LAYER_ID";
+
+  // Adjust private static final variables below to change the example's UI
+  private static final int LINE_COLOR = Color.RED;
+  private static final float LINE_WIDTH = 2f;
+
+  private PermissionsManager permissionsManager;
+  private List<Point> pointList;
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private TextView distanceTextView;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_javaservices_straight_line_distance);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+
+        StraightLineDistanceMapMovementActivity.this.mapboxMap = mapboxMap;
+
+        mapboxMap.setStyle(new Style.Builder()
+            .fromUri(Style.DARK)
+
+            // Add the source to the map
+            .withSource(new GeoJsonSource(DISTANCE_SOURCE_ID))
+
+            // Style and add the LineLayer to the map.
+            .withLayer(new LineLayer(DISTANCE_LINE_LAYER_ID, DISTANCE_SOURCE_ID).withProperties(
+              lineColor(LINE_COLOR),
+              lineWidth(LINE_WIDTH),
+              lineJoin(LINE_JOIN_ROUND))), new Style.OnStyleLoaded() {
+                @Override
+                  public void onStyleLoaded(@NonNull Style style) {
+                    enableLocationComponent(style);
+
+                    StraightLineDistanceMapMovementActivity.this.mapboxMap
+                      .addOnCameraMoveListener(StraightLineDistanceMapMovementActivity.this);
+
+                    distanceTextView = findViewById(R.id.straight_line_distance_textview);
+                    distanceTextView.setTextColor(Color.RED);
+
+                    Toast.makeText(StraightLineDistanceMapMovementActivity.this,
+                      getString(R.string.move_map_around_instruction), Toast.LENGTH_SHORT).show();
+                  }
+                }
+        );
+      }
+    });
+  }
+
+  @Override
+  public void onCameraMove() {
+    redrawLine(mapboxMap.getCameraPosition().target);
+  }
+
+  private void redrawLine(@NonNull LatLng targetLatLng) {
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        GeoJsonSource geoJsonSource = style.getSourceAs(DISTANCE_SOURCE_ID);
+        if (geoJsonSource != null) {
+          pointList = new ArrayList<>();
+          Location lastKnownLocation = mapboxMap.getLocationComponent().getLastKnownLocation();
+          if (lastKnownLocation != null) {
+
+            // Add the start and ending points to the straight line
+            Point targetPoint = Point.fromLngLat(targetLatLng.getLongitude(), targetLatLng.getLatitude());
+            Point deviceLocationPoint = Point.fromLngLat(lastKnownLocation.getLongitude(),
+              lastKnownLocation.getLatitude());
+            pointList.add(targetPoint);
+            pointList.add(deviceLocationPoint);
+
+            // Update the source with the new LineString line
+            geoJsonSource.setGeoJson(LineString.fromLngLats(pointList));
+
+            // Update the TextView with the new straight line distance
+            double distanceBetweenDeviceAndTarget = TurfMeasurement.distance(deviceLocationPoint,
+              targetPoint, UNIT_METERS);
+
+            distanceTextView.setText(String.format("%s meters", String.valueOf(
+              NumberFormat.getNumberInstance(Locale.US).format(distanceBetweenDeviceAndTarget))));
+          }
+        }
+      }
+    });
+  }
+
+  @SuppressWarnings( {"MissingPermission"})
+  private void enableLocationComponent(@NonNull Style loadedMapStyle) {
+    // Check if permissions are enabled and if not request
+    if (PermissionsManager.areLocationPermissionsGranted(this)) {
+
+      // Get an instance of the component
+      LocationComponent locationComponent = mapboxMap.getLocationComponent();
+
+      // Activate with options
+      locationComponent.activateLocationComponent(
+        LocationComponentActivationOptions.builder(this, loadedMapStyle).build());
+
+      // Enable to make component visible
+      locationComponent.setLocationComponentEnabled(true);
+
+      // Set the component's camera mode
+      locationComponent.setCameraMode(CameraMode.TRACKING);
+
+      // Set the component's render mode
+      locationComponent.setRenderMode(RenderMode.COMPASS);
+    } else {
+      permissionsManager = new PermissionsManager(this);
+      permissionsManager.requestLocationPermissions(this);
+    }
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                         @NonNull int[] grantResults) {
+    permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
+  }
+
+  @Override
+  public void onExplanationNeeded(List<String> permissionsToExplain) {
+    Toast.makeText(this, R.string.user_location_permission_explanation,
+      Toast.LENGTH_LONG).show();
+  }
+
+  @Override
+  public void onPermissionResult(boolean granted) {
+    if (granted) {
+      mapboxMap.getStyle(new Style.OnStyleLoaded() {
+        @Override
+        public void onStyleLoaded(@NonNull Style style) {
+          enableLocationComponent(style);
+        }
+      });
+    } else {
+      Toast.makeText(this, R.string.user_location_permission_not_granted, Toast.LENGTH_LONG).show();
+      finish();
+    }
+  }
+
+  // Add the mapView lifecycle to the activity's lifecycle methods
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    if (mapboxMap != null) {
+      mapboxMap.removeOnCameraMoveListener(this);
+    }
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_straight_line_distance.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_straight_line_distance.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraint_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.javaservices.TurfLineDistanceActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="parent"
+        mapbox:layout_constraintTop_toTopOf="parent"
+        mapbox:mapbox_cameraTargetLat="21.3011229"
+        mapbox:mapbox_cameraTargetLng="-157.851376"
+        mapbox:mapbox_cameraZoom="12" />
+
+    <TextView
+        android:id="@+id/straight_line_distance_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        mapbox:layout_constraintBottom_toBottomOf="parent"
+        mapbox:layout_constraintEnd_toEndOf="parent"
+        mapbox:layout_constraintStart_toStartOf="@+id/mapView"
+        mapbox:layout_constraintTop_toTopOf="@+id/mapView" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -244,8 +244,8 @@
 
     <!-- Building outline-->
     <string name="building_layer_not_present">This map style doesn\'t have a building layer</string>
-    <string name="move_map_around_building_out_instruction">Move map to place red dot on a building</string>
-    <string name="move_map_around_instruction">Move map around</string>
+    <string name="move_map_around_building_out_instruction">Move the map to place red dot on a building</string>
+    <string name="move_map_around_instruction">Move the map around</string>
 
     <!--Calendar integration toast-->
     <string name="user_calendar_permission_explanation">This example needs calendar access in order to show calendar and map integration.</string>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -98,6 +98,7 @@
     <string name="activity_java_services_multiple_geometries_from_directions_route_description">Show multiple geometries based on a single Mapbox Directions API response.</string>
     <string name="activity_java_services_turf_elevation_query_description">Use the Tilequery API to query the Mapbox Terrain vector tileset and retrieve elevation information for a specific location.</string>
     <string name="activity_java_services_bordered_circle_description">Use Turf to generate a circle with a radius expressed in physical units and to create an adjustable border</string>
+    <string name="activity_java_services_straight_line_distance_description">Use Turf to calculate a straight line distance ("as the crow flies") between the device location and the map camera\'s target.</string>
     <string name="activity_plugins_traffic_plugin_description">Use the traffic plugin to display live car congestion data on top of a map.</string>
     <string name="activity_plugins_building_plugin_description">Use the building plugin to easily display 3D building height</string>
     <string name="activity_plugins_places_plugin_description">Add location search ("geocoding") functionality and UI to search for any place in the world</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -98,6 +98,7 @@
     <string name="activity_java_services_multiple_geometries_from_directions_route_title">Multiple geometries from Directions route</string>
     <string name="activity_java_services_turf_elevation_query_title">Retrieve elevation data</string>
     <string name="activity_java_services_bordered_circle_title">Bordered circle</string>
+    <string name="activity_java_services_straight_line_distance_title">Straight line distance</string>
     <string name="activity_plugins_traffic_plugin_title">Display real-time traffic</string>
     <string name="activity_plugins_building_plugin_title">Display buildings in 3D</string>
     <string name="activity_plugins_localization_plugin_title">Change map text to device language</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -96,6 +96,7 @@
     <string name="activity_java_services_multiple_geometries_from_directions_route_url" translatable="false">https://i.imgur.com/Tz35fHA.png</string>
     <string name="activity_java_services_turf_elevation_query_url" translatable="false">https://i.imgur.com/zrE2oSR.png</string>
     <string name="activity_java_services_bordered_circle_url" translatable="false">https://i.imgur.com/cCbwj1y.png</string>
+    <string name="activity_java_services_straight_line_distance_url" translatable="false">https://i.imgur.com/1vGQqBh.png</string>
     <string name="activity_plugins_traffic_plugin_url" translatable="false">http://i.imgur.com/HRriOVR.png</string>
     <string name="activity_plugins_building_plugin_url" translatable="false">http://i.imgur.com/Vcu67UR.png</string>
     <string name="activity_plugins_places_plugin_url" translatable="false">https://i.imgur.com/oKHx3bv.png</string>


### PR DESCRIPTION
This pr adds a new example that shows how to use Turf distance to calculate a straight line distance ("as the crow flies") between the device location and the map camera's target. This example is inspired by what @kmadsen and I saw in a Japanese navigation company's turn-by-turn app experience (cc @mapbox/navigation-android )

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/72849623-f77bd600-3c5b-11ea-9d68-83bb9dc31a5c.gif)
