### PR TITLE
Added vibrate device on pin drop example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -110,6 +110,7 @@ import com.mapbox.mapboxandroiddemo.examples.labs.SpaceStationLocationActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SpinningSymbolLayerIconActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SymbolLayerMapillaryActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.ValueAnimatorIconAnimationActivity;
+import com.mapbox.mapboxandroiddemo.examples.labs.VibrateOnPinDropKotlinActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.KotlinLocationComponentActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.LocationChangeListeningActivity;
 import com.mapbox.mapboxandroiddemo.examples.location.LocationComponentActivity;
@@ -1385,6 +1386,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         new Intent(MainActivity.this, BaseballSprayChartActivity.class),
         null,
         R.string.activity_lab_baseball_spray_chart_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+        R.id.nav_lab,
+        R.string.activity_lab_vibrate_on_pin_drop_title,
+        R.string.activity_lab_vibrate_on_pin_drop_description,
+        null,
+        new Intent(MainActivity.this, VibrateOnPinDropKotlinActivity.class),
+        R.string.activity_lab_vibrate_on_pin_drop_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_dds,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
 
     <uses-feature
         android:name="android.hardware.location.gps"
@@ -701,6 +702,13 @@
         <activity
             android:name=".examples.labs.BaseballSprayChartActivity"
             android:label="@string/activity_lab_baseball_spray_chart_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
