### PR TITLE
Added two person isochrone POIs within expression filter example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -87,6 +87,7 @@ import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfCirclePoiWithinFil
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfLineDistanceActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfPhysicalCircleActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.TurfRingActivity;
+import com.mapbox.mapboxandroiddemo.examples.javaservices.TwoPersonMeetupLocationIsochroneWithinActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.AnimatedImageGifActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.AnimatedMarkerActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.BaseballSprayChartActivity;
@@ -1173,6 +1174,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         new Intent(MainActivity.this, TurfCirclePoiWithinFilterActivity.class),
         null,
         R.string.activity_java_services_turf_circle_poi_within_filter_url, true, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+        R.id.nav_java_services,
+        R.string.activity_java_services_two_person_meetup_isochrone_within_title,
+        R.string.activity_java_services_two_person_meetup_isochrone_within_description,
+        new Intent(MainActivity.this, TwoPersonMeetupLocationIsochroneWithinActivity.class),
+        null,
+        R.string.activity_java_services_two_person_meetup_isochrone_within_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_snapshot_image_generator,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -416,6 +416,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.javaservices.TwoPersonMeetupLocationIsochroneWithinActivity"
+            android:label="@string/activity_java_services_two_person_meetup_isochrone_within_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.javaservices.MapMatchingActivity"
             android:label="@string/activity_java_services_map_matching_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TwoPersonMeetupLocationIsochroneWithinActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/TwoPersonMeetupLocationIsochroneWithinActivity.java
