### PR TITLE
Added Mapbox token initialization to PlaceSelectionPluginActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlaceSelectionPluginActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/plugins/PlaceSelectionPluginActivity.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 
 import com.mapbox.api.geocoding.v5.models.CarmenFeature;
 import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.camera.CameraPosition;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.plugins.places.picker.PlacePicker;
@@ -27,7 +28,14 @@ public class PlaceSelectionPluginActivity extends AppCompatActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    // This contains the MapView in XML and needs to be called after the access token is configured.
     setContentView(R.layout.activity_place_selection);
+
     selectedLocationTextView = findViewById(R.id.selected_location_info_textview);
     goToPickerActivity();
   }


### PR DESCRIPTION
@moritzzzzz pointed out that this app's `PlaceSelectionPluginActivity` was missing the `Mapbox.getInstance(this, getString(R.string.access_token));` line. This pr fixes this.