+            android:name=".examples.labs.VibrateOnPinDropKotlinActivity"
+            android:label="@string/activity_lab_vibrate_on_pin_drop_title">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/VibrateOnPinDropKotlinActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/VibrateOnPinDropKotlinActivity.kt
@@ -1,0 +1,136 @@
+package com.mapbox.mapboxandroiddemo.examples.labs
+
+import android.os.Build
+import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.geojson.Point
+import com.mapbox.mapboxandroiddemo.R
+import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.mapboxsdk.geometry.LatLng
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource
+import com.mapbox.mapboxsdk.utils.BitmapUtils
+import kotlinx.android.synthetic.main.activity_lab_vibrate_on_pin_drop_kotlin.*
+
+/**
+ * Vibrate the Android device when a pin icon is dropped on the map.
+ */
+class VibrateOnPinDropKotlinActivity : AppCompatActivity(), OnMapReadyCallback, MapboxMap.OnMapLongClickListener {
+
+    var mapboxMap: MapboxMap? = null
+
+    companion object {
+        private const val SOURCE_ID = "SOURCE_ID"
+        private const val ICON_ID = "ICON_ID"
+        private const val LAYER_ID = "LAYER_ID"
+        private const val VIBRATE_SPEED_ONE_HUNDRED_MILLISECONDS = 100L
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        // Mapbox access token is configured here. This needs to be called either in your application
+        // object or in the same activity which contains the mapview.
+        Mapbox.getInstance(this, getString(R.string.access_token))
+
+        // This contains the MapView in XML and needs to be called after the access token is configured.
+        setContentView(R.layout.activity_lab_vibrate_on_pin_drop_kotlin)
+        mapView?.onCreate(savedInstanceState)
+        mapView?.getMapAsync(this)
+    }
+
+    override fun onMapReady(mapboxMap: MapboxMap) {
+        mapboxMap.setStyle(Style.Builder().fromUri(Style.OUTDOORS)
+
+                // Add the SymbolLayer icon image to the map style
+                .withImage(ICON_ID, BitmapUtils.getDrawableFromRes(
+                        this@VibrateOnPinDropKotlinActivity,
+                        R.drawable.mapbox_marker_icon_default)!!)
+
+                // Adding a GeoJson source for the SymbolLayer icons.
+                .withSource(GeoJsonSource(SOURCE_ID))
+
+                // Adding the actual SymbolLayer to the map style.
+                .withLayer(SymbolLayer(LAYER_ID, SOURCE_ID)
+                        .withProperties(
+                                iconImage(ICON_ID),
+                                iconAllowOverlap(true),
+                                iconIgnorePlacement(true))
+                )) {
+            this.mapboxMap = mapboxMap
+            mapboxMap.addOnMapLongClickListener(this@VibrateOnPinDropKotlinActivity)
+            Toast.makeText(this@VibrateOnPinDropKotlinActivity,
+                    R.string.long_press_to_add_pin, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    override fun onMapLongClick(point: LatLng): Boolean {
+        mapboxMap?.getStyle {
+
+            // Update the SymbolLayer icon's source to move the map pin
+            val geoJsonSource = it.getSourceAs<GeoJsonSource>(SOURCE_ID)
+            geoJsonSource?.setGeoJson(Point.fromLngLat(point.longitude, point.latitude))
+
+            // Vibrate the device
+            vibrate()
+        }
+        return true
+    }
+
+    /**
+     * Vibrate the device
+     */
+    private fun vibrate() {
+        val vibrator = getSystemService(VIBRATOR_SERVICE) as Vibrator
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            vibrator.vibrate(VibrationEffect.createOneShot(VIBRATE_SPEED_ONE_HUNDRED_MILLISECONDS,
+                    VibrationEffect.DEFAULT_AMPLITUDE))
+        } else {
+            vibrator.vibrate(VIBRATE_SPEED_ONE_HUNDRED_MILLISECONDS)
+        }
+    }
+
+    // Add the mapView lifecycle to the activity's lifecycle methods
+    public override fun onResume() {
+        super.onResume()
+        mapView?.onResume()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView?.onStart()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView?.onStop()
+    }
+
+    public override fun onPause() {
+        super.onPause()
+        mapView?.onPause()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView?.onLowMemory()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapView?.onDestroy()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView?.onSaveInstanceState(outState)
+    }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_lab_vibrate_on_pin_drop_kotlin.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_lab_vibrate_on_pin_drop_kotlin.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.labs.VibrateOnPinDropKotlinActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="6.2443382"
+        mapbox:mapbox_cameraTargetLng="-75.573553"
+        mapbox:mapbox_cameraZoom="11.4"/>
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -475,4 +475,7 @@
     <!-- Circle icon toggling on click-->
     <string name="tap_on_map_to_toggle_instruction">Tap on a circle and then marker to toggle. Tap elsewhere to reset to circles.</string>
 
+    <!-- Vibrate-->
+    <string name="long_press_to_add_pin">Long press on the map to add a pin icon</string>
+
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -145,6 +145,7 @@
     <string name="activity_lab_shared_preferences_description">Use the Android system\'s SharedPreferences to save and retrieve information such as coordinates.</string>
     <string name="activity_lab_biometric_fingerprint_description">Use the Android system\'s fingerprint unlock to reveal "personal" data on a map.</string>
     <string name="activity_lab_baseball_spray_chart_description">Use the Maps SDK and filters to explore baseball data.</string>
+    <string name="activity_lab_vibrate_on_pin_drop_description">Vibrate the device when an icon is dropped on the map for a more interactive map experience.</string>
     <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
     <string name="activity_china_simple_china_bounds_checker_description">Use the China plugin to determine whether or not the device is inside of China.</string>
     <string name="activity_china_mixed_china_and_global_style_description">Load a China style if the device is in China. Load a global/.com style if not.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -148,4 +148,5 @@
     <string name="activity_lab_change_attribution_color_title">Style attribution</string>
     <string name="activity_lab_shared_preferences_title">Saving to SharedPreferences</string>
     <string name="activity_lab_biometric_fingerprint_title">Biometric fingerprint</string>
+    <string name="activity_lab_vibrate_on_pin_drop_title">Vibrate device on pin drop</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -143,6 +143,7 @@
     <string name="activity_lab_shared_preferences_url" translatable="false">https://i.imgur.com/znxAhDG.png</string>
     <string name="activity_lab_biometric_fingerprint_url" translatable="false">https://i.imgur.com/iQZzMIR.png</string>
     <string name="activity_lab_baseball_spray_chart_url" translatable="false">https://i.imgur.com/1j7WVoO.png</string>
+    <string name="activity_lab_vibrate_on_pin_drop_url" translatable="false">https://i.imgur.com/0FgIP5n.png</string>
     <string name="activity_china_simple_china_mapview_url" translatable="false">https://i.imgur.com/KwoEynZ.png</string>
     <string name="activity_china_simple_china_bounds_checker_url" translatable="false">https://i.imgur.com/fIFWqJu.png</string>
     <string name="activity_china_mixed_china_and_global_style_url" translatable="false">https://i.imgur.com/XBS1WAn.png</string>


### PR DESCRIPTION
This pr shows how to vibrate the device when a map-based action is taken. In this specific example, it's adding a `SymbolLayer` pin icon. 

This example uses the Navigation SDK's vibration code https://github.com/mapbox/mapbox-navigation-android/search?q=vibrate&unscoped_q=vibrate

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/79908444-1a8b6280-83d0-11ea-922a-a05c64aa4ae2.gif)