@@ -1,0 +1,317 @@
+package com.mapbox.mapboxandroiddemo.examples.javaservices;
+
+import android.graphics.Color;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import com.mapbox.api.isochrone.IsochroneCriteria;
+import com.mapbox.api.isochrone.MapboxIsochrone;
+import com.mapbox.geojson.Feature;
+import com.mapbox.geojson.FeatureCollection;
+import com.mapbox.geojson.Point;
+import com.mapbox.geojson.Polygon;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.plugins.annotation.OnSymbolDragListener;
+import com.mapbox.mapboxsdk.plugins.annotation.Symbol;
+import com.mapbox.mapboxsdk.plugins.annotation.SymbolManager;
+import com.mapbox.mapboxsdk.plugins.annotation.SymbolOptions;
+import com.mapbox.mapboxsdk.style.layers.FillLayer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
+import com.mapbox.mapboxsdk.style.sources.GeoJsonSource;
+import com.mapbox.mapboxsdk.utils.BitmapUtils;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import timber.log.Timber;
+
+import static com.mapbox.mapboxsdk.style.expressions.Expression.all;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.eq;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.geometryType;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.within;
+import static com.mapbox.mapboxsdk.style.layers.Property.NONE;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillOpacity;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
+
+/**
+ * See how which places of interest (POIs) are within a 15 min walk of two different peoples'
+ * locations. This example requests information from the Mapbox
+ * Isochrone API (https://www.mapbox.com/api-documentation/#isochrone) and then uses the
+ * {@link com.mapbox.mapboxsdk.style.expressions.Expression#within(Polygon)} expression to
+ * filter out POIs that aren't inside of both peoples' isochrone {@link Polygon} areas.
+ */
+public class TwoPersonMeetupLocationIsochroneWithinActivity extends AppCompatActivity {
+
+  private static final String PERSON_ONE_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID =
+      "PERSON_ONE_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID";
+  private static final String PERSON_TWO_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID =
+      "PERSON_TWO_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID";
+  private static final String PERSON_ONE_ISOCHRONE_FILL_LAYER = "PERSON_ONE_ISOCHRONE_FILL_LAYER";
+  private static final String PERSON_TWO_ISOCHRONE_FILL_LAYER = "PERSON_TWO_ISOCHRONE_FILL_LAYER";
+  private static final String PERSON_ONE_MARKER_SOURCE_ID = "PERSON_ONE_MARKER_SOURCE_ID";
+  private static final String PERSON_TWO_MARKER_SOURCE_ID = "PERSON_TWO_MARKER_SOURCE_ID";
+  private static final String PERSON_ONE_MARKER_ICON_ID = "PERSON_ONE_MARKER_ICON_ID";
+  private static final String PERSON_TWO_MARKER_ICON_ID = "PERSON_TWO_MARKER_ICON_ID";
+  private static final LatLng PERSON_ONE_STARTING_LAT_LNG = new LatLng(
+      41.37932575, 2.17045283);
+  private static final LatLng PERSON_TWO_STARTING_LAT_LNG = new LatLng(
+      41.39003512, 2.17685586);
+  private static final int WALKING_TIME = 15;
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private Polygon personOnePolygonArea;
+  private Polygon personTwoPolygonArea;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
+    setContentView(R.layout.activity_javaservices_two_person_isochrone_poi_meetup);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+      public void onMapReady(@NonNull MapboxMap mapboxMap) {
+        mapboxMap.setStyle(new Style.Builder().fromUri(Style.MAPBOX_STREETS)
+                //Add a SymbolLayer to the map so that the map click point has a visual marker. This is where the
+                // Isochrone API information radiates from.
+                .withImage(PERSON_ONE_MARKER_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+                    getResources().getDrawable(R.drawable.luciana)))
+                .withImage(PERSON_TWO_MARKER_ICON_ID, BitmapUtils.getBitmapFromDrawable(
+                    getResources().getDrawable(R.drawable.carlos)))
+                .withSource(new GeoJsonSource(PERSON_ONE_MARKER_SOURCE_ID,
+                    Feature.fromGeometry(Point.fromLngLat(PERSON_ONE_STARTING_LAT_LNG.getLongitude(),
+                        PERSON_ONE_STARTING_LAT_LNG.getLatitude()))))
+                .withSource(new GeoJsonSource(PERSON_TWO_MARKER_SOURCE_ID,
+                    Feature.fromGeometry(Point.fromLngLat(PERSON_TWO_STARTING_LAT_LNG.getLongitude(),
+                        PERSON_TWO_STARTING_LAT_LNG.getLatitude()))))
+                .withSource(new GeoJsonSource(PERSON_ONE_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID))
+                .withSource(new GeoJsonSource(PERSON_TWO_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID)),
+            new Style.OnStyleLoaded() {
+              @Override
+              public void onStyleLoaded(@NonNull Style style) {
+
+                TwoPersonMeetupLocationIsochroneWithinActivity.this.mapboxMap = mapboxMap;
+
+                hideLayers();
+                initPeopleFaceSymbols();
+                initIsochroneResponsePolygonFillLayers(style);
+
+                Toast.makeText(TwoPersonMeetupLocationIsochroneWithinActivity.this,
+                    getString(R.string.drag_faces_instruction), Toast.LENGTH_SHORT).show();
+
+                makeIsochroneApiCall(PERSON_ONE_STARTING_LAT_LNG, true);
+                makeIsochroneApiCall(PERSON_TWO_STARTING_LAT_LNG, false);
+              }
+            });
+      }
+    });
+  }
+
+  private void initPeopleFaceSymbols() {
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        SymbolManager symbolManager = new SymbolManager(mapView, mapboxMap, style);
+        symbolManager.setIconIgnorePlacement(true);
+        symbolManager.setIconAllowOverlap(true);
+        symbolManager.create(new SymbolOptions()
+            .withLatLng(PERSON_ONE_STARTING_LAT_LNG)
+            .withIconImage(PERSON_ONE_MARKER_ICON_ID)
+            .withDraggable(true));
+
+        symbolManager.create(new SymbolOptions()
+            .withLatLng(PERSON_TWO_STARTING_LAT_LNG)
+            .withIconImage(PERSON_TWO_MARKER_ICON_ID)
+            .withDraggable(true));
+
+        symbolManager.addDragListener(new OnSymbolDragListener() {
+          @Override
+          public void onAnnotationDragStarted(Symbol annotation) {
+            // Left empty on purpose because it's not needed in this example
+          }
+
+          @Override
+          public void onAnnotationDrag(Symbol symbol) {
+            // Left empty on purpose because it's not needed in this example
+          }
+
+          @Override
+          public void onAnnotationDragFinished(Symbol annotation) {
+            // annotation.getId() is either 0 or 1, so person 1 in
+            // this example actually has an annotation id of 0.
+            makeIsochroneApiCall(annotation.getLatLng(),
+                annotation.getId() == 0);
+          }
+        });
+      }
+    });
+  }
+
+  /**
+   * Make a request to the Mapbox Isochrone API
+   *
+   * @param finalDragLatLng The center point of the isochrone. It is part of the API request.
+   */
+  private void makeIsochroneApiCall(@NonNull LatLng finalDragLatLng,
+                                    boolean callMadeForPersonOne) {
+
+    MapboxIsochrone mapboxIsochroneRequest = MapboxIsochrone.builder()
+        .accessToken(getString(R.string.access_token))
+        .profile(IsochroneCriteria.PROFILE_WALKING)
+        .addContoursMinutes(WALKING_TIME)
+        .polygons(true)
+        .generalize(2f)
+        .denoise(.4f)
+        .coordinates(Point.fromLngLat(finalDragLatLng.getLongitude(), finalDragLatLng.getLatitude()))
+        .build();
+
+    mapboxIsochroneRequest.enqueueCall(new Callback<FeatureCollection>() {
+      @Override
+      public void onResponse(Call<FeatureCollection> call, Response<FeatureCollection> response) {
+        // Redraw Isochrone information based on response body
+        if (response.body() != null && response.body().features() != null) {
+          mapboxMap.getStyle(new Style.OnStyleLoaded() {
+            @Override
+            public void onStyleLoaded(@NonNull Style style) {
+              if (callMadeForPersonOne) {
+                GeoJsonSource personOneSource = style.getSourceAs(PERSON_ONE_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID);
+                if (personOneSource != null && response.body().features().size() > 0) {
+                  personOneSource.setGeoJson(response.body());
+                }
+                personOnePolygonArea = (Polygon) response.body().features().get(0).geometry();
+              } else {
+                GeoJsonSource personTwoSource = style.getSourceAs(PERSON_TWO_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID);
+                if (personTwoSource != null && response.body().features().size() > 0) {
+                  personTwoSource.setGeoJson(response.body());
+                }
+                personTwoPolygonArea = (Polygon) response.body().features().get(0).geometry();
+              }
+
+              SymbolLayer poiLabelLayer = style.getLayerAs("poi-label");
+              if (poiLabelLayer != null) {
+                if (personOnePolygonArea != null && personTwoPolygonArea != null) {
+                  poiLabelLayer.setFilter(all(within(personOnePolygonArea), within(personTwoPolygonArea)));
+                  poiLabelLayer.setProperties(
+                      textSize(14f),
+                      textColor(Color.BLACK));
+                }
+              }
+            }
+          });
+        }
+      }
+
+      @Override
+      public void onFailure(Call<FeatureCollection> call, Throwable throwable) {
+        Timber.d("Request failed: %s", throwable.getMessage());
+      }
+    });
+  }
+
+  /**
+   * Add a FillLayer so that that polygons returned by the Isochrone API response can be displayed
+   */
+  private void initIsochroneResponsePolygonFillLayers(@NonNull Style style) {
+    // Create and style a FillLayer based on information in the Isochrone API response
+    FillLayer personOneIsochroneFillLayer = new FillLayer(PERSON_ONE_ISOCHRONE_FILL_LAYER,
+        PERSON_ONE_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID);
+    personOneIsochroneFillLayer.setProperties(
+        fillColor(Color.parseColor("#41f4f1")),
+        fillOpacity(.6f));
+    personOneIsochroneFillLayer.setFilter(eq(geometryType(), literal("Polygon")));
+    style.addLayerBelow(personOneIsochroneFillLayer, "poi-label");
+
+    // Create and style a FillLayer based on information in the Isochrone API response
+    FillLayer personTwoIsochroneFillLayer = new FillLayer(PERSON_TWO_ISOCHRONE_FILL_LAYER,
+        PERSON_TWO_ISOCHRONE_RESPONSE_GEOJSON_SOURCE_ID);
+    personTwoIsochroneFillLayer.setProperties(
+        fillColor(Color.parseColor("#bc404c")),
+        fillOpacity(.6f));
+    personTwoIsochroneFillLayer.setFilter(eq(geometryType(), literal("Polygon")));
+    style.addLayerBelow(personTwoIsochroneFillLayer, PERSON_ONE_ISOCHRONE_FILL_LAYER);
+  }
+
+  /**
+   * Remove other types of label layers from the style in order to highlight the POI label layer.
+   */
+  private void hideLayers() {
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        SymbolLayer roadLabelLayer = style.getLayerAs("road-label");
+        if (roadLabelLayer != null) {
+          roadLabelLayer.setProperties(visibility(NONE));
+        }
+        SymbolLayer transitLabelLayer = style.getLayerAs("transit-label");
+        if (transitLabelLayer != null) {
+          transitLabelLayer.setProperties(visibility(NONE));
+        }
+        SymbolLayer roadNumberShieldLayer = style.getLayerAs("road-number-shield");
+        if (roadNumberShieldLayer != null) {
+          roadNumberShieldLayer.setProperties(visibility(NONE));
+        }
+      }
+    });
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  public void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    mapView.onDestroy();
+  }
+
+  @Override
+  protected void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+}

