### PR TITLE
Fixed location of MixedChinaAndGlobalStyleActivity token toast message

### DIFF
--- a/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/examples/MixedChinaAndGlobalStyleActivity.kt
+++ b/MapboxAndroidDemo/src/china/java/com/mapbox/mapboxandroiddemo/examples/MixedChinaAndGlobalStyleActivity.kt
@@ -56,6 +56,8 @@ class MixedChinaAndGlobalStyleActivity : AppCompatActivity(), OnMapReadyCallback
 
         this.savedInstanceState = savedInstanceState
 
+        Toast.makeText(this, R.string.china_token_warning_toast, Toast.LENGTH_LONG).show()
+
         // Check location permissions
         locationPermissionCheckAndStart()
     }
@@ -82,8 +84,6 @@ class MixedChinaAndGlobalStyleActivity : AppCompatActivity(), OnMapReadyCallback
      */
     override fun onSuccess(result: LocationEngineResult?) {
         val lastLocation = result?.lastLocation
-
-        Toast.makeText(this, R.string.china_token_warning_toast, Toast.LENGTH_LONG).show()
 
         if (deviceInChina == null) {
 


### PR DESCRIPTION
This pr moves the Toast message out of the `onSuccess()` Location callback. The Toast kept firing whenever a new `Location` update happened. We only want the Toast to show once when the example is opened.