### PR TITLE
Fixed tools:context in activity_basic_simple_kotlin.xml

### DIFF
--- a/MapboxAndroidDemo/src/china/res/layout/activity_basic_simple_kotlin.xml
+++ b/MapboxAndroidDemo/src/china/res/layout/activity_basic_simple_kotlin.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".examples.basics.SimpleMapViewActivity">
+    tools:context=".examples.basics.KotlinSimpleMapViewActivity">
 
     <com.mapbox.mapboxsdk.plugins.china.maps.ChinaMapView
         android:id="@+id/mapView"
@@ -14,7 +14,6 @@
         mapbox:mapbox_cameraTargetLat="-34.069040"
         mapbox:mapbox_cameraTargetLng="-69.837955"
         mapbox:mapbox_cameraTilt="54.9710"
-        mapbox:mapbox_cameraZoom="7.899536"
-        />
+        mapbox:mapbox_cameraZoom="7.899536" />
 
 </FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_basic_simple_kotlin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_basic_simple_kotlin.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".examples.basics.MapViewActivityKotlin">
+    tools:context=".examples.basics.KotlinSimpleMapViewActivity">
 
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"


### PR DESCRIPTION
Now it points to .examples.basics.KotlinSimpleMapViewActivity instead of .examples.basics.SimpleMapViewActivity (china) and .examples.basics.MapViewActivityKotlin (main)