### PR TITLE
Removed v7 style usage and upgraded to v8 styles

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MatrixApiActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/javaservices/MatrixApiActivity.java
@@ -83,7 +83,7 @@ public class MatrixApiActivity extends AppCompatActivity {
       public void onMapReady(@NonNull final MapboxMap mapboxMap) {
         MatrixApiActivity.this.mapboxMap = mapboxMap;
 
-        mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/mapbox/cj8gg22et19ot2rnz65958fkn"),
+        mapboxMap.setStyle(Style.LIGHT,
           new Style.OnStyleLoaded() {
             @Override
             public void onStyleLoaded(@NonNull Style style) {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/InsetMapActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/InsetMapActivity.java
@@ -41,7 +41,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.visibility;
 
 public class InsetMapActivity extends AppCompatActivity implements MapboxMap.OnCameraMoveListener {
 
-  private static final String STYLE_URL = "mapbox://styles/mapbox/cj5l80zrp29942rmtg0zctjto";
+  private static final String STYLE_URL = Style.DARK;
   private static final String INSET_FRAGMENT_TAG = "com.mapbox.insetMapFragment";
   private static final String BOUNDS_LINE_LAYER_SOURCE_ID = "BOUNDS_LINE_LAYER_SOURCE_ID";
   private static final String BOUNDS_LINE_LAYER_LAYER_ID = "BOUNDS_LINE_LAYER_LAYER_ID";

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/KotlinLocationComponentActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/KotlinLocationComponentActivity.kt
@@ -42,8 +42,7 @@ class KotlinLocationComponentActivity : AppCompatActivity(), OnMapReadyCallback,
 
   override fun onMapReady(mapboxMap: MapboxMap) {
     this.mapboxMap = mapboxMap
-    mapboxMap.setStyle(Style.Builder().fromUri(
-            "mapbox://styles/mapbox/cjerxnqt3cgvp2rmyuxbeqme7")) {
+    mapboxMap.setStyle(Style.OUTDOORS) {
 
       // Map is set up and the style has loaded. Now you can add data or make other map adjustments
       enableLocationComponent(it)

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/location/LocationComponentActivity.java
@@ -50,7 +50,7 @@ public class LocationComponentActivity extends AppCompatActivity implements
   public void onMapReady(@NonNull final MapboxMap mapboxMap) {
     LocationComponentActivity.this.mapboxMap = mapboxMap;
 
-    mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/mapbox/cjerxnqt3cgvp2rmyuxbeqme7"),
+    mapboxMap.setStyle(Style.OUTDOORS,
       new Style.OnStyleLoaded() {
         @Override
         public void onStyleLoaded(@NonNull Style style) {

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/MapboxStudioStyleActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/MapboxStudioStyleActivity.java
@@ -34,7 +34,7 @@ public class MapboxStudioStyleActivity extends AppCompatActivity {
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
       public void onMapReady(@NonNull MapboxMap mapboxMap) {
-        mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/mapbox/cj3kbeqzo00022smj7akz3o1e"));
+        mapboxMap.setStyle(new Style.Builder().fromUri("mapbox://styles/appsatmapboxcom/ckeeq7t1l157r19oetc2gmexp"));
       }
     });
   }

--- a/MapboxAndroidDemo/src/main/res/layout/activity_style_mapbox_studio.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_style_mapbox_studio.xml
@@ -13,6 +13,6 @@
         android:layout_height="match_parent"
         mapbox:mapbox_cameraTargetLat="41.89010"
         mapbox:mapbox_cameraTargetLng="12.49200"
-        mapbox:mapbox_cameraZoom="15"/>
+        mapbox:mapbox_cameraZoom="11"/>
 
 </FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -8,7 +8,7 @@
     <string name="activity_basic_support_map_frag_url" translatable="false">https://i.imgur.com/y5QIBeM.png</string>
     <string name="activity_basic_mapbox_options_url" translatable="false">https://i.imgur.com/CRtK8UE.png</string>
     <string name="activity_basic_kotlin_support_map_frag_url" translatable="false">https://i.imgur.com/y5QIBeM.png</string>
-    <string name="activity_styles_mapbox_studio_url" translatable="false">http://i.imgur.com/MbR2zbD.png</string>
+    <string name="activity_styles_mapbox_studio_url" translatable="false">https://i.imgur.com/wDjzrEB.png</string>
     <string name="activity_styles_default_url" translatable="false">http://i.imgur.com/ZuUhFHw.jpg</string>
     <string name="activity_styles_zoom_dependent_fill_color_url" translatable="false">http://i.imgur.com/rHl1pmC.png</string>
     <string name="activity_styles_color_switcher_url" translatable="false">http://i.imgur.com/a0ZaKHG.png</string>
@@ -88,7 +88,7 @@
     <string name="activity_java_services_directions_url" translatable="false">http://i.imgur.com/DhQltqB.jpg</string>
     <string name="activity_java_services_static_image_url" translatable="false">https://i.imgur.com/aHxPYRU.png</string>
     <string name="activity_java_services_optimization_url" translatable="false">http://i.imgur.com/guEQtlP.jpg</string>
-    <string name="activity_java_services_matrix_url" translatable="false">https://i.imgur.com/65RlfRZ.png</string>
+    <string name="activity_java_services_matrix_url" translatable="false">https://i.imgur.com/mrtg3jS.png</string>
     <string name="activity_java_services_geocoding_url" translatable="false">https://i.imgur.com/9xl3EF8.png</string>
     <string name="activity_java_services_isochrone_url" translatable="false">https://i.imgur.com/eUByGvt.png</string>
     <string name="activity_java_services_isochrone_with_seekbar_url" translatable="false">https://i.imgur.com/hCVswtE.png</string>
@@ -115,7 +115,7 @@
     <string name="activity_plugins_place_picker_plugin_url" translatable="false">https://i.imgur.com/fPZQg7z.png</string>
     <string name="activity_plugins_markerview_plugin_url" translatable="false">https://i.imgur.com/DyDVUJr.png</string>
     <string name="activity_plugins_scalebar_plugin_url" translatable="false">https://i.imgur.com/YIGSu0C.png</string>
-    <string name="activity_location_location_component_url" translatable="false">https://i.imgur.com/77PVsni.png</string>
+    <string name="activity_location_location_component_url" translatable="false">https://i.imgur.com/1eWWyTW.png</string>
     <string name="activity_location_user_location_fragment_plugin_url" translatable="false">https://i.imgur.com/1jG8WQG.png</string>
     <string name="activity_location_location_component_options_url" translatable="false">https://i.imgur.com/4HiEJC1.png</string>
     <string name="activity_location_location_component_camera_options_url" translatable="false">https://i.imgur.com/Q2cB3NY.png</string>
@@ -133,7 +133,7 @@
     <string name="activity_lab_indoor_map_url" translatable="false">http://i.imgur.com/ItqdTiG.png</string>
     <string name="activity_lab_rv_on_map_url" translatable="false">http://i.imgur.com/8mQQuMo.jpg</string>
     <string name="activity_lab_symbol_layer_on_map_url" translatable="false">https://i.imgur.com/FZWgfd0.png</string>
-    <string name="activity_labs_inset_map_url" translatable="false">https://i.imgur.com/BM1Rkqq.png</string>
+    <string name="activity_labs_inset_map_url" translatable="false">https://i.imgur.com/b0wQGbG.png</string>
     <string name="activity_labs_gif_on_map_url" translatable="false">https://i.imgur.com/3d810QI.png</string>
     <string name="activity_labs_snaking_directions_route_url" translatable="false">https://i.imgur.com/6jWEFJi.png</string>
     <string name="activity_lab_moving_icon_with_trailing_line_url" translatable="false">https://i.imgur.com/jyrQn10.png</string>


### PR DESCRIPTION
Per @colleenmcginnis' suggestion, this pr resolves https://github.com/mapbox/mapbox-android-demo/issues/1314 by removing v7 style usage in certain demo app examples. This pr also updates the URL strings file so that the examples' images match the new style usage.