### PR TITLE
Refactored and added languages to language switch example

### DIFF
--- a/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LanguageSwitchActivity.java
+++ b/MapboxAndroidDemo/src/main/java/com/mapbox/mapboxandroiddemo/examples/styles/LanguageSwitchActivity.java
@@ -1,10 +1,11 @@
 package com.mapbox.mapboxandroiddemo.examples.styles;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.mapbox.mapboxandroiddemo.R;
 import com.mapbox.mapboxsdk.Mapbox;
@@ -12,7 +13,7 @@ import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
 import com.mapbox.mapboxsdk.maps.Style;
-import com.mapbox.mapboxsdk.style.layers.Layer;
+import com.mapbox.mapboxsdk.style.layers.SymbolLayer;
 
 import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
 
@@ -22,7 +23,7 @@ import static com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField;
 public class LanguageSwitchActivity extends AppCompatActivity {
 
   private MapView mapView;
-  private MapboxMap map;
+  private MapboxMap mapboxMap;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -40,10 +41,10 @@ public class LanguageSwitchActivity extends AppCompatActivity {
     mapView.getMapAsync(new OnMapReadyCallback() {
       @Override
       public void onMapReady(@NonNull MapboxMap mapboxMap) {
-        map = mapboxMap;
         mapboxMap.setStyle(Style.LIGHT, new Style.OnStyleLoaded() {
           @Override
           public void onStyleLoaded(@NonNull Style style) {
+            LanguageSwitchActivity.this.mapboxMap = mapboxMap;
           }
         });
       }
@@ -100,26 +101,44 @@ public class LanguageSwitchActivity extends AppCompatActivity {
 
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
-    map.getStyle(new Style.OnStyleLoaded() {
+    mapboxMap.getStyle(new Style.OnStyleLoaded() {
       @Override
       public void onStyleLoaded(@NonNull Style style) {
-        Layer mapText = style.getLayer("country-label");
-        if (mapText != null) {
+        SymbolLayer countryLabelTextSymbolLayer = style.getLayerAs("country-label");
+        if (countryLabelTextSymbolLayer != null) {
           switch (item.getItemId()) {
             case R.id.french:
-              mapText.setProperties(textField("{name_fr}"));
+              countryLabelTextSymbolLayer.setProperties(textField("{name_fr}"));
               return;
             case R.id.russian:
-              mapText.setProperties(textField("{name_ru}"));
+              countryLabelTextSymbolLayer.setProperties(textField("{name_ru}"));
               return;
             case R.id.german:
-              mapText.setProperties(textField("{name_de}"));
+              countryLabelTextSymbolLayer.setProperties(textField("{name_de}"));
               return;
             case R.id.spanish:
-              mapText.setProperties(textField("{name_es}"));
+              countryLabelTextSymbolLayer.setProperties(textField("{name_es}"));
+              return;
+            case R.id.italian:
+              countryLabelTextSymbolLayer.setProperties(textField("{name_it}"));
+              return;
+            case R.id.vietnamese:
+              countryLabelTextSymbolLayer.setProperties(textField("{name_vi}"));
+              return;
+            case R.id.korean:
+              countryLabelTextSymbolLayer.setProperties(textField("{name_ko}"));
+              return;
+            case R.id.japanese:
+              countryLabelTextSymbolLayer.setProperties(textField("{name_ja}"));
+              return;
+            case R.id.simplified_chinese:
+              countryLabelTextSymbolLayer.setProperties(textField("{name_zh-Hans}"));
+              return;
+            case R.id.traditional_chinese:
+              countryLabelTextSymbolLayer.setProperties(textField("{name_zh-Hant}"));
               return;
             default:
-              mapText.setProperties(textField("{name_en}"));
+              countryLabelTextSymbolLayer.setProperties(textField("{name_en}"));
           }
         }
       }

--- a/MapboxAndroidDemo/src/main/res/menu/menu_map_langauge.xml
+++ b/MapboxAndroidDemo/src/main/res/menu/menu_map_langauge.xml
@@ -1,35 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/english"
         android:orderInCategory="100"
         android:title="@string/language_switch_options_menu_language_english"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/french"
         android:orderInCategory="100"
         android:title="@string/language_switch_options_menu_language_french"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/russian"
         android:orderInCategory="100"
         android:title="@string/language_switch_options_menu_language_russian"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/german"
         android:orderInCategory="100"
         android:title="@string/language_switch_options_menu_language_german"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
 
     <item
         android:id="@+id/spanish"
         android:orderInCategory="100"
         android:title="@string/language_switch_options_menu_language_spanish"
-        app:showAsAction="never"/>
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/italian"
+        android:orderInCategory="100"
+        android:title="@string/language_switch_options_menu_language_italian"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/vietnamese"
+        android:orderInCategory="100"
+        android:title="@string/language_switch_options_menu_language_vietnamese"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/korean"
+        android:orderInCategory="100"
+        android:title="@string/language_switch_options_menu_language_korean"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/japanese"
+        android:orderInCategory="100"
+        android:title="@string/language_switch_options_menu_language_japanese"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/simplified_chinese"
+        android:orderInCategory="100"
+        android:title="@string/language_switch_options_menu_language_simplified_chinese"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/traditional_chinese"
+        android:orderInCategory="100"
+        android:title="@string/language_switch_options_menu_language_traditional_chinese"
+        app:showAsAction="never" />
 </menu>

--- a/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
+++ b/MapboxAndroidDemo/src/main/res/values/activity_strings.xml
@@ -115,6 +115,12 @@
     <string name="language_switch_options_menu_language_russian">Russian</string>
     <string name="language_switch_options_menu_language_german">German</string>
     <string name="language_switch_options_menu_language_spanish">Spanish</string>
+    <string name="language_switch_options_menu_language_italian">Italian</string>
+    <string name="language_switch_options_menu_language_vietnamese">Vietnamese</string>
+    <string name="language_switch_options_menu_language_korean">Korean</string>
+    <string name="language_switch_options_menu_language_japanese">Japanese</string>
+    <string name="language_switch_options_menu_language_simplified_chinese">Simplified Chinese</string>
+    <string name="language_switch_options_menu_language_traditional_chinese">Traditional Chinese</string>
 
     <!--LanguageSwitchActivity activity-->
 


### PR DESCRIPTION
This pr refactors https://docs.mapbox.com/android/maps/examples/change-a-maps-language/ to account for all of the available languages in the latest Mapbox Streets tileset: https://docs.mapbox.com/vector-tiles/reference/mapbox-streets-v8/#common-fields

https://github.com/mapbox/mapbox-plugins-android/pull/1098  is related and about adding additional language support to https://docs.mapbox.com/android/plugins/overview/localization/.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/4394910/94349584-a5652e80-fffa-11ea-8f98-7cc6e6605fc7.gif)
