### PR TITLE
Fixed source and layer name for ImageSourceActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ImageSourceActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/ImageSourceActivity.java
@@ -21,8 +21,8 @@ import com.mapbox.mapboxsdk.style.sources.ImageSource;
 public class ImageSourceActivity extends AppCompatActivity implements OnMapReadyCallback {
 
   private MapView mapView;
-  private static final String ID_IMAGE_SOURCE = "animated_image_source";
-  private static final String ID_IMAGE_LAYER = "animated_image_layer";
+  private static final String ID_IMAGE_SOURCE = "image_source-id";
+  private static final String ID_IMAGE_LAYER = "image_layer-id";
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
This pr fixes the source and layer ids in `ImageSourceActivity` so that they make a little more sense. They were leftover from `AnimatedImageGifActivity`.