### PR TITLE
Added single 3D building extrusion highlight example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -70,6 +70,7 @@ import com.mapbox.mapboxandroiddemo.examples.extrusions.Indoor3DMapActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.MarathonExtrusionActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.PopulationDensityExtrusionActivity;
 import com.mapbox.mapboxandroiddemo.examples.extrusions.RotationExtrusionActivity;
+import com.mapbox.mapboxandroiddemo.examples.extrusions.SingleHighlightedBuildingExtrusionActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.DirectionsActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.DirectionsGradientLineActivity;
 import com.mapbox.mapboxandroiddemo.examples.javaservices.ElevationQueryActivity;
@@ -783,6 +784,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         null,
         new Intent(MainActivity.this, OpacityZoomChangeExtrusionKotlinActivity.class),
         R.string.activity_extrusions_zoom_opacity_change_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+      R.id.nav_extrusions,
+      R.string.activity_extrusions_single_highlighted_building_extrusion_title,
+      R.string.activity_extrusions_single_highlighted_building_extrusion_description,
+      new Intent(MainActivity.this, SingleHighlightedBuildingExtrusionActivity.class),
+      null,
+      R.string.activity_extrusions_single_highlighted_building_extrusion_url, false, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_plugins,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -1003,6 +1003,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.extrusions.SingleHighlightedBuildingExtrusionActivity"
+            android:label="@string/activity_extrusions_single_highlighted_building_extrusion_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.dds.SymbolCollisionDetectionActivity"
             android:label="@string/activity_dds_symbol_collision_detection_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/AdjustExtrusionLightActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/AdjustExtrusionLightActivity.java
