### PR TITLE
Remove the unnecessary google-services plugin

### DIFF
--- a/MapboxAndroidDemo/build.gradle
+++ b/MapboxAndroidDemo/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.github.triplet.play'
 apply plugin: 'com.google.firebase.crashlytics'
-apply plugin: 'com.google.gms.google-services'
 apply plugin: 'org.jmailen.kotlinter'
 apply from: "$project.rootDir/gradle/script-git-version.gradle"
 apply from: "$project.rootDir/gradle/gradle-dependencies-graph.gradle"


### PR DESCRIPTION
We already have the [goole-services plugin config for release](https://github.com/mapbox/mapbox-android-demo/blob/0ad2c544d8cf976b013609045dd3f9019adca47c/MapboxAndroidDemo/build.gradle#L187), so no need to apply it again

Fixes https://github.com/mapbox/mapbox-android-demo/issues/1388