### PR TITLE
Added spinning radar example

### DIFF
--- a/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
+++ b/MapboxAndroidDemo/src/global/java/com/mapbox/mapboxandroiddemo/MainActivity.java
@@ -114,6 +114,7 @@ import com.mapbox.mapboxandroiddemo.examples.labs.RecyclerViewOnMapActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SharedPreferencesActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SnakingDirectionsRouteActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SpaceStationLocationActivity;
+import com.mapbox.mapboxandroiddemo.examples.labs.SpinningRadarActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SpinningSymbolLayerIconActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.SymbolLayerMapillaryActivity;
 import com.mapbox.mapboxandroiddemo.examples.labs.ValueAnimatorIconAnimationActivity;
@@ -1469,6 +1470,14 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         null,
         new Intent(MainActivity.this, VibrateOnPinDropKotlinActivity.class),
         R.string.activity_lab_vibrate_on_pin_drop_url, false, BuildConfig.MIN_SDK_VERSION));
+
+    exampleItemModels.add(new ExampleItemModel(
+            R.id.nav_lab,
+            R.string.activity_lab_spinning_radar_title,
+            R.string.activity_lab_spinning_radar_description,
+            null,
+            new Intent(MainActivity.this, SpinningRadarActivity.class),
+            R.string.activity_lab_spinning_radar_url, true, BuildConfig.MIN_SDK_VERSION));
 
     exampleItemModels.add(new ExampleItemModel(
       R.id.nav_dds,

--- a/MapboxAndroidDemo/src/main/AndroidManifest.xml
+++ b/MapboxAndroidDemo/src/main/AndroidManifest.xml
@@ -728,6 +728,13 @@
                 android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
         </activity>
         <activity
+            android:name=".examples.labs.SpinningRadarActivity"
+            android:label="@string/activity_lab_spinning_radar_title">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.mapbox.mapboxandroiddemo.MainActivity" />
+        </activity>
+        <activity
             android:name=".examples.labs.BaseballSprayChartActivity"
             android:label="@string/activity_lab_baseball_spray_chart_title">
             <meta-data

--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SpinningRadarActivity.kt
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/labs/SpinningRadarActivity.kt
@@ -1,0 +1,210 @@
+package com.mapbox.mapboxandroiddemo.examples.labs
+
+import android.animation.ValueAnimator
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.animation.LinearInterpolator
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.mapbox.android.core.location.LocationEngine
+import com.mapbox.android.core.permissions.PermissionsListener
+import com.mapbox.android.core.permissions.PermissionsManager
+import com.mapbox.mapboxandroiddemo.R
+import com.mapbox.mapboxsdk.Mapbox
+import com.mapbox.mapboxsdk.location.LocationComponentActivationOptions
+import com.mapbox.mapboxsdk.location.LocationComponentConstants.LOCATION_SOURCE
+import com.mapbox.mapboxsdk.location.LocationComponentOptions
+import com.mapbox.mapboxsdk.location.modes.CameraMode
+import com.mapbox.mapboxsdk.location.modes.RenderMode
+import com.mapbox.mapboxsdk.maps.MapboxMap
+import com.mapbox.mapboxsdk.maps.OnMapReadyCallback
+import com.mapbox.mapboxsdk.maps.Style
+import com.mapbox.mapboxsdk.style.expressions.Expression.interpolate
+import com.mapbox.mapboxsdk.style.expressions.Expression.linear
+import com.mapbox.mapboxsdk.style.expressions.Expression.stop
+import com.mapbox.mapboxsdk.style.expressions.Expression.zoom
+import com.mapbox.mapboxsdk.style.layers.Layer
+import com.mapbox.mapboxsdk.style.layers.Property.ICON_PITCH_ALIGNMENT_MAP
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconAllowOverlap
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconIgnorePlacement
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconOpacity
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconPitchAlignment
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconRotate
+import com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconSize
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer
+import com.mapbox.mapboxsdk.utils.BitmapUtils
+import kotlinx.android.synthetic.main.activity_lab_spinning_radar.mapView
+
+/**
+ * Turn a conical gradient drawable as a [SymbolLayer]'s icon and rotate the icon
+ * to create a spinning radar effect.
+ */
+class SpinningRadarActivity : AppCompatActivity(), OnMapReadyCallback, PermissionsListener {
+
+    private var permissionsManager: PermissionsManager = PermissionsManager(this)
+    private lateinit var mapboxMap: MapboxMap
+    private var iconSpinningAnimator: ValueAnimator? = null
+    private var locationEngine: LocationEngine? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Mapbox access token is configured here. This needs to be called either in your application
+        // object or in the same activity which contains the mapview.
+        Mapbox.getInstance(this, getString(R.string.access_token))
+
+        // This contains the MapView in XML and needs to be called after the access token is configured.
+        setContentView(R.layout.activity_lab_spinning_radar)
+
+        mapView.onCreate(savedInstanceState)
+        mapView.getMapAsync(this)
+    }
+
+    override fun onMapReady(mapboxMap: MapboxMap) {
+        this.mapboxMap = mapboxMap
+        mapboxMap.setStyle(Style.DARK) { style ->
+            enableLocationComponent(style)
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun enableLocationComponent(loadedMapStyle: Style) {
+        // Check if permissions are enabled and if not request
+        if (PermissionsManager.areLocationPermissionsGranted(this)) {
+            mapboxMap.locationComponent.apply {
+
+                // Activate the LocationComponent with options
+                activateLocationComponent(LocationComponentActivationOptions
+                        .builder(this@SpinningRadarActivity, loadedMapStyle)
+                        .locationComponentOptions(LocationComponentOptions.builder(this@SpinningRadarActivity)
+                                .accuracyAnimationEnabled(false)
+                                .accuracyAlpha(0f)
+                                .enableStaleState(false)
+                                .build())
+                        .build())
+
+                // Enable to make the LocationComponent visible
+                isLocationComponentEnabled = true
+
+                // Set the LocationComponent's camera mode
+                cameraMode = CameraMode.TRACKING
+
+                // Set the LocationComponent's render mode
+                renderMode = RenderMode.NORMAL
+
+                // Add the conical gradient drawable as a Bitmap
+                loadedMapStyle.addImage(SPINNING_RADAR_IMAGE_ID, BitmapUtils.getBitmapFromDrawable(ContextCompat.getDrawable(
+                        applicationContext, R.drawable.spinning_radar_gradient))!!)
+
+                /**
+                 * Create the gradient radar image's SymbolLayer and place is below the
+                 * Maps SDK's LocationComponent.
+                 */
+                loadedMapStyle.addLayerBelow(SymbolLayer(SPINNING_RADAR_LAYER_ID, LOCATION_SOURCE)
+                        .withProperties(
+                                iconImage(SPINNING_RADAR_IMAGE_ID),
+                                iconSize(interpolate(linear(), zoom(),
+                                        stop(4, 2.5f),
+                                        stop(15, 1f))),
+                                iconOpacity(.7f),
+                                iconIgnorePlacement(true),
+                                iconAllowOverlap(true),
+                                iconPitchAlignment(ICON_PITCH_ALIGNMENT_MAP)),
+                        "mapbox-location-pulsing-circle-layer")
+
+                startSpinningRadarAnimation()
+            }
+        } else {
+            permissionsManager = PermissionsManager(this).also {
+                it.requestLocationPermissions(this)
+            }
+        }
+    }
+
+    /**
+     * Set up and start the spinning radar animation. The Android system ValueAnimator emits a new value, which is
+     * used as the radar gradient image's rotation value. The value is animated from 0 to 360 because of the
+     * direction of the gradient's design and the desire to have it spin clockwise.
+     */
+    private fun startSpinningRadarAnimation() {
+        iconSpinningAnimator?.cancel()
+        iconSpinningAnimator = ValueAnimator.ofFloat(0f, 360f).also {
+            it.duration = SPINNING_RADAR_IMAGE_SECONDS_PER_SPIN * 1000.toLong()
+            it.interpolator = LinearInterpolator()
+            it.repeatCount = ValueAnimator.INFINITE
+            it.addUpdateListener { valueAnimator -> // Retrieve the new animation number to use as the map camera bearing value
+                val newIconRotateValue = valueAnimator.animatedValue as Float
+                mapboxMap.getStyle { style ->
+                    val locationComponentRadarBackgroundLayer = style.getLayerAs<Layer>(SPINNING_RADAR_LAYER_ID)
+                    locationComponentRadarBackgroundLayer?.setProperties(
+                            iconRotate(newIconRotateValue)
+                    )
+                }
+            }
+            it.start()
+        }
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    }
+
+    override fun onExplanationNeeded(permissionsToExplain: List<String>) {
+        Toast.makeText(this, R.string.user_location_permission_explanation, Toast.LENGTH_LONG).show()
+    }
+
+    override fun onPermissionResult(granted: Boolean) {
+        if (granted) {
+            mapboxMap.getStyle {
+                enableLocationComponent(it)
+            }
+        } else {
+            Toast.makeText(this, R.string.user_location_permission_not_granted, Toast.LENGTH_LONG).show()
+            finish()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapView.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        mapView.onResume()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        mapView.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapView.onStop()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        iconSpinningAnimator?.cancel()
+        mapView.onDestroy()
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        mapView.onLowMemory()
+    }
+
+    companion object {
+        private const val SPINNING_RADAR_LAYER_ID = "SPINNING_RADAR_LAYER_ID"
+        private const val SPINNING_RADAR_IMAGE_ID = "SPINNING_RADAR_IMAGE_ID"
+        private const val SPINNING_RADAR_IMAGE_SECONDS_PER_SPIN = 10
+    }
+}

--- a/MapboxAndroidDemo/src/main/res/drawable/spinning_radar_gradient.xml
+++ b/MapboxAndroidDemo/src/main/res/drawable/spinning_radar_gradient.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <gradient
+        android:centerColor="#00000000"
+        android:endColor="#4CAF50"
+        android:startColor="#00000000"
+        android:type="sweep" />
+    <size
+        android:width="100dp"
+        android:height="100dp" />
+</shape>

--- a/MapboxAndroidDemo/src/main/res/layout/activity_lab_spinning_radar.xml
+++ b/MapboxAndroidDemo/src/main/res/layout/activity_lab_spinning_radar.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:mapbox="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.mapboxsdk.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        mapbox:mapbox_cameraZoom="12" />
+
+</FrameLayout>

--- a/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/descriptions_strings.xml
@@ -155,6 +155,7 @@
     <string name="activity_lab_biometric_fingerprint_description">Use the Android system\'s fingerprint unlock to reveal "personal" data on a map.</string>
     <string name="activity_lab_baseball_spray_chart_description">Use the Maps SDK and filters to explore baseball data.</string>
     <string name="activity_lab_vibrate_on_pin_drop_description">Vibrate the device when an icon is dropped on the map for a more interactive map experience.</string>
+    <string name="activity_lab_spinning_radar_description">Rotate an conical gradient image under the LocationComponent to create a spinning radar effect.</string>
     <string name="activity_china_simple_china_mapview_description">Show an accurate and government-approved China map in your app using the Mapbox Maps SDK.</string>
     <string name="activity_china_simple_china_bounds_checker_description">Use the China plugin to determine whether or not the device is inside of China.</string>
     <string name="activity_china_mixed_china_and_global_style_description">Load a China style if the device is in China. Load a global/.com style if not.</string>

--- a/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/titles_strings.xml
@@ -158,4 +158,5 @@
     <string name="activity_lab_shared_preferences_title">Saving to SharedPreferences</string>
     <string name="activity_lab_biometric_fingerprint_title">Biometric fingerprint</string>
     <string name="activity_lab_vibrate_on_pin_drop_title">Vibrate device on pin drop</string>
+    <string name="activity_lab_spinning_radar_title">Spinning radar scan</string>
 </resources>

--- a/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/urls_strings.xml
@@ -153,6 +153,7 @@
     <string name="activity_lab_biometric_fingerprint_url" translatable="false">https://i.imgur.com/iQZzMIR.png</string>
     <string name="activity_lab_baseball_spray_chart_url" translatable="false">https://i.imgur.com/1j7WVoO.png</string>
     <string name="activity_lab_vibrate_on_pin_drop_url" translatable="false">https://i.imgur.com/0FgIP5n.png</string>
+    <string name="activity_lab_spinning_radar_url" translatable="false">https://i.imgur.com/Eg7SJWd.png</string>
     <string name="activity_china_simple_china_mapview_url" translatable="false">https://i.imgur.com/KwoEynZ.png</string>
     <string name="activity_china_simple_china_bounds_checker_url" translatable="false">https://i.imgur.com/fIFWqJu.png</string>
     <string name="activity_china_mixed_china_and_global_style_url" translatable="false">https://i.imgur.com/XBS1WAn.png</string>


### PR DESCRIPTION

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/4394910/94293374-044f7880-ff13-11ea-9fdc-588f566e99b6.gif)


This pr adds an example of a spinning radar effect. A conical gradient XML drawable is made into a Bitmap, the Bitmap is added to the `Style` object as an image, the image is used in a `SymbolLayer`, and the icon is rotated with a `ValueAnimator`.

This example is inspired by what I saw in the Citizen app's spinning radar effect on a Mapbox map: https://play.google.com/store/apps/details?id=sp0n.citizen&hl=en_US

<img width="210" alt="Screen Shot 2020-09-25 at 9 20 33 AM" src="https://user-images.githubusercontent.com/4394910/94291353-5f33a080-ff10-11ea-9cf7-1fb0b9d86258.png">

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/4394910/94292537-f64d2800-ff11-11ea-8675-2d90a4588ec7.gif)