### PR TITLE
Places plugin 0.11.0 bump

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -122,6 +122,7 @@ import com.mapbox.mapboxandroiddemo.examples.offline.SimpleOfflineMapActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.BuildingPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.LocalizationPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.MarkerViewPluginActivity;
+import com.mapbox.mapboxandroiddemo.examples.plugins.PlaceSelectionPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.PlacesPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.ScalebarPluginActivity;
 import com.mapbox.mapboxandroiddemo.examples.plugins.SymbolListenerActivity;
@@ -806,17 +807,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
       R.string.activity_plugins_localization_plugin_url, false, BuildConfig.MIN_SDK_VERSION)
     );
 
-    // TODO: The example below is currently commented out because it crashes due
-    //  to incompatibility between the Mapbox Places Plugin and this app's usage
-    //  of AndroidX. This is being tracked at:
-    //  https://github.com/mapbox/mapbox-plugins-android/issues/908
-    /* exampleItemModels.add(new ExampleItemModel(
-    R.id.nav_plugins,
-    R.string.activity_plugins_place_picker_plugin_title,
-    R.string.activity_plugins_place_picker_plugin_description,
-    new Intent(MainActivity.this, PlaceSelectionPluginActivity.class),
-    null, R.string.activity_plugins_place_picker_plugin_url, false, BuildConfig.MIN_SDK_VERSION)
-    );*/
+    exampleItemModels.add(new ExampleItemModel(
+        R.id.nav_plugins,
+        R.string.activity_plugins_place_picker_plugin_title,
+        R.string.activity_plugins_place_picker_plugin_description,
+        new Intent(MainActivity.this, PlaceSelectionPluginActivity.class),
+        null,
+        R.string.activity_plugins_place_picker_plugin_url, false, BuildConfig.MIN_SDK_VERSION)
+    );
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_plugins,

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -15,7 +15,7 @@ ext {
             mapboxTurf               : '5.1.0',
             mapboxServices           : '5.1.0',
             mapboxPluginBuilding     : '0.7.0',
-            mapboxPluginPlaces       : '0.10.0',
+            mapboxPluginPlaces       : '0.11.0',
             mapboxPluginLocalization : '0.12.0',
             mapboxPluginTraffic      : '0.10.0',
             mapboxChinaPlugin        : '2.4.0',


### PR DESCRIPTION
Part of https://github.com/mapbox/mapbox-plugins-android/issues/1111

Because the `0.11.0` release fixes the Places Plugin's place picker functionality, this pr also re-introduces the `PlaceSelectionPluginActivity` example to the app, which is **finally** working again.

![ezgif com-resize (4)](https://user-images.githubusercontent.com/4394910/78064312-681f2d00-7346-11ea-8059-7ba3c0ae7610.gif)