--- a/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_two_person_isochrone_poi_meetup.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_javaservices_two_person_isochrone_poi_meetup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".examples.javaservices.IsochroneActivity">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="41.3828939"
+        mapbox:mapbox_cameraTargetLng="2.1774322"
+        mapbox:mapbox_cameraZoom="13.5" />
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -481,4 +481,6 @@
         <item>Kilometers</item>
     </string-array>
 
+    <!-- Two-person meetup location isochrone within  -->
+    <string name="drag_faces_instruction">Tap on, hold, and drag a face to move it to a new location</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -106,6 +106,7 @@
     <string name="activity_java_services_static_image_notification_description">Use the Static Image API to eventually place and continually update an notification image</string>
     <string name="activity_java_services_directions_profile_toggle_description">Retrieve Mapbox Directions API routes for different profiles and toggle between them.</string>
     <string name="activity_java_services_turf_circle_poi_within_filter_description">Use the within expression to only show POIs that are inside of a moveable circle polygon.</string>
+    <string name="activity_java_services_two_person_meetup_isochrone_within_description">See which places of interest (POIs) are within a 15 minute walk from two peoples\' current locations.</string>
     <string name="activity_plugins_traffic_plugin_description">Use the traffic plugin to display live car congestion data on top of a map.</string>
     <string name="activity_plugins_building_plugin_description">Use the building plugin to easily display 3D building height</string>
     <string name="activity_plugins_places_plugin_description">Add location search ("geocoding") functionality and UI to search for any place in the world</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -106,6 +106,7 @@
     <string name="activity_java_services_static_image_notification_title">Static image notification</string>
     <string name="activity_java_services_directions_profile_toggle_title">Directions route profiles</string>
     <string name="activity_java_services_turf_circle_poi_within_filter_title">Moveable POI within filter</string>
