### PR TITLE
Added feature list size check in PolygonSelectToggleActivity

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/PolygonSelectToggleActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/dds/PolygonSelectToggleActivity.kt
@@ -125,13 +125,19 @@ class PolygonSelectToggleActivity : AppCompatActivity(), MapboxMap.OnMapClickLis
      */
     private fun handleClickIcon(screenPoint: PointF): Boolean {
         val features = mapboxMap.queryRenderedFeatures(screenPoint, BASE_NEIGHBORHOOD_FILL_LAYER_ID)
-        val name = features[0].getStringProperty(NEIGHBORHOOD_NAME_PROPERTY)
-        val featureList = featureCollection?.features()
-        (0 until featureList!!.size).iterator().forEach {
-            if (featureList[it].getStringProperty(NEIGHBORHOOD_NAME_PROPERTY) == name) {
-                if (featureSelectStatus(it))
-                    setFeatureSelectState(featureList[it], false) else
-                    setSelected(it)
+        if (features.isNotEmpty()) {
+            val name = features[0].getStringProperty(NEIGHBORHOOD_NAME_PROPERTY)
+            val featureList = featureCollection?.features()
+            if (featureList != null) {
+                if (featureList.isNotEmpty()) {
+                    (0 until featureList.size).forEach {
+                        if (featureList[it].getStringProperty(NEIGHBORHOOD_NAME_PROPERTY) == name) {
+                            if (featureSelectStatus(it)) {
+                                setFeatureSelectState(featureList[it], false)
+                            } else setSelected(it)
+                        }
+                    }
+                }
             }
         }
         return true


### PR DESCRIPTION
`PolygonSelectToggleActivity` was missing a check for the feature list size. It was assuming it'd be > 0 , which led to a crash when none of the features were tapped on 👇. This pr fixes that by adding a `if (features.isNotEmpty())` check   

![ezgif com-resize](https://user-images.githubusercontent.com/4394910/82272477-96c18900-992f-11ea-9516-c131ff005f8e.gif)
