### PR TITLE
Bump target SDK, compile SDK, and buildtools to 29

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ workflows:
 jobs:
   primary:
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:769c31f1d8
     working_directory: ~/code
     environment:
       JVM_OPTS: -Xmx3200m
@@ -91,7 +91,7 @@ jobs:
 # ------------------------------------------------------------------------------
   release:
     docker:
-      - image: mbgl/61abee1674:android-ndk-r18
+      - image: mbgl/android-ndk-r21:769c31f1d8
     working_directory: ~/code
     environment:
       JVM_OPTS: -Xmx3200m

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,8 +2,8 @@ ext {
     androidVersions = [
             minSdkVersion    : 16,
             minWearSdkVersion: 23,
-            targetSdkVersion : 28,
-            compileSdkVersion: 28,
+            targetSdkVersion : 29,
+            compileSdkVersion: 29,
             buildToolsVersion: '28.0.3'
     ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
             minWearSdkVersion: 23,
             targetSdkVersion : 29,
             compileSdkVersion: 29,
-            buildToolsVersion: '28.0.3'
+            buildToolsVersion: '29.0.2'
     ]
 
     version = [


### PR DESCRIPTION
This pr resolves @knov's https://github.com/mapbox/mapbox-android-demo/issues/1366 by bumping the target sdk, compile sdk, and build tools versions to 29.

This pr also updates this demo app's CI to use the same image that the Maps and Nav SDKs use. This image uses build tools of `29.0.2`: https://github.com/mapbox/mbgl-ci-images/blob/master/images/android-ndk-r21#L29