### PR TITLE
Updated gradle options in circle.yml file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,7 @@ jobs:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
       IS_LOCAL_DEVELOPMENT: false
+      GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - checkout
       - restore_cache:
@@ -96,6 +97,7 @@ jobs:
       JVM_OPTS: -Xmx3200m
       BUILDTYPE: Debug
       IS_LOCAL_DEVELOPMENT: false
+      GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Gradle daemon issues appeared CircleCI, which blocked the 9.2.0 release (https://github.com/mapbox/mapbox-android-demo/releases/tag/9.2.0) from making it to the Play Store Console.

The same issue was appearing in the Navigation SDK and was ultimately fixed with https://github.com/mapbox/mapbox-navigation-android/pull/2969. This pr replicates the work done in https://github.com/mapbox/mapbox-navigation-android/pull/2969 to see if it helps here.