### PR TITLE
Update dependencies.gradle

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     androidVersions = [
-            minSdkVersion    : 16,
+            minSdkVersion    : 21,
             minWearSdkVersion: 23,
             targetSdkVersion : 28,
             compileSdkVersion: 28,


### PR DESCRIPTION
Update MinSdkVersion to 21 for Firebase compatibility.

The demo wouldn't run, was crashing instantly. Finally was able to track down the problem: 
```
2020-07-24 09:56:38.172 7186-7186/com.mapbox.mapboxandroiddemo.debug W/FirebaseApp: Default FirebaseApp failed to initialize because no default options were found. This usually means that com.google.gms:google-services was not applied to your gradle project.
2020-07-24 09:56:38.172 7186-7186/com.mapbox.mapboxandroiddemo.debug I/FirebaseInitProvider: FirebaseApp initialization unsuccessful
2020-07-24 09:56:39.109 7186-7186/com.mapbox.mapboxandroiddemo.debug D/FirebasePerformance: Creating a new Non Verbose Session: 3d30ae187e6f466cb1a086e72b140a86
2020-07-24 09:56:39.110 7186-7186/com.mapbox.mapboxandroiddemo.debug D/FirebasePerformance: Creating a new Non Verbose Session: 2d73f3685fe24cbabed9d08b3b4bbbb0
2020-07-24 09:56:40.022 7186-7186/com.mapbox.mapboxandroiddemo.debug D/FirebasePerformance: onResume(): com.mapbox.mapboxandroiddemo.account.LandingActivity: 1885247 microseconds
```

This post on Stack Overflow suggested that the MinSdkVersion needed to be at least 21, not 16. I made the change and everything worked. 