+    <string name="activity_java_services_two_person_meetup_isochrone_within_title">Two person meetup POIs</string>
     <string name="activity_plugins_traffic_plugin_title">Display real-time traffic</string>
     <string name="activity_plugins_building_plugin_title">Display buildings in 3D</string>
     <string name="activity_plugins_localization_plugin_title">Change map text to device language</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -104,6 +104,7 @@
     <string name="activity_java_services_static_image_notification_url" translatable="false">https://i.imgur.com/crbB91w.png</string>
     <string name="activity_java_services_directions_profile_toggle_url" translatable="false">https://i.imgur.com/GckrLt3.png</string>
     <string name="activity_java_services_turf_circle_poi_within_filter_url" translatable="false">https://i.imgur.com/56JawQ2.png</string>
+    <string name="activity_java_services_two_person_meetup_isochrone_within_url" translatable="false">https://i.imgur.com/rS14uiG.png</string>
     <string name="activity_plugins_traffic_plugin_url" translatable="false">http://i.imgur.com/HRriOVR.png</string>
     <string name="activity_plugins_building_plugin_url" translatable="false">http://i.imgur.com/Vcu67UR.png</string>
     <string name="activity_plugins_places_plugin_url" translatable="false">https://i.imgur.com/oKHx3bv.png</string>


### PR DESCRIPTION
This example uses [isochrones](https://docs.mapbox.com/android/java/overview/isochrone) and the within expression (https://blog.mapbox.com/introducing-gl-js-v1-9-0-and-the-within-expression-6268f6c32be3) in a filter, to show POIs that are within a certain range for two people. 

![ezgif com-resize (1) (1)](https://user-images.githubusercontent.com/4394910/80992956-1f4c0f80-8def-11ea-999b-994c57918e3e.gif)