@@ -2,11 +2,12 @@ package com.mapbox.mapboxandroiddemo.examples.extrusions;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/SingleHighlightedBuildingExtrusionActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/extrusions/SingleHighlightedBuildingExtrusionActivity.java
@@ -1,0 +1,204 @@
+package com.mapbox.mapboxandroiddemo.examples.extrusions;
+
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.mapbox.geojson.Feature;
+import com.mapbox.mapboxandroiddemo.R;
+import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.geometry.LatLng;
+import com.mapbox.mapboxsdk.maps.MapView;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Style;
+import com.mapbox.mapboxsdk.style.expressions.Expression;
+import com.mapbox.mapboxsdk.style.layers.FillExtrusionLayer;
+
+import java.util.List;
+
+import static android.graphics.Color.parseColor;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.all;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.eq;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.get;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.id;
+import static com.mapbox.mapboxsdk.style.expressions.Expression.literal;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight;
+import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity;
+
+/**
+ * Tap on the map to extrude a single 3D building extrusion. This is done by applying a
+ * filter to a Maps SDK {@link FillExtrusionLayer}.
+ */
+public class SingleHighlightedBuildingExtrusionActivity extends AppCompatActivity
+    implements MapboxMap.OnMapClickListener {
+
+  private static final String EXTRUSION_BUILDING_LAYER_LAYER_ID = "EXTRUSION_BUILDING_LAYER_LAYER_ID";
+  private static final String COMPOSITE_SOURCE_ID = "composite";
+  private static final String DEFAULT_BUILDING_ID = "0";
+  private static final String BUILDING_LAYER_ID = "building";
+  private static final String EXTRUSION_COLOR = "#fb14ff";
+  private static final float EXTRUSION_OPACITY = 0.8f;
+  private MapView mapView;
+  private MapboxMap mapboxMap;
+  private boolean firstBuildingTapHasHappened = false;
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // Mapbox access token is configured here. This needs to be called either in your application
+    // object or in the same activity which contains the mapview.
+    Mapbox.getInstance(this, getString(R.string.access_token));
+
+    setContentView(R.layout.activity_single_highlighted_building_extrusion);
+
+    mapView = findViewById(R.id.mapView);
+    mapView.onCreate(savedInstanceState);
+    mapView.getMapAsync(new OnMapReadyCallback() {
+      @Override
+    public void onMapReady(@NonNull final MapboxMap mapboxMap) {
+        SingleHighlightedBuildingExtrusionActivity.this.mapboxMap = mapboxMap;
+        mapboxMap.setStyle(new Style.Builder().fromUri(Style.LIGHT),
+          new Style.OnStyleLoaded() {
+            @Override
+        public void onStyleLoaded(@NonNull Style style) {
+              addExtrusionLayerToMap(style);
+              mapboxMap.addOnMapClickListener(SingleHighlightedBuildingExtrusionActivity.this);
+              Toast.makeText(SingleHighlightedBuildingExtrusionActivity.this,
+                  R.string.tap_on_building,
+                  Toast.LENGTH_SHORT).show();
+            }
+          });
+      }
+    });
+  }
+
+  @Override
+  public boolean onMapClick(@NonNull LatLng mapTapLatLng) {
+    setFilterOnCorrectBuilding(mapTapLatLng);
+    return true;
+  }
+
+  /**
+   * Sets a filter on the {@link FillExtrusionLayer}.
+   *
+   * @param clickLatLng The {@link LatLng} of wherever the map was tapped.
+   */
+  private void setFilterOnCorrectBuilding(LatLng clickLatLng) {
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
+      @Override
+      public void onStyleLoaded(@NonNull Style style) {
+        FillExtrusionLayer buildingExtrusionLayer = style.getLayerAs(EXTRUSION_BUILDING_LAYER_LAYER_ID);
+        if (buildingExtrusionLayer != null) {
+          buildingExtrusionLayer.setFilter(
+              getBuildingFilterExpression(getBuildingId(clickLatLng)));
+        }
+      }
+    });
+  }
+
+  /**
+   * Returns the correctly built {@link Expression} to apply to the {@link FillExtrusionLayer}.
+   *
+   * @param buildingId the ID of the selected building
+   * @return an {@link Expression} to use in a filter
+   */
+  private Expression getBuildingFilterExpression(String buildingId) {
+    return all(
+        eq(get("extrude"), "true"),
+        eq(get("underground"), "false"),
+        eq(Expression.toString(id()), Expression.toString(literal(buildingId)))
+    );
+  }
+
+  /**
+   * Gets the {@link Feature#id()} of the building {@link Feature} that has the queryLatLng
+   * within its footprint. This ID is then used in the filter that's applied to the
+   * {@link FillExtrusionLayer}.
+   *
+   * @param queryLatLng the {@link LatLng} to use for querying the {@link MapboxMap} to eventually
+   *          get the building ID.
+   * @return the selected building's ID
+   */
+  private String getBuildingId(LatLng queryLatLng) {
+    List<Feature> renderedBuildingFootprintFeatures = mapboxMap.queryRenderedFeatures(
+        mapboxMap.getProjection().toScreenLocation(queryLatLng), BUILDING_LAYER_ID);
+    if (!renderedBuildingFootprintFeatures.isEmpty()) {
+      if (!firstBuildingTapHasHappened) {
+        Toast.makeText(SingleHighlightedBuildingExtrusionActivity.this,
+            R.string.keep_tapping_on_building_footprint,
+            Toast.LENGTH_SHORT).show();
+      }
+      firstBuildingTapHasHappened = true;
+      return renderedBuildingFootprintFeatures.get(0).id();
+    }
+    return DEFAULT_BUILDING_ID;
+  }
+
+  /**
+   * Adds a {@link FillExtrusionLayer} to the map.
+   *
+   * @param loadedMapStyle A loaded {@link Style} on the {@link MapboxMap}.
+   */
+  private void addExtrusionLayerToMap(@NonNull Style loadedMapStyle) {
+    FillExtrusionLayer fillExtrusionLayer = new FillExtrusionLayer(
+        EXTRUSION_BUILDING_LAYER_LAYER_ID, COMPOSITE_SOURCE_ID);
+    fillExtrusionLayer.setSourceLayer(BUILDING_LAYER_ID);
+    fillExtrusionLayer.setProperties(
+        fillExtrusionColor(parseColor(EXTRUSION_COLOR)),
+        fillExtrusionColor(parseColor(EXTRUSION_COLOR)),
+        fillExtrusionHeight(get("height")),
+        fillExtrusionOpacity(EXTRUSION_OPACITY));
+    loadedMapStyle.addLayer(fillExtrusionLayer);
+  }
+
+  @Override
+  protected void onStart() {
+    super.onStart();
+    mapView.onStart();
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    mapView.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    super.onPause();
+    mapView.onPause();
+  }
+
+  @Override
+  protected void onStop() {
+    super.onStop();
+    mapView.onStop();
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    mapView.onSaveInstanceState(outState);
+  }
+
+  @Override
+  public void onLowMemory() {
+    super.onLowMemory();
+    mapView.onLowMemory();
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    if (mapboxMap != null) {
+      mapboxMap.removeOnMapClickListener(this);
+    }
+    mapView.onDestroy();
+  }
+}
+

