### PR TITLE
secret token retrieval should be the same as the docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
             }
             credentials {
                 username = "mapbox"
-                password = System.getenv("SDK_REGISTRY_TOKEN") ?: project.property("SDK_REGISTRY_TOKEN") as String
+                password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
             }
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/mapbox/mapbox-android-demo/issues/1393

It should follow the same procedure as the instruction step 5.

https://docs.mapbox.com/android/maps/guides/install/#add-the-dependency