### PR TITLE
Consistify YOUR_MAPBOX_ACCESS_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _This demo app uses Mapbox vector tiles, which require a Mapbox account and a Ma
 With the first Gradle invocation, Gradle will take the value of the `MAPBOX_ACCESS_TOKEN` environment variable and save it to `SharedCode/src/main/res/values/developer-config.xml`. If the environment variable wasn't set, you can create/edit the `developer-config.xml` file. Create an `access_token` String resource and paste your access token into it:
 
 ```xml
-<string name="access_token">PASTE_YOUR_TOKEN_HERE</string>
+<string name="access_token">YOUR_MAPBOX_ACCESS_TOKEN</string>
 ```
 ##### Product flavors
 

--- a/SharedCode/gradle-config.gradle
+++ b/SharedCode/gradle-config.gradle
@@ -32,7 +32,7 @@ task secretKeysSetup {
         String mapboxAccessToken = "$System.env.MAPBOX_ACCESS_TOKEN"
         if (mapboxAccessToken == "null") {
             System.out.println("You should set the MAPBOX_ACCESS_TOKEN environment variable.")
-            mapboxAccessToken = "YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE"
+            mapboxAccessToken = "YOUR_MAPBOX_ACCESS_TOKEN"
         }
 
         String tokenFileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +


### PR DESCRIPTION
Re: https://github.com/mapbox/documentation/issues/773

- replaces two instances of string placeholder to consistify YOUR_MAPBOX_ACCESS_TOKEN as the placeholder string