--- a/MapboxAndroidDemo/src/main/res/layout/activity_single_highlighted_building_extrusion.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_single_highlighted_building_extrusion.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraTargetLat="-6.8160837"
+        mapbox:mapbox_cameraTargetLng="39.2803583"
+        mapbox:mapbox_cameraTilt="45"
+        mapbox:mapbox_cameraZoom="17.5" />
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -495,4 +495,8 @@
     <!-- Feature filter  -->
     <string name="showing_all_country_labels">Showing all country labels</string>
     <string name="filtering_countries">Match filter using "name_en", applied to layer to hide some countries\' labels</string>
+
+    <!-- Single building highlight  -->
+    <string name="tap_on_building">Tap on a building to get started</string>
+    <string name="keep_tapping_on_building_footprint">Keep tapping on any building footprints!</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -45,6 +45,7 @@
     <string name="activity_extrusions_rotate_extrusions_description">Rotate and tilt device to change camera and see all around 3D buildings.</string>
     <string name="activity_extrusions_zoom_opacity_change_description">Use runtime styling to make the 3D buildings\' opacity dependent on the map\'s zoom level.</string>
     <string name="activity_extrusions_indoor_3d_description">Create a 3D indoor map with the fill-extrude-height paint property.</string>
+    <string name="activity_extrusions_single_highlighted_building_extrusion_description">Highlight a single building extrusion with a different color when tapped on.</string>
     <string name="activity_dds_style_circle_categorically_description">Using a categorical circle-color property function for a visualization.</string>
     <string name="activity_dds_kotlin_style_circle_categorically_description">Kotlin example for using a categorical circle-color property function for a visualization.</string>
     <string name="activity_dds_heatmap_description">Add and customize a heatmap to visualize data.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -44,6 +44,7 @@
     <string name="activity_extrusions_rotate_extrusions_title">Rotate and tilt with 3D buildings</string>
     <string name="activity_extrusions_indoor_3d_title">Extrude polygons for 3D indoor mapping</string>
     <string name="activity_extrusions_zoom_opacity_change_title">Zoom-based opacity</string>
+    <string name="activity_extrusions_single_highlighted_building_extrusion_title">Highlighted building</string>
     <string name="activity_dds_style_circle_categorically_title">Style circles categorically</string>
     <string name="activity_dds_style_kotlin_circle_categorically_title">Kotlin: Styled circles</string>
     <string name="activity_dds_choropleth_zoom_change_title">Update a choropleth layer by zoom level</string>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -43,6 +43,7 @@
     <string name="activity_extrusions_indoor_3d_url" translatable="false">http://i.imgur.com/1at7cMf.png</string>
     <string name="activity_extrusions_rotate_extrusions_url" translatable="false">http://i.imgur.com/OzcCsB2.png</string>
     <string name="activity_extrusions_zoom_opacity_change_url" translatable="false">https://i.imgur.com/7FomeoZ.png</string>
+    <string name="activity_extrusions_single_highlighted_building_extrusion_url" translatable="false">https://i.imgur.com/Wy3Gh1Q.png</string>
     <string name="activity_dds_style_circle_categorically_url" translatable="false">http://i.imgur.com/C3mtfgF.png</string>
     <string name="activity_dds_heatmap_url" translatable="false">https://i.imgur.com/VektJUJ.png</string>
     <string name="activity_dds_multiple_heatmap_styling_url" translatable="false">https://i.imgur.com/Uw2DHWB.png</string>


### PR DESCRIPTION
This pr adds an example of how to style and show a single building extrusion using runtime styling and layer filtering. The filter uses the id of the `Feature` in the `building` map layer. 

This work is based on my equivalent work in the Nav UI SDK https://github.com/mapbox/mapbox-navigation-android/pulls?q=is%3Apr+building+is%3Aclosed

![ezgif com-resize (4)](https://user-images.githubusercontent.com/4394910/91614484-7e9dd480-e936-11ea-8e47-6312db6b1ecc.gif